### PR TITLE
Service account

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/BearerTokenCredential.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/BearerTokenCredential.java
@@ -1,34 +1,11 @@
 package org.csanchez.jenkins.plugins.kubernetes;
 
-import com.cloudbees.plugins.credentials.CredentialsScope;
-import com.cloudbees.plugins.credentials.impl.*;
-import hudson.Extension;
-import hudson.util.Secret;
-import org.kohsuke.stapler.DataBoundConstructor;
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
-public class BearerTokenCredential extends BaseStandardCredentials {
-
-    private final Secret token;
-
-    @DataBoundConstructor
-    public BearerTokenCredential(CredentialsScope scope, String id, String description, String token) {
-        super(scope, id, description);
-        this.token = Secret.fromString(token);
-    }
-
-    public String getToken() {
-        return Secret.toString(token);
-    }
-
-    @Extension
-    public static class DescriptorImpl extends BaseStandardCredentialsDescriptor {
-
-        @Override
-        public String getDisplayName() {
-            return "OAuth Bearer token";
-        }
-    }
+public interface BearerTokenCredential extends Credentials, StandardCredentials {
+    String getToken();
 }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/BearerTokenCredentialImpl.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/BearerTokenCredentialImpl.java
@@ -1,0 +1,35 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.impl.*;
+import hudson.Extension;
+import hudson.util.Secret;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+public class BearerTokenCredentialImpl extends BaseStandardCredentials implements BearerTokenCredential {
+
+    private final Secret token;
+
+    @DataBoundConstructor
+    public BearerTokenCredentialImpl(CredentialsScope scope, String id, String description, String token) {
+        super(scope, id, description);
+        this.token = Secret.fromString(token);
+    }
+
+    @Override
+    public String getToken() {
+        return Secret.toString(token);
+    }
+
+    @Extension
+    public static class DescriptorImpl extends BaseStandardCredentialsDescriptor {
+
+        @Override
+        public String getDisplayName() {
+            return "OAuth Bearer token";
+        }
+    }
+}

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ServiceAccountCredential.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ServiceAccountCredential.java
@@ -3,6 +3,7 @@ package org.csanchez.jenkins.plugins.kubernetes;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import hudson.Extension;
 import org.apache.commons.io.FileUtils;
+import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.File;
 import java.io.IOException;
@@ -16,7 +17,8 @@ import java.io.IOException;
  */
 public class ServiceAccountCredential extends BearerTokenCredential {
 
-    public ServiceAccountCredential(CredentialsScope scope, String id, String description, String token) {
+    @DataBoundConstructor
+    public ServiceAccountCredential(CredentialsScope scope, String id, String description) {
         super(scope, id, description, null);
     }
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ServiceAccountCredential.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ServiceAccountCredential.java
@@ -1,0 +1,40 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import hudson.Extension;
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Read the OAuth bearer token from service account file provisionned by kubernetes
+ * <a href="http://kubernetes.io/v1.0/docs/admin/service-accounts-admin.html">Service Account Admission Controller</a>
+ * when Jenkins itself is deployed inside a Pod.
+ *
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+public class ServiceAccountCredential extends BearerTokenCredential {
+
+    public ServiceAccountCredential(CredentialsScope scope, String id, String description, String token) {
+        super(scope, id, description, null);
+    }
+
+    @Override
+    public String getToken() {
+        try {
+            return FileUtils.readFileToString(new File("/run/secrets/kubernetes.io/serviceaccount/token"));
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    @Extension
+    public static class DescriptorImpl extends BaseStandardCredentialsDescriptor {
+
+        @Override
+        public String getDisplayName() {
+            return "Kubernetes Service Account";
+        }
+    }
+}

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ServiceAccountCredential.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ServiceAccountCredential.java
@@ -29,8 +29,14 @@ public class ServiceAccountCredential extends BearerTokenCredential {
         }
     }
 
-    @Extension
+    @Extension(optional = true)
     public static class DescriptorImpl extends BaseStandardCredentialsDescriptor {
+
+        public DescriptorImpl() {
+            if (!new File("/run/secrets/kubernetes.io/serviceaccount/token").exists()) {
+                throw new RuntimeException("Jenkins isn't running inside Kubernetes with Admission Controller.");
+            }
+        }
 
         @Override
         public String getDisplayName() {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ServiceAccountCredential.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ServiceAccountCredential.java
@@ -1,6 +1,7 @@
 package org.csanchez.jenkins.plugins.kubernetes;
 
 import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
 import hudson.Extension;
 import org.apache.commons.io.FileUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -15,11 +16,11 @@ import java.io.IOException;
  *
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
-public class ServiceAccountCredential extends BearerTokenCredential {
+public class ServiceAccountCredential extends BaseStandardCredentials implements BearerTokenCredential {
 
     @DataBoundConstructor
     public ServiceAccountCredential(CredentialsScope scope, String id, String description) {
-        super(scope, id, description, null);
+        super(scope, id, description);
     }
 
     @Override

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ServiceAccountCredential/credentials.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ServiceAccountCredential/credentials.jelly
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
+  <st:include page="id-and-description" class="${descriptor.clazz}"/>
+</j:jelly>


### PR DESCRIPTION
alternative impl for https://github.com/jenkinsci/kubernetes-plugin/pull/17
enable a dedicated credential type when jenkins do run inside kubernetes with service account enabled, so cloud can be setup with a fixed configuration, but actual credentials get injected at runtime.