### PR TITLE
use a Bearer token to connect to API master (typically to connect to openshift origin)

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/BearerTokenCredential.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/BearerTokenCredential.java
@@ -1,0 +1,34 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.impl.*;
+import hudson.Extension;
+import hudson.util.Secret;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+public class BearerTokenCredential extends BaseStandardCredentials {
+
+    private final Secret token;
+
+    @DataBoundConstructor
+    public BearerTokenCredential(CredentialsScope scope, String id, String description, String token) {
+        super(scope, id, description);
+        this.token = Secret.fromString(token);
+    }
+
+    public String getToken() {
+        return Secret.toString(token);
+    }
+
+    @Extension
+    public static class DescriptorImpl extends BaseStandardCredentialsDescriptor {
+
+        @Override
+        public String getDisplayName() {
+            return "OAuth Bearer token";
+        }
+    }
+}

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/BearerTokenCredential/credentials.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/BearerTokenCredential/credentials.jelly
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
+  <f:entry title="${%Token}" field="token">
+    <f:textbox/>
+  </f:entry>
+  <st:include page="id-and-description" class="${descriptor.clazz}"/>
+</j:jelly>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/config.jelly
@@ -13,16 +13,19 @@
       <f:textarea/>
     </f:entry>
 
-    <f:entry title="${%Credentials}" field="credentialsId">
-      <c:select/>
+    <f:entry title="${%Disable https certificate check}" field="skipTlsVerify">
+      <f:checkbox />
     </f:entry>
-
-    <f:validateButton title="${%Test Connection}" progress="${%Testing...}" method="testConnection" with="serverUrl,credentialsId,serverCertificate" />
-
 
     <f:entry title="${%Kubernetes Namespace}" field="namespace">
       <f:textbox default="default" />
     </f:entry>
+
+    <f:entry title="${%Credentials}" field="credentialsId">
+      <c:select/>
+    </f:entry>
+
+    <f:validateButton title="${%Test Connection}" progress="${%Testing...}" method="testConnection" with="serverUrl,credentialsId,serverCertificate,skipTlsVerify,namespace" />
 
     <f:entry title="${%Jenkins URL}" field="jenkinsUrl">
       <f:textbox />

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/help-skipTlsVerify.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/help-skipTlsVerify.html
@@ -1,0 +1,5 @@
+With this option enabled, communication with kubernetes API master will rely on https but will fully ignore ssl
+certificate verification. This is usefull for quick setup but does make your installation unsecured, so please consider
+twice.
+<p>
+Alternatively, capture API server certificate and register it as Kubernetes server certificate key.


### PR DESCRIPTION
OpenShift v3 "origin" do rely on Kubernetes, but with a custom Client certificate / OAuth authorization service. As a result, admin can't use k8s API with plain username/password.
This PR introduce a new credentials type for OAuth Bearer token (afaik there's no plugin to define one already)

PR also introduce option to ignore the TLS Verify step when accessing an https (self-signed) kubernetes master. This mimic openshift CLI `--insecure-skip-tls-verify` option