### PR TITLE
Added support for storing OpenShift OAuth access token as a credential

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/OpenShiftBearerTokenCredentialImpl.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/OpenShiftBearerTokenCredentialImpl.java
@@ -142,7 +142,7 @@ public class OpenShiftBearerTokenCredentialImpl extends UsernamePasswordCredenti
 
         @Override
         public String getDisplayName() {
-            return "OpenShift OAuth Access token";
+            return "OpenShift Username and Password";
         }
     }
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/OpenShiftTokenCredentialImpl.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/OpenShiftTokenCredentialImpl.java
@@ -1,0 +1,42 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
+
+import hudson.Extension;
+import hudson.util.Secret;
+
+/**
+ * @author <a href="mailto:andy.block@gmail.com">Andrew Block</a>
+ */
+public class OpenShiftTokenCredentialImpl extends BaseStandardCredentials implements TokenProducer {
+
+    private final Secret secret;
+
+    @DataBoundConstructor
+    public OpenShiftTokenCredentialImpl(CredentialsScope scope, String id, String description, Secret secret) {
+        super(scope, id, description);
+        this.secret = secret;
+    }
+
+    @Override
+    public String getToken(String serviceAddress, String caCertData, boolean skipTlsVerify) {
+        return secret.getPlainText();
+    }
+    
+    public Secret getSecret() {
+    	return secret;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends BaseStandardCredentialsDescriptor {
+
+        @Override
+        public String getDisplayName() {
+            return "OpenShift OAuth token";
+        }
+    }
+
+}

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/OpenShiftTokenCredentialImpl/credentials.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/OpenShiftTokenCredentialImpl/credentials.jelly
@@ -1,0 +1,7 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
+    <f:entry title="${%Token}" field="secret">
+        <f:password/>
+    </f:entry>
+    <st:include page="id-and-description" class="${descriptor.clazz}"/>
+</j:jelly>


### PR DESCRIPTION
Added support for storing an OpenShift OAuth token as credentials. This is useful especially when using service accounts to communicate between Jenkins and OpenShift