### PR TITLE
added Always imagePullPolicy to always pull latest image

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -218,6 +218,8 @@ public class KubernetesCloud extends Cloud {
 
         manifestContainer.setName(CONTAINER_NAME);
         manifestContainer.setImage(template.getImage());
+        manifestContainer.setImagePullPolicy("Always");
+
         if (template.isPrivileged())
             manifestContainer.setSecurityContext(new SecurityContext(null, true, null, null));
 

--- a/src/main/kubernetes/pod.yml
+++ b/src/main/kubernetes/pod.yml
@@ -21,6 +21,7 @@
           - 
             name: "jenkins-data"
             mountPath: "/var/jenkins_home"
+        imagePullPolicy: Always
     volumes: 
       - 
         name: "jenkins-data"


### PR DESCRIPTION
If we need to update one of the slave images, we push a change to a slave repo which Jenkins will build and publish to our private registry. This will enable the Kubernetes Plugin to auto pull the latest on all Kubernetes nodes after an updated slave image becomes available.