### PR TITLE
.gitignore for IntelliJ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 /.project
 /.settings/
 /work/
+
+/.idea/
+*.iml


### PR DESCRIPTION
Fix JENKINS-31076 - [kubernetes cli] proper message if credentials are not defined or not found