### PR TITLE
Support client certificate authentication of kubernetes api

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ Get the ip (in this case `104.197.19.100`) with `kubectl describe services/jenki
 Configure Jenkins, adding the `Kubernetes` cloud under configuration, setting
 Kubernetes URL to the container engine cluster endpoint or simply `https://kubernetes.default.svc.cluster.local`.
 Under credentials, click `Add` and select `Kubernetes Service Account`,
-or alternatively use the Kubernetes API username and password.
+or alternatively use the Kubernetes API username and password. Select 'Certificate' as credentials type if the
+kubernetes cluster is configured to use client certificates for authentication.
 
 ![image](credentials.png)
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubectlBuildWrapper.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubectlBuildWrapper.java
@@ -2,6 +2,7 @@ package org.csanchez.jenkins.plugins.kubernetes;
 
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardCertificateCredentials;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
@@ -24,6 +25,7 @@ import hudson.util.ListBoxModel;
 import hudson.util.Secret;
 import jenkins.model.Jenkins;
 import jenkins.tasks.SimpleBuildWrapper;
+import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -31,20 +33,38 @@ import org.kohsuke.stapler.QueryParameter;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
+import java.security.Key;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
 import java.util.Collections;
+import java.util.Set;
+
+import static com.google.common.collect.Sets.newHashSet;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public class KubectlBuildWrapper extends SimpleBuildWrapper {
 
+    private static final String BEGIN_CERTIFICATE = "-----BEGIN CERTIFICATE-----";
+    private static final String END_CERTIFICATE = "-----END CERTIFICATE-----";
+    private static final String BEGIN_PRIVATE_KEY = "-----BEGIN PRIVATE KEY-----";
+    private static final String END_PRIVATE_KEY = "-----END PRIVATE KEY-----";
+
     private final String serverUrl;
     private final String credentialsId;
+    private final String caCertificate;
 
     @DataBoundConstructor
-    public KubectlBuildWrapper(@Nonnull String serverUrl, @Nonnull String credentialsId) {
+    public KubectlBuildWrapper(@Nonnull String serverUrl, @Nonnull String credentialsId,
+            @Nonnull String caCertificate) {
         this.serverUrl = serverUrl;
         this.credentialsId = credentialsId;
+        this.caCertificate = caCertificate;
     }
 
     public String getServerUrl() {
@@ -55,13 +75,34 @@ public class KubectlBuildWrapper extends SimpleBuildWrapper {
         return credentialsId;
     }
 
+    public String getCaCertificate() {
+        return caCertificate;
+    }
+
     @Override
     public void setUp(Context context, Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener, EnvVars initialEnvironment) throws IOException, InterruptedException {
 
         FilePath configFile = workspace.createTempFile(".kube", "config");
+        Set<String> tempFiles = newHashSet(configFile.getRemote());
+
+        String tlsConfig;
+        if (caCertificate != null && !caCertificate.isEmpty()) {
+            FilePath caCrtFile = workspace.createTempFile("cert-auth", "crt");
+            String ca = caCertificate;
+            if (!ca.startsWith(BEGIN_CERTIFICATE)) {
+                ca = wrapWithMarker(BEGIN_CERTIFICATE, END_CERTIFICATE, ca);
+            }
+            caCrtFile.write(ca, null);
+            tempFiles.add(caCrtFile.getRemote());
+
+            tlsConfig = " --certificate-authority=" + caCrtFile.getRemote();
+        } else {
+            tlsConfig = " --insecure-skip-tls-verify=true";
+        }
 
         int status = launcher.launch()
-                .cmdAsSingleString("kubectl config --kubeconfig=" + configFile.getRemote() + " set-cluster k8s --server=" + serverUrl + " --insecure-skip-tls-verify=true")
+                .cmdAsSingleString("kubectl config --kubeconfig=" + configFile.getRemote()
+                        + " set-cluster k8s --server=" + serverUrl + tlsConfig)
                 .join();
         if (status != 0) throw new IOException("Failed to run kubectl config "+status);
 
@@ -75,6 +116,35 @@ public class KubectlBuildWrapper extends SimpleBuildWrapper {
         } else if (c instanceof UsernamePasswordCredentials) {
             UsernamePasswordCredentials upc = (UsernamePasswordCredentials) c;
             login = "--username=" + upc.getUsername() + " --password=" + Secret.toString(upc.getPassword());
+        } else if (c instanceof StandardCertificateCredentials) {
+            StandardCertificateCredentials scc = (StandardCertificateCredentials) c;
+            KeyStore keyStore = scc.getKeyStore();
+            String alias;
+            try {
+                alias = keyStore.aliases().nextElement();
+                X509Certificate certificate = (X509Certificate) keyStore.getCertificate(alias);
+                Key key = keyStore.getKey(alias, Secret.toString(scc.getPassword()).toCharArray());
+                FilePath clientCrtFile = workspace.createTempFile("client", "crt");
+                FilePath clientKeyFile = workspace.createTempFile("client", "key");
+                String encodedClientCrt = wrapWithMarker(BEGIN_CERTIFICATE, END_CERTIFICATE,
+                        Base64.encodeBase64String(certificate.getEncoded()));
+                String encodedClientKey = wrapWithMarker(BEGIN_PRIVATE_KEY, END_PRIVATE_KEY,
+                        Base64.encodeBase64String(key.getEncoded()));
+                clientCrtFile.write(encodedClientCrt, null);
+                clientKeyFile.write(encodedClientKey, null);
+                tempFiles.add(clientCrtFile.getRemote());
+                tempFiles.add(clientKeyFile.getRemote());
+                login = "--client-certificate=" + clientCrtFile.getRemote() + " --client-key="
+                        + clientKeyFile.getRemote();
+            } catch (KeyStoreException e) {
+                throw new AbortException(e.getMessage());
+            } catch (UnrecoverableKeyException e) {
+                throw new AbortException(e.getMessage());
+            } catch (NoSuchAlgorithmException e) {
+                throw new AbortException(e.getMessage());
+            } catch (CertificateEncodingException e) {
+                throw new AbortException(e.getMessage());
+            }
         } else {
             throw new AbortException("Unsupported Credentials type " + c.getClass().getName());
         }
@@ -95,7 +165,7 @@ public class KubectlBuildWrapper extends SimpleBuildWrapper {
                 .join();
         if (status != 0) throw new IOException("Failed to run kubectl config "+status);
 
-        context.setDisposer(new CleanupDisposer(configFile.getRemote()));
+        context.setDisposer(new CleanupDisposer(tempFiles));
 
         context.env("KUBECONFIG", configFile.getRemote());
     }
@@ -122,6 +192,13 @@ public class KubectlBuildWrapper extends SimpleBuildWrapper {
         return result;
     }
 
+    private static String wrapWithMarker(String begin, String end, String encodedBody) {
+        return new StringBuilder(begin).append("\n")
+                .append(encodedBody).append("\n")
+                .append(end)
+                .toString();
+    }
+
     @Extension
     public static class DescriptorImpl extends BuildWrapperDescriptor {
 
@@ -141,7 +218,8 @@ public class KubectlBuildWrapper extends SimpleBuildWrapper {
                     .withMatching(
                             CredentialsMatchers.anyOf(
                                     CredentialsMatchers.instanceOf(StandardUsernamePasswordCredentials.class),
-                                    CredentialsMatchers.instanceOf(TokenProducer.class)
+                                    CredentialsMatchers.instanceOf(TokenProducer.class),
+                                    CredentialsMatchers.instanceOf(StandardCertificateCredentials.class)
                             ),
                             CredentialsProvider.lookupCredentials(
                                     StandardCredentials.class,
@@ -157,15 +235,18 @@ public class KubectlBuildWrapper extends SimpleBuildWrapper {
 
     private static class CleanupDisposer extends Disposer {
 
-        private String configFile;
+        private static final long serialVersionUID = 3006113419319201358L;
+        private Set<String> configFiles;
 
-        public CleanupDisposer(String configFile) {
-            this.configFile = configFile;
+        public CleanupDisposer(Set<String> tempFiles) {
+            this.configFiles = tempFiles;
         }
 
         @Override
         public void tearDown(Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener) throws IOException, InterruptedException {
-            workspace.child(configFile).delete();
+            for (String configFile : configFiles) {
+                workspace.child(configFile).delete();
+            }
         }
     }
 }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -2,6 +2,7 @@ package org.csanchez.jenkins.plugins.kubernetes;
 
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardCertificateCredentials;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
@@ -30,12 +31,12 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 
-import javax.annotation.CheckForNull;
 import java.io.IOException;
 import java.net.URL;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateEncodingException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -46,6 +47,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import javax.annotation.CheckForNull;
 
 /**
  * Kubernetes cloud provider.
@@ -183,8 +186,10 @@ public class KubernetesCloud extends Cloud {
      * Connects to Docker.
      *
      * @return Docker client.
+     * @throws CertificateEncodingException
      */
-    public KubernetesClient connect() throws UnrecoverableKeyException, NoSuchAlgorithmException, KeyStoreException, IOException {
+    public KubernetesClient connect() throws UnrecoverableKeyException, NoSuchAlgorithmException, KeyStoreException,
+            IOException, CertificateEncodingException {
 
         LOGGER.log(Level.FINE, "Building connection to Kubernetes host " + name + " URL " + serverUrl);
 
@@ -502,7 +507,8 @@ public class KubernetesCloud extends Cloud {
                     .withMatching(
                             CredentialsMatchers.anyOf(
                                     CredentialsMatchers.instanceOf(StandardUsernamePasswordCredentials.class),
-                                    CredentialsMatchers.instanceOf(TokenProducer.class)
+                                    CredentialsMatchers.instanceOf(TokenProducer.class),
+                                    CredentialsMatchers.instanceOf(StandardCertificateCredentials.class)
                             ),
                             CredentialsProvider.lookupCredentials(StandardCredentials.class,
                                     Jenkins.getInstance(),

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFactoryAdapter.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFactoryAdapter.java
@@ -2,6 +2,7 @@ package org.csanchez.jenkins.plugins.kubernetes;
 
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardCertificateCredentials;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
@@ -11,13 +12,19 @@ import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import jenkins.model.Jenkins;
+import org.apache.commons.codec.binary.Base64;
 
-import javax.annotation.CheckForNull;
 import java.io.IOException;
+import java.security.Key;
+import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
 import java.util.Collections;
+
+import javax.annotation.CheckForNull;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
@@ -48,7 +55,8 @@ public class KubernetesFactoryAdapter {
         );
     }
 
-    public KubernetesClient createClient() throws NoSuchAlgorithmException, UnrecoverableKeyException, KeyStoreException, IOException {
+    public KubernetesClient createClient() throws NoSuchAlgorithmException, UnrecoverableKeyException,
+            KeyStoreException, IOException, CertificateEncodingException {
         ConfigBuilder builder = new ConfigBuilder().withMasterUrl(serviceAddress);
         if (credentials != null) {
             if (credentials instanceof TokenProducer) {
@@ -58,6 +66,16 @@ public class KubernetesFactoryAdapter {
             else if (credentials instanceof UsernamePasswordCredentials) {
                 UsernamePasswordCredentials usernamePassword = (UsernamePasswordCredentials) credentials;
                 builder.withUsername(usernamePassword.getUsername()).withPassword(Secret.toString(usernamePassword.getPassword()));
+            }
+            else if (credentials instanceof StandardCertificateCredentials) {
+                StandardCertificateCredentials certificateCredentials = (StandardCertificateCredentials) credentials;
+                KeyStore keyStore = certificateCredentials.getKeyStore();
+                String alias = keyStore.aliases().nextElement();
+                X509Certificate certificate = (X509Certificate) keyStore.getCertificate(alias);
+                Key key = keyStore.getKey(alias, Secret.toString(certificateCredentials.getPassword()).toCharArray());
+                builder.withClientCertData(Base64.encodeBase64String(certificate.getEncoded()))
+                        .withClientKeyData(pemEncodeKey(key))
+                        .withClientKeyPassphrase(Secret.toString(certificateCredentials.getPassword()));
             }
         }
 
@@ -69,5 +87,13 @@ public class KubernetesFactoryAdapter {
             builder.withCaCertData(caCertData);
         }
         return new DefaultKubernetesClient(builder.build());
+    }
+
+    private static String pemEncodeKey(Key key) {
+        return Base64.encodeBase64String(new StringBuilder()
+                .append("-----BEGIN PRIVATE KEY-----\n")
+                .append(Base64.encodeBase64String(key.getEncoded()))
+                .append("\n-----END PRIVATE KEY-----\n")
+                .toString().getBytes());
     }
 }

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubectlBuildWrapper/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubectlBuildWrapper/config.jelly
@@ -5,6 +5,10 @@
     <f:textbox/>
   </f:entry>
 
+  <f:entry title="${%Certificate of certificate authority (CA)}" field="caCertificate">
+    <f:textarea/>
+  </f:entry>
+
   <f:entry field="credentialsId" title="${%Credentials}">
     <c:select/>
   </f:entry>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubectlBuildWrapper/help-caCertificate.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubectlBuildWrapper/help-caCertificate.html
@@ -1,0 +1,4 @@
+<div>
+    The base64 encoded certificate of the certificate authority (CA). It is used to verify the server certificate.
+    <p>Leaving this field empty will skip the certificate verification.</p> 
+</div>


### PR DESCRIPTION
Extend credentials to accept certificates and properly encode certificate and key before passing to kubernetes client config builder.

Fixes [JENKINS-30894](https://issues.jenkins-ci.org/browse/JENKINS-30894)