### PR TITLE
Migrate to the new fabric8 client for kubernetes.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,8 +43,8 @@
 
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>kubernetes-api</artifactId>
-      <version>2.2.16</version>
+      <artifactId>kubernetes-client</artifactId>
+      <version>1.3.47</version>
     </dependency>
 
     <!-- Required to prevent a version conflict with jenkins-core NoSuchMethodError:org.springframework.util.ClassUtils.isCglibProxyClass -->
@@ -101,37 +101,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-joda</artifactId>
-      <version>${jackson.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.jaxrs</groupId>
-      <artifactId>jackson-jaxrs-base</artifactId>
-      <version>${jackson.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.jaxrs</groupId>
-      <artifactId>jackson-jaxrs-json-provider</artifactId>
-      <version>${jackson.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.jersey.connectors</groupId>
-      <artifactId>jersey-apache-connector</artifactId>
-      <version>2.11</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <version>4.3.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.jersey.core</groupId>
-      <artifactId>jersey-client</artifactId>
-      <version>2.11</version>
-    </dependency>
-
-    <dependency>
-      <groupId>com.fasterxml.jackson.module</groupId>
-      <artifactId>jackson-module-jaxb-annotations</artifactId>
       <version>${jackson.version}</version>
     </dependency>
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
@@ -72,7 +72,7 @@ public class KubernetesSlave extends AbstractCloudSlave {
         }
 
         try {
-            cloud.connect().deletePod(name, cloud.getNamespace());
+            cloud.connect().pods().inNamespace(cloud.getNamespace()).withName(name).delete();
             LOGGER.log(Level.INFO, "Terminated Kubernetes instance for slave {0}", name);
             toComputer().disconnect(OfflineCause.create(new Localizable(HOLDER, "offline")));
             LOGGER.log(Level.INFO, "Disconnected computer {0}", name);


### PR DESCRIPTION
This pull request upgrades to the latest Fabric8 client for Kubernetes. 

The new client provides a DSL that makes code easier to read and write.
It has also much smaller footprint and fewer dependencies (no longer using cxf, jaxrs etc).
Last but not least it contains a lot of improvements, reduces complexity etc (and judging from some comments in the source I think they will come in handy). 

Cheers.