### PR TITLE
[JENKINS-36253] Add Annotations to Pod Template

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -259,6 +259,7 @@ public class KubernetesCloud extends Cloud {
                 .withNewMetadata()
                     .withName(slave.getNodeName())
                     .withLabels(getLabelsFor(id))
+                    .withAnnotations(getAnnotationsMap(template.getAnnotations()))
                 .endMetadata()
                 .withNewSpec()
                     .withVolumes(volumes)
@@ -299,6 +300,16 @@ public class KubernetesCloud extends Cloud {
         if (StringUtils.isNotBlank(cpu)) {
             Quantity cpuQuantity = new Quantity(cpu);
             builder.put("cpu", cpuQuantity);
+        }
+        return builder.build();
+    }
+
+    private Map<String, String> getAnnotationsMap(List<PodAnnotation> annotations) {
+        ImmutableMap.Builder<String, String> builder = ImmutableMap.<String, String> builder();
+        if(annotations!=null) {
+            for (PodAnnotation podAnnotation :annotations) {
+                builder.put(podAnnotation.getKey(), podAnnotation.getValue());
+            }
         }
         return builder.build();
     }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodAnnotation.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodAnnotation.java
@@ -1,0 +1,42 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class PodAnnotation extends AbstractDescribableImpl<PodAnnotation> {
+
+    private String key;
+    private String value;
+
+    @DataBoundConstructor
+    public PodAnnotation(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<PodAnnotation> {
+        @Override
+        public String getDisplayName() {
+            return "Pod Annotation";
+        }
+    }
+}

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -54,6 +54,8 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> {
 
     private final List<PodEnvVar> envVars = new ArrayList<PodEnvVar>();
 
+    private final List<PodAnnotation> annotations = new ArrayList<PodAnnotation>();
+
     @DataBoundConstructor
     public PodTemplate(String image, List<? extends PodVolume> volumes) {
         this(null, image, volumes);
@@ -182,6 +184,15 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> {
     @DataBoundSetter
     public void setEnvVars(List<PodEnvVar> envVars) {
         this.envVars.addAll(envVars);
+    }
+
+    public List<PodAnnotation> getAnnotations() {
+        return annotations;
+    }
+
+    @DataBoundSetter
+    public void setAnnotations(List<PodAnnotation> annotations) {
+        this.annotations.addAll(annotations);
     }
 
     public String getResourceRequestMemory() {

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodAnnotation/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodAnnotation/config.jelly
@@ -1,0 +1,40 @@
+<!--
+The MIT License
+
+Copyright (c) 2004-2009, Sun Microsystems, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<!--
+  Config page
+-->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+
+  <f:entry field="key" title="${%Key}">
+    <f:textbox/>
+  </f:entry>
+
+  <f:entry field="value" title="${%Value}">
+    <f:textbox/>
+  </f:entry>
+
+</j:jelly>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodAnnotation/help-key.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodAnnotation/help-key.html
@@ -1,0 +1,1 @@
+The annotation key.

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodAnnotation/help-value.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodAnnotation/help-value.html
@@ -1,0 +1,1 @@
+The annotation value.

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
@@ -71,6 +71,11 @@ THE SOFTWARE.
                                   deleteCaption="Delete Environment Variable" />
     </f:entry>
 
+    <f:entry title="${%Annotations}" description="${%List of annotations to set in slave pod}">
+      <f:repeatableHeteroProperty field="annotations" hasHeader="true" addCaption="Add Annotation"
+                                  deleteCaption="Delete annotation Variable" />
+    </f:entry>
+
   <f:advanced>
     <f:entry field="privileged" title="${%Run in privileged mode}">
       <f:checkbox/>


### PR DESCRIPTION
Pod Annotations are useful. We should be able to create a Pod Annotation in the Template.

I am using them with EC2Metaproxy to grant permissions on AWS.