### PR TITLE
[WIP] Add support for nodeSelector

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -231,6 +231,7 @@ public class KubernetesCloud extends Cloud {
                         .addToArgs(slave.getComputer().getJnlpMac())
                         .addToArgs(slave.getComputer().getName())
                 .endContainer()
+                .withNodeSelector(getNodeSelectorMap(template.getNodeSelector()))
                 .withRestartPolicy("Never")
                 .endSpec()
                 .build();
@@ -238,6 +239,20 @@ public class KubernetesCloud extends Cloud {
 
     private Map<String, String> getLabelsFor(String id) {
         return ImmutableMap.<String, String> builder().putAll(POD_LABEL).putAll(ImmutableMap.of("name", id)).build();
+    }
+
+    private Map<String, String> getNodeSelectorMap(String selectors)
+    {
+        ImmutableMap.Builder builder = ImmutableMap.<String, String> builder();
+
+        for (String selector : selectors.split(","))
+        {
+            String[] parts = selector.split("=");
+
+            builder = builder.put(parts[0], parts[1]);
+        }
+
+        return builder.build();
     }
 
     /**

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -35,6 +35,8 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> {
 
     private String label;
 
+    private String nodeSelector;
+
     @DataBoundConstructor
     public PodTemplate(String image) {
         Preconditions.checkArgument(!StringUtils.isBlank(image));
@@ -121,6 +123,19 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> {
 
     public String getLabel() {
         return label;
+    }
+
+    public Set<LabelAtom> getNodeSelectorSet() {
+        return Label.parse(nodeSelector);
+    }
+
+    @DataBoundSetter
+    public void setNodeSelector(String nodeSelector) {
+        this.nodeSelector = nodeSelector;
+    }
+
+    public String getNodeSelector() {
+        return nodeSelector;
     }
 
     @DataBoundSetter

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -125,10 +125,6 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> {
         return label;
     }
 
-    public Set<LabelAtom> getNodeSelectorSet() {
-        return Label.parse(nodeSelector);
-    }
-
     @DataBoundSetter
     public void setNodeSelector(String nodeSelector) {
         this.nodeSelector = nodeSelector;

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
@@ -61,6 +61,10 @@ THE SOFTWARE.
     <f:entry field="privileged" title="${%Run in privileged mode}">
       <f:checkbox/>
     </f:entry>
+
+    <f:entry field="nodeSelector" title="${%Node Selector}">
+      <f:textbox/>
+    </f:entry>
   </f:advanced>
 
 </j:jelly>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/help-nodeSelector.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/help-nodeSelector.html
@@ -1,0 +1,2 @@
+Specify which nodes the pod should operate on by providing a comma separated list of node labels:
+`label1=value1,label2=value2`.


### PR DESCRIPTION
The following PR adds support for specifying the `nodeSelector` property as part of the pod template. This should allow users to have some control on which nodes a pod might get scheduled on.

I'm marking this as a WIP since I'm new to Jenkins plugin development and there might be a couple of things I missed along the way :sweat_smile:.