### PR TITLE
Avoid race with OnceRetentionStrategy timeout

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
@@ -50,7 +50,7 @@ public class KubernetesSlave extends AbstractCloudSlave {
                 Node.Mode.NORMAL,
                 label == null ? null : label.toString(),
                 new JNLPLauncher(),
-                new OnceRetentionStrategy(0),
+                new OnceRetentionStrategy(/*minutes idle*/ 1),
                 Collections.<NodeProperty<Node>> emptyList());
 
         // this.pod = pod;


### PR DESCRIPTION
The one-shot retention strategy constructor takes a fallback timeout
(in minutes) to use if the task does not signal completion. Setting
this value to zero allows the timeout-based cleanup to race with tasks
starting, which can easily happen for JNLP-launched slaves started by
this plugin. This causes at best the kube pods to be terminated
prematurely, and can lead to worse behavior like leaked pods that
eventually fill up the plugin's simultaneous container limit.

A one minute timeout should not be excessive. Note that the slaves are
still one-shot; upon task completion, the retention policy disables
acceptance.