### PR TITLE
Make OnceRetentionStrategy timeout configurable

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -70,6 +70,9 @@ public class KubernetesCloud extends Cloud {
 
     private static final String CONTAINER_NAME = "slave";
 
+    /** Default timeout for idle workers that don't correctly indicate exit. */
+    private static final int DEFAULT_RETENTION_TIMEOUT_MINUTES = 5;
+
     private final List<PodTemplate> templates;
     private final String serverUrl;
     @CheckForNull
@@ -84,12 +87,13 @@ public class KubernetesCloud extends Cloud {
     @CheckForNull
     private String credentialsId;
     private final int containerCap;
+    private final int retentionTimeout;
 
     private transient KubernetesClient client;
 
     @DataBoundConstructor
     public KubernetesCloud(String name, List<? extends PodTemplate> templates, String serverUrl, String namespace,
-            String jenkinsUrl, String containerCapStr, int connectTimeout, int readTimeout) {
+            String jenkinsUrl, String containerCapStr, int connectTimeout, int readTimeout, int retentionTimeout) {
         super(name);
 
         Preconditions.checkArgument(!StringUtils.isBlank(serverUrl));
@@ -107,8 +111,17 @@ public class KubernetesCloud extends Cloud {
         } else {
             this.containerCap = Integer.parseInt(containerCapStr);
         }
+
+        if (retentionTimeout > 0) {
+            this.retentionTimeout = retentionTimeout;
+        } else {
+            this.retentionTimeout = DEFAULT_RETENTION_TIMEOUT_MINUTES;
+        }
     }
 
+    public int getRetentionTimeout() {
+        return retentionTimeout;
+    }
 
     public List<PodTemplate> getTemplates() {
         return templates;

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
@@ -50,7 +50,7 @@ public class KubernetesSlave extends AbstractCloudSlave {
                 Node.Mode.NORMAL,
                 label == null ? null : label.toString(),
                 new JNLPLauncher(),
-                new OnceRetentionStrategy(/*minutes idle*/ 1),
+                new OnceRetentionStrategy(cloud.getRetentionTimeout()),
                 Collections.<NodeProperty<Node>> emptyList());
 
         // this.pod = pod;

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/config.jelly
@@ -47,6 +47,12 @@
         <f:textbox default="10"/>
     </f:entry>
 
+    <f:advanced>
+      <f:entry title="${%Container Cleanup Timeout (minutes)}" field="retentionTimeout">
+        <f:textbox default="5"/>
+      </f:entry>
+    </f:advanced>
+
     <f:entry title="${%Images}" description="${%List of Images to be launched as slaves}">
       <f:repeatableHeteroProperty field="templates" hasHeader="true" addCaption="Add Pod Template"
                                   deleteCaption="Delete Template" />

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/help-retentionTimeout.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/help-retentionTimeout.html
@@ -1,0 +1,7 @@
+Time in minutes after which the Kubernetes cloud plugin will clean up an idle
+worker that has not already terminated. This cleanup is only necessary in
+exceptional conditions; typically workers will terminate upon completion of the
+invoking task.
+
+<p>For tasks that use very large images, this timeout can be increased to avoid
+early termination of the task while the Kubernetes pod is still deploying.</p>

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudTest.java
@@ -10,7 +10,7 @@ import com.google.common.collect.ImmutableList;
 public class KubernetesCloudTest {
 
     private KubernetesCloud cloud = new KubernetesCloud("test", null, "http://localhost:8080", "default", null, "", 0,
-            0);
+            0, /*retentionTimeoutMinutes=*/ 5);
 
     @Test
     public void testParseDockerCommand() {


### PR DESCRIPTION
The default value of one minute introduced in commit 0138277e is small
enough that it trips up jobs with large (~ 1GB, e.g.) images on first
deployment in some settings. This patch bumps the default to 5
minutes and makes it configurable via system property. It seems
*unlikely* that this will be a frequently-adjusted parameter, so
making it part of the plugin configuration settings seems excessively
invasive.

Refs #20.