### PR TITLE
Make it possible to define more than one containers inside a pod.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,8 @@
     <!-- Jenkins plugin version -->
     <durable-task.version>1.6</durable-task.version>
     <credentials.version>1.22</credentials.version>
+    <script-security.version>1.14</script-security.version>
+    <workflow.version>2.1</workflow.version>
   </properties>
 
   <dependencies>
@@ -70,6 +72,42 @@
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>
       <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>script-security</artifactId>
+      <version>${script-security.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-step-api</artifactId>
+      <version>${workflow.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-cps</artifactId>
+      <version>${workflow.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-aggregator</artifactId>
+      <version>${workflow.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency> <!-- StepConfigTester -->
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-step-api</artifactId>
+      <version>${workflow.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency> <!-- SemaphoreStep -->
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-support</artifactId>
+      <version>${workflow.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,38 +30,45 @@
   </developers>
 
   <properties>
+    <httpclient.version>4.5.1</httpclient.version>
+    <kubernetes-client.version>1.3.98</kubernetes-client.version>
     <jackson.version>2.5.0</jackson.version>
+    <slf4j.version>1.7.7</slf4j.version>
     <spring.version>3.2.14.RELEASE</spring.version>
+
+    <!-- Jenkins plugin version -->
+    <durable-task.version>1.6</durable-task.version>
+    <credentials.version>1.22</credentials.version>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>1.22</version>
+      <version>${credentials.version}</version>
     </dependency>
 
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-client</artifactId>
-      <version>1.3.98</version>
+      <version>${kubernetes-client.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.5.1</version>
+      <version>${httpclient.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>durable-task</artifactId>
-      <version>1.6</version>
+      <version>${durable-task.version}</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.7</version>
+      <version>${slf4j.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerEnvVar.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerEnvVar.java
@@ -5,15 +5,13 @@ import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-@Deprecated
-//Use ContainerEnv instead. This will be removed in future versions
-public class PodEnvVar extends AbstractDescribableImpl<PodEnvVar> {
+public class ContainerEnvVar extends AbstractDescribableImpl<ContainerEnvVar> {
 
     private String key;
     private String value;
 
     @DataBoundConstructor
-    public PodEnvVar(String key, String value) {
+    public ContainerEnvVar(String key, String value) {
         this.key = key;
         this.value = value;
     }
@@ -35,7 +33,7 @@ public class PodEnvVar extends AbstractDescribableImpl<PodEnvVar> {
     }
 
     @Extension
-    public static class DescriptorImpl extends Descriptor<PodEnvVar> {
+    public static class DescriptorImpl extends Descriptor<ContainerEnvVar> {
         @Override
         public String getDisplayName() {
             return "Container Environment Variable";

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
@@ -27,6 +27,8 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
 
     private String args;
 
+    private boolean ttyEnabled;
+
     private int instanceCap;
 
     private String resourceRequestCpu;
@@ -79,6 +81,15 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
 
     public String getArgs() {
         return args;
+    }
+
+    @DataBoundSetter
+    public void setTtyEnabled(boolean ttyEnabled) {
+        this.ttyEnabled = ttyEnabled;
+    }
+
+    public boolean isTtyEnabled() {
+        return ttyEnabled;
     }
 
     public String getDisplayName() {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
@@ -1,28 +1,17 @@
 package org.csanchez.jenkins.plugins.kubernetes;
 
-import com.google.common.base.Strings;
+import com.google.common.base.Preconditions;
 import hudson.Extension;
-import hudson.Util;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
-import hudson.model.Label;
-import hudson.model.labels.LabelAtom;
-
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import com.google.common.base.Preconditions;
-import org.csanchez.jenkins.plugins.kubernetes.PodVolumes.PodVolume;
-
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
-/**
- * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
- */
-public class PodTemplate extends AbstractDescribableImpl<PodTemplate> {
+public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate> {
 
     private String name;
 
@@ -32,19 +21,13 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> {
 
     private boolean alwaysPullImage;
 
+    private String workingDir;
+
     private String command;
 
     private String args;
 
-    private String remoteFs;
-
     private int instanceCap;
-
-    private String label;
-
-    private String serviceAccount;
-
-    private String nodeSelector;
 
     private String resourceRequestCpu;
 
@@ -54,23 +37,17 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> {
 
     private String resourceLimitMemory;
 
-    private final List<ContainerTemplate> containers;
-
-    private final List<PodVolume> volumes;
-
-    private final List<PodEnvVar> envVars = new ArrayList<PodEnvVar>();
+    private final List<ContainerEnvVar> envVars = new ArrayList<ContainerEnvVar>();
 
     @DataBoundConstructor
-    public PodTemplate(String image, List<? extends PodVolume> volumes, List<ContainerTemplate> containers) {
-        this(null, image, volumes, containers);
+    public ContainerTemplate(String image) {
+        this(null, image);
     }
 
-    PodTemplate(String name, String image, List<? extends PodVolume> volumes, List<ContainerTemplate> containers) {
-        Preconditions.checkState(!Strings.isNullOrEmpty(image)  || !(containers == null || containers.isEmpty()), "Need to specify either image or add at least one container");
+    ContainerTemplate(String name, String image) {
+        Preconditions.checkArgument(!StringUtils.isBlank(image));
         this.name = name;
         this.image = image;
-        this.volumes = (volumes == null) ? new ArrayList<PodVolume>() : new ArrayList<PodVolume>(volumes);
-        this.containers = (containers == null) ? new ArrayList<ContainerTemplate>() : new ArrayList<ContainerTemplate>(containers);
     }
 
     @DataBoundSetter
@@ -105,16 +82,16 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> {
     }
 
     public String getDisplayName() {
-        return "Kubernetes Pod Template";
+        return "Container Pod Template";
     }
 
     @DataBoundSetter
-    public void setRemoteFs(String remoteFs) {
-        this.remoteFs = StringUtils.isBlank(remoteFs) ? "/home/jenkins" : remoteFs;
+    public void setWorkingDir(String workingDir) {
+        this.workingDir = workingDir;
     }
 
-    public String getRemoteFs() {
-        return remoteFs;
+    public String getWorkingDir() {
+        return workingDir;
     }
 
     public void setInstanceCap(int instanceCap) {
@@ -142,28 +119,6 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> {
         }
     }
 
-    public Set<LabelAtom> getLabelSet() {
-        return Label.parse(label);
-    }
-
-    @DataBoundSetter
-    public void setLabel(String label) {
-        this.label = label;
-    }
-
-    public String getLabel() {
-        return label;
-    }
-
-    @DataBoundSetter
-    public void setNodeSelector(String nodeSelector) {
-        this.nodeSelector = nodeSelector;
-    }
-
-    public String getNodeSelector() {
-        return nodeSelector;
-    }
-
     @DataBoundSetter
     public void setPrivileged(boolean privileged) {
         this.privileged = privileged;
@@ -171,15 +126,6 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> {
 
     public boolean isPrivileged() {
         return privileged;
-    }
-
-    public String getServiceAccount() {
-        return serviceAccount;
-    }
-
-    @DataBoundSetter
-    public void setServiceAccount(String serviceAccount) {
-        this.serviceAccount = Util.fixEmpty(serviceAccount);
     }
 
     @DataBoundSetter
@@ -191,12 +137,12 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> {
         return alwaysPullImage;
     }
 
-    public List<PodEnvVar> getEnvVars() {
+    public List<ContainerEnvVar> getEnvVars() {
         return envVars;
     }
 
     @DataBoundSetter
-    public void setEnvVars(List<PodEnvVar> envVars) {
+    public void setEnvVars(List<ContainerEnvVar> envVars) {
         this.envVars.addAll(envVars);
     }
 
@@ -236,20 +182,12 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> {
         this.resourceRequestCpu = resourceRequestCpu;
     }
 
-    public List<PodVolume> getVolumes() {
-        return volumes;
-    }
-
-    public List<ContainerTemplate> getContainers() {
-        return containers;
-    }
-
     @Extension
-    public static class DescriptorImpl extends Descriptor<PodTemplate> {
+    public static class DescriptorImpl extends Descriptor<ContainerTemplate> {
 
         @Override
         public String getDisplayName() {
-            return "Kubernetes Pod Template";
+            return "Container Template";
         }
     }
 }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
@@ -8,10 +8,16 @@ import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate> {
+public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate> implements Serializable {
+
+    private static final String DEFAULT_WORKING_DIR = "/home/jenkins";
+    private static final String DEFAULT_COMMAND = "/bin/sh -c";
+    private static final String DEFAULT_ARGS = "cat";
+    private static final Boolean DEFAULT_IS_TTY_ENABLED = true;
 
     private String name;
 
@@ -21,13 +27,13 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
 
     private boolean alwaysPullImage;
 
-    private String workingDir;
+    private String workingDir = DEFAULT_WORKING_DIR;
 
-    private String command;
+    private String command = DEFAULT_COMMAND;
 
-    private String args;
+    private String args = DEFAULT_ARGS;
 
-    private boolean ttyEnabled;
+    private boolean ttyEnabled = DEFAULT_IS_TTY_ENABLED;
 
     private int instanceCap;
 
@@ -80,7 +86,7 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
     }
 
     public String getArgs() {
-        return args;
+        return StringUtils.isBlank(args) ? DEFAULT_ARGS : args;
     }
 
     @DataBoundSetter

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -259,6 +259,7 @@ public class KubernetesCloud extends Cloud {
                 .withEnv(env)
                 .withCommand(parseDockerCommand(containerTemplate.getCommand()))
                 .withArgs(arguments)
+                .withTty(containerTemplate.isTtyEnabled())
                 .withNewResources()
                     .withRequests(getResourcesMap(containerTemplate.getResourceRequestMemory(), containerTemplate.getResourceRequestCpu()))
                     .withLimits(getResourcesMap(containerTemplate.getResourceLimitMemory(), containerTemplate.getResourceLimitCpu()))

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -304,7 +304,7 @@ public class KubernetesCloud extends Cloud {
                 fallback.getEnvVars().add(new ContainerEnvVar(envVar.getKey(), envVar.getValue()));
             }
             List<VolumeMount> containerMounts = new ArrayList<VolumeMount>(volumeMounts);
-            if (!mountPathExists(fallback.getWorkingDir(), volumeMounts)) {
+            if (!PodVolumes.volumeMountExists(fallback.getWorkingDir(), volumeMounts)) {
                 containerMounts.add(new VolumeMount(fallback.getWorkingDir(), WORKSPACE_VOLUME_NAME, false));
             }
 
@@ -312,7 +312,7 @@ public class KubernetesCloud extends Cloud {
         } else {
             for (ContainerTemplate containerTemplate : template.getContainers()) {
                 List<VolumeMount> containerMounts = new ArrayList<VolumeMount>(volumeMounts);
-                if (!mountPathExists(containerTemplate.getWorkingDir(), volumeMounts)) {
+                if (!PodVolumes.volumeMountExists(containerTemplate.getWorkingDir(), volumeMounts)) {
                     containerMounts.add(new VolumeMount(containerTemplate.getWorkingDir(), WORKSPACE_VOLUME_NAME, false));
                 }
                 containers.add(createContainer(slave, containerTemplate, containerMounts));
@@ -390,15 +390,6 @@ public class KubernetesCloud extends Cloud {
             commands.add(m.group(1).replace("\"", ""));
         }
         return commands;
-    }
-
-    private boolean mountPathExists(String path, List<VolumeMount> existingMounts) {
-        for (VolumeMount mount : existingMounts) {
-            if (mount.getMountPath().equals(path)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     @Override

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -63,6 +63,8 @@ public class KubernetesCloud extends Cloud {
     private static final Logger LOGGER = Logger.getLogger(KubernetesCloud.class.getName());
     private static final Pattern SPLIT_IN_SPACES = Pattern.compile("([^\"]\\S*|\".+?\")\\s*");
 
+    private static final String EMPTY = "";
+    private static final String ONE_OR_MORE_SPACES = "[ ]+";
     private static final String DEFAULT_ID = "jenkins-slave-default";
     private static final String WORKSPACE_VOLUME_NAME = "workspace-volume";
 
@@ -70,6 +72,10 @@ public class KubernetesCloud extends Cloud {
     private static final Map<String, String> POD_LABEL = ImmutableMap.of("jenkins", "slave");
 
     private static final String CONTAINER_NAME = "slave";
+
+    private static final String JNLPMAC_REF = "\\$\\{computer.jnlpmac\\}";
+    private static final String NAME_REF = "\\$\\{computer.name\\}";
+    private static final String FALLBACK_ARGUMENTS = "${computer.jnlpmac} ${computer.name}";
 
     /** Default timeout for idle workers that don't correctly indicate exit. */
     private static final int DEFAULT_RETENTION_TIMEOUT_MINUTES = 5;
@@ -236,6 +242,11 @@ public class KubernetesCloud extends Cloud {
         }
         env.add(new EnvVar("HOME", containerTemplate.getWorkingDir(), null));
 
+        String[] arguments = (!Strings.isNullOrEmpty(containerTemplate.getArgs()) ? containerTemplate.getArgs() : EMPTY)
+                .replaceAll(JNLPMAC_REF, slave.getComputer().getJnlpMac())
+                .replaceAll(NAME_REF, slave.getComputer().getName()).split(ONE_OR_MORE_SPACES);
+
+
         return new ContainerBuilder()
                 .withName(containerTemplate.getName())
                 .withImage(containerTemplate.getImage())
@@ -247,12 +258,11 @@ public class KubernetesCloud extends Cloud {
                 .withVolumeMounts(volumeMounts)
                 .withEnv(env)
                 .withCommand(parseDockerCommand(containerTemplate.getCommand()))
+                .withArgs(arguments)
                 .withNewResources()
                     .withRequests(getResourcesMap(containerTemplate.getResourceRequestMemory(), containerTemplate.getResourceRequestCpu()))
                     .withLimits(getResourcesMap(containerTemplate.getResourceLimitMemory(), containerTemplate.getResourceLimitCpu()))
                 .endResources()
-                .addToArgs(slave.getComputer().getJnlpMac())
-                .addToArgs(slave.getComputer().getName())
                 .build();
     }
 
@@ -287,7 +297,7 @@ public class KubernetesCloud extends Cloud {
             fallback.setResourceLimitCpu(template.getResourceLimitCpu());
             fallback.setWorkingDir(template.getRemoteFs());
             fallback.setCommand(template.getCommand());
-            fallback.setArgs(template.getArgs());
+            fallback.setArgs(!Strings.isNullOrEmpty(template.getArgs()) ? template.getArgs() : FALLBACK_ARGUMENTS);
 
             for (PodEnvVar envVar : template.getEnvVars()) {
                 fallback.getEnvVars().add(new ContainerEnvVar(envVar.getKey(), envVar.getValue()));

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodVolumes.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodVolumes.java
@@ -5,13 +5,17 @@ import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeBuilder;
+import io.fabric8.kubernetes.api.model.VolumeMount;
 import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.Serializable;
+import java.util.List;
 
 public class PodVolumes {
     /**
      * Base class for all Kubernetes volume types
      */
-    public static abstract class PodVolume extends AbstractDescribableImpl<PodVolume> {
+    public static abstract class PodVolume extends AbstractDescribableImpl<PodVolume> implements Serializable {
         // Where to mount this volume in the pod.
         public abstract String getMountPath();
 
@@ -127,5 +131,23 @@ public class PodVolumes {
                 return "Host Path Volume";
             }
         }
+    }
+
+    public static boolean volumeMountExists(String path, List<VolumeMount> existingMounts) {
+        for (VolumeMount mount : existingMounts) {
+            if (mount.getMountPath().equals(path)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static boolean podVolumeExists(String path, List<PodVolume> existingVolumes) {
+        for (PodVolume podVolume : existingVolumes) {
+            if (podVolume.getMountPath().equals(path)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/Constants.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/Constants.java
@@ -1,0 +1,13 @@
+package org.csanchez.jenkins.plugins.kubernetes.pipeline;
+
+/**
+ * Created by iocanel on 7/29/16.
+ */
+public class Constants {
+
+    public static final String EXIT = "exit";
+    public static final String NEWLINE = "\n";
+    public static final String UTF_8 = "UTF-8";
+    public static final char CTRL_C = '\u0003';
+    public static final String SPACE = " ";
+}

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -76,11 +76,13 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
                         .usingListener(new ExecListener() {
                             @Override
                             public void onOpen(Response response) {
+                                launcher.getListener().getLogger().println("Execution channel is open.");
                                 alive.set(true);
                                 started.countDown();
                             }
                             @Override
                             public void onFailure(IOException e, Response response) {
+                                launcher.getListener().getLogger().println("Execution failure:" + response.message());
                                 alive.set(false);
                                 e.printStackTrace(launcher.getListener().getLogger());
                                 started.countDown();
@@ -89,6 +91,7 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
 
                             @Override
                             public void onClose(int i, String s) {
+                                launcher.getListener().getLogger().println("Execution channel is closed.");
                                 alive.set(false);
                                 started.countDown();
                                 finished.countDown();
@@ -107,6 +110,7 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
 
             @Override
             public void kill(Map<String, String> modelEnvVars) throws IOException, InterruptedException {
+                getListener().getLogger().println("Killing process.");
                 ContainerExecDecorator.this.close();
             }
         };
@@ -159,7 +163,6 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
             }
             //I shouldn't been doing that, but clearly the script that is passed to us is wrong?
             allCommands.add(cmd.replaceAll("\\$\\$", "\\$"));
-            allCommands.add(cmd);
         }
         return allCommands.toArray(new String[allCommands.size()]);
     }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (C) 2015 Original Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.csanchez.jenkins.plugins.kubernetes.pipeline;
+
+import com.squareup.okhttp.Response;
+import hudson.Launcher;
+import hudson.LauncherDecorator;
+import hudson.Proc;
+import hudson.model.Node;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.ExecListener;
+import io.fabric8.kubernetes.client.dsl.ExecWatch;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.io.PrintStream;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.csanchez.jenkins.plugins.kubernetes.pipeline.Constants.*;
+
+public class ContainerExecDecorator extends LauncherDecorator implements Serializable, Closeable {
+
+    private final transient KubernetesClient client;
+    private final transient String podName;
+    private final transient String containerName;
+    private final transient String path;
+    private final transient AtomicBoolean alive;
+    private final transient CountDownLatch started;
+    private final transient CountDownLatch finished;
+
+    private transient ExecWatch watch;
+    private transient ContainerExecProc proc;
+
+    public ContainerExecDecorator(KubernetesClient client, String podName, String containerName, String path, AtomicBoolean alive, CountDownLatch started, CountDownLatch finished) {
+        this.client = client;
+        this.podName = podName;
+        this.containerName = containerName;
+        this.path = path;
+        this.alive = alive;
+        this.started = started;
+        this.finished = finished;
+    }
+
+    @Override
+    public Launcher decorate(final Launcher launcher, final Node node) {
+        return new Launcher.DecoratedLauncher(launcher) {
+            @Override
+            public Proc launch(ProcStarter starter) throws IOException {
+                launcher.getListener().getLogger().println("Executing shell script inside container: [" + containerName + "] of pod: [" + podName + "]");
+                watch = client.pods().withName(podName)
+                        .inContainer(containerName)
+                        .redirectingInput()
+                        .writingOutput(launcher.getListener().getLogger())
+                        .writingError(launcher.getListener().getLogger())
+                        .withTTY()
+                        .usingListener(new ExecListener() {
+                            @Override
+                            public void onOpen(Response response) {
+                                alive.set(true);
+                                started.countDown();
+                            }
+                            @Override
+                            public void onFailure(IOException e, Response response) {
+                                alive.set(false);
+                                e.printStackTrace(launcher.getListener().getLogger());
+                                started.countDown();
+                                finished.countDown();
+                            }
+
+                            @Override
+                            public void onClose(int i, String s) {
+                                alive.set(false);
+                                started.countDown();
+                                finished.countDown();
+                            }
+                        }).exec();
+
+                waitQuietly(started);
+
+                //We need to get into the project workspace.
+                //The workspace is not known in advance, so we have to execute a cd command.
+                watch.getInput().write(("cd " + path + NEWLINE).getBytes(UTF_8));
+                doExec(watch, launcher.getListener().getLogger(), getCommands(starter));
+                proc = new ContainerExecProc(watch, alive, finished);
+                return proc;
+            }
+
+            @Override
+            public void kill(Map<String, String> modelEnvVars) throws IOException, InterruptedException {
+                ContainerExecDecorator.this.close();
+            }
+        };
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (watch != null) {
+            watch.close();
+        }
+
+        if (proc != null) {
+            try {
+                proc.kill();
+            } catch (InterruptedException e) {
+                throw new InterruptedIOException();
+            }
+        }
+    }
+
+    private static void doExec(ExecWatch watch, PrintStream out, String... statements) {
+        try {
+            out.print("Executing command:");
+            for (String stmt : statements) {
+                out.print(stmt);
+                out.print(SPACE);
+                watch.getInput().write((stmt).getBytes(UTF_8));
+                watch.getInput().write((SPACE).getBytes(UTF_8));
+            }
+            out.println();
+            //We need to exit so that we know when the command has finished.
+            watch.getInput().write(NEWLINE.getBytes(UTF_8));
+            watch.getInput().write(EXIT.getBytes(UTF_8));
+            watch.getInput().write(NEWLINE.getBytes(UTF_8));
+            watch.getInput().flush();
+        } catch (Exception e) {
+            e.printStackTrace(out);
+        }
+    }
+
+    private static String[] getCommands(Launcher.ProcStarter starter) {
+        List<String> allCommands = new ArrayList<String>();
+
+
+        boolean first = true;
+        for (String cmd : starter.cmds()) {
+            if (first && "nohup".equals(cmd)) {
+                first = false;
+                continue;
+            }
+            //I shouldn't been doing that, but clearly the script that is passed to us is wrong?
+            allCommands.add(cmd.replaceAll("\\$\\$", "\\$"));
+            allCommands.add(cmd);
+        }
+        return allCommands.toArray(new String[allCommands.size()]);
+    }
+
+    private static void waitQuietly(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            //ignore
+        }
+    }
+}

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -76,13 +76,11 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
                         .usingListener(new ExecListener() {
                             @Override
                             public void onOpen(Response response) {
-                                launcher.getListener().getLogger().println("Execution channel is open.");
                                 alive.set(true);
                                 started.countDown();
                             }
                             @Override
                             public void onFailure(IOException e, Response response) {
-                                launcher.getListener().getLogger().println("Execution failure:" + response.message());
                                 alive.set(false);
                                 e.printStackTrace(launcher.getListener().getLogger());
                                 started.countDown();
@@ -91,7 +89,6 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
 
                             @Override
                             public void onClose(int i, String s) {
-                                launcher.getListener().getLogger().println("Execution channel is closed.");
                                 alive.set(false);
                                 started.countDown();
                                 finished.countDown();

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecProc.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecProc.java
@@ -1,0 +1,58 @@
+package org.csanchez.jenkins.plugins.kubernetes.pipeline;
+
+import hudson.Proc;
+import io.fabric8.kubernetes.client.dsl.ExecWatch;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class ContainerExecProc extends Proc {
+
+    private final AtomicBoolean alive;
+    private final CountDownLatch finished;
+    private final ExecWatch watch;
+
+    public ContainerExecProc(ExecWatch watch, AtomicBoolean alive, CountDownLatch finished) {
+        this.watch = watch;
+        this.alive = alive;
+        this.finished = finished;
+    }
+
+    @Override
+    public boolean isAlive() throws IOException, InterruptedException {
+        return alive.get();
+    }
+
+    @Override
+    public void kill() throws IOException, InterruptedException {
+        //What we actually do is send a ctrl-c to the current process and then exit the shell.
+        watch.getInput().write(Constants.CTRL_C);
+        watch.getInput().write(Constants.EXIT.getBytes(Constants.UTF_8));
+        watch.getInput().write(Constants.NEWLINE.getBytes(Constants.UTF_8));
+        watch.getInput().flush();
+    }
+
+    @Override
+    public int join() throws IOException, InterruptedException {
+        finished.await();
+        return 1;
+    }
+
+    @Override
+    public InputStream getStdout() {
+        return watch.getOutput();
+    }
+
+    @Override
+    public InputStream getStderr() {
+        return watch.getOutput();
+    }
+
+    @Override
+    public OutputStream getStdin() {
+        return watch.getInput();
+    }
+}

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerStep.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerStep.java
@@ -1,0 +1,63 @@
+package org.csanchez.jenkins.plugins.kubernetes.pipeline;
+
+import hudson.Extension;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.Serializable;
+
+public class ContainerStep extends AbstractStepImpl implements Serializable {
+
+    private static final long serialVersionUID = 5588861066775717487L;
+
+    private final String pod;
+    private final String name;
+
+    @DataBoundConstructor
+    public ContainerStep(String pod, String name) {
+        this.pod = pod;
+        this.name = name;
+    }
+
+    public String getPod() {
+        return pod;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends AbstractStepDescriptorImpl {
+
+       public DescriptorImpl() {
+            super(ContainerStepExecution.class);
+        }
+
+        public DescriptorImpl(Class<? extends StepExecution> executionType) {
+            super(executionType);
+        }
+
+        @Override
+        public String getFunctionName() {
+            return "container";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Run build steps in a container";
+        }
+
+        @Override
+        public boolean takesImplicitBlockArgument() {
+            return true;
+        }
+
+        @Override
+        public boolean isAdvanced() {
+            return true;
+        }
+    }
+}

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerStepExecution.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerStepExecution.java
@@ -1,0 +1,86 @@
+package org.csanchez.jenkins.plugins.kubernetes.pipeline;
+
+import hudson.FilePath;
+import hudson.LauncherDecorator;
+import hudson.model.TaskListener;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
+import org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback;
+import org.jenkinsci.plugins.workflow.steps.BodyInvoker;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
+
+import javax.inject.Inject;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Logger;
+import java.util.logging.Level;
+
+public class ContainerStepExecution extends AbstractStepExecutionImpl {
+
+    private static final transient Logger LOGGER = Logger.getLogger(ContainerStepExecution.class.getName());
+    private static final transient String HOSTNAME_FILE = "/etc/hostname";
+
+    @Inject
+    private ContainerStep step;
+    @StepContextParameter private transient FilePath workspace;
+    @StepContextParameter private transient TaskListener listener;
+
+    private transient KubernetesClient client;
+    private transient ContainerExecDecorator decorator;
+
+    @Override
+    public boolean start() throws Exception {
+        LOGGER.log(Level.FINE, "Starting container step.");
+        StepContext context = getContext();
+        String podName = workspace.child(HOSTNAME_FILE).readToString().trim();
+        String containerName = step.getName();
+
+        final AtomicBoolean podAlive = new AtomicBoolean(false);
+        final CountDownLatch podStarted = new CountDownLatch(1);
+        final CountDownLatch podFinished = new CountDownLatch(1);
+
+        client = new DefaultKubernetesClient();
+        decorator = new ContainerExecDecorator(client, podName, containerName, workspace.getRemote(), podAlive, podStarted, podFinished);
+        context.newBodyInvoker()
+                .withContext(BodyInvoker
+                        .mergeLauncherDecorators(getContext().get(LauncherDecorator.class), decorator))
+                .withCallback(new ContainerExecCallback())
+                .start();
+        return false;
+    }
+
+    @Override
+    public void stop(Throwable cause) throws Exception {
+        LOGGER.log(Level.FINE, "Stopping container step.");
+        closeQuietly(client, decorator);
+    }
+
+    private void closeQuietly(Closeable...  closeables) {
+        for (Closeable c : closeables) {
+            if (c != null) {
+                try {
+                    c.close();
+                } catch (IOException e) {
+                    listener.error("Error while closing: [" + c + "]");
+                }
+            }
+        }
+    }
+
+    private class ContainerExecCallback extends BodyExecutionCallback {
+
+        @Override
+        public void onSuccess(StepContext context, Object result) {
+            context.onSuccess(result);
+        }
+
+        @Override
+        public void onFailure(StepContext context, Throwable t) {
+            context.onFailure(t);
+        }
+    }
+}

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep.java
@@ -1,0 +1,150 @@
+package org.csanchez.jenkins.plugins.kubernetes.pipeline;
+
+import hudson.Extension;
+import org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate;
+import org.csanchez.jenkins.plugins.kubernetes.PodVolumes;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PodTemplateStep extends AbstractStepImpl implements Serializable {
+
+    private static final long serialVersionUID = 5588861066775717487L;
+
+    private static final String DEFAULT_CLOUD = "kubernetes";
+    private static final String DEFAULT_TEMPLATE = "kubernetes";
+    private static final String DEFAULT_COMMAND = "/bin/sh -c";
+    private static final String DEFAULT_ARGS = "cat";
+    private static final Boolean DEFAULT_TTY_ENABLED = true;
+    private static final String DEFAULT_WORKING_DIR = "/home/jenkins";
+
+    private String cloud = DEFAULT_CLOUD;
+    private String inheritFrom;
+
+    private final String label;
+    private final String name;
+
+    private List<ContainerTemplate> containers = new ArrayList<ContainerTemplate>();
+    private List<PodVolumes.PodVolume> volumes = new ArrayList<PodVolumes.PodVolume>();
+
+    private String serviceAccount;
+    private String nodeSelector;
+    private String workingDir = DEFAULT_WORKING_DIR;
+
+    @DataBoundConstructor
+    public PodTemplateStep(String label, String name) {
+        this.label = label;
+        this.name = name;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+
+    public String getCloud() {
+        return cloud;
+    }
+
+    @DataBoundSetter
+    public void setCloud(String cloud) {
+        this.cloud = cloud;
+    }
+
+    public String getInheritFrom() {
+        return inheritFrom;
+    }
+
+    @DataBoundSetter
+    public void setInheritFrom(String inheritFrom) {
+        this.inheritFrom = inheritFrom;
+    }
+
+    public List<ContainerTemplate> getContainers() {
+        return containers;
+    }
+
+    @DataBoundSetter
+    public void setContainers(List<ContainerTemplate> containers) {
+        this.containers = containers;
+    }
+
+    public List<PodVolumes.PodVolume> getVolumes() {
+        return volumes;
+    }
+
+    @DataBoundSetter
+    public void setVolumes(List<PodVolumes.PodVolume> volumes) {
+        this.volumes = volumes;
+    }
+
+    public String getServiceAccount() {
+        return serviceAccount;
+    }
+
+    @DataBoundSetter
+    public void setServiceAccount(String serviceAccount) {
+        this.serviceAccount = serviceAccount;
+    }
+
+    public String getNodeSelector() {
+        return nodeSelector;
+    }
+
+    @DataBoundSetter
+    public void setNodeSelector(String nodeSelector) {
+        this.nodeSelector = nodeSelector;
+    }
+
+    public String getWorkingDir() {
+        return workingDir;
+    }
+
+    @DataBoundSetter
+    public void setWorkingDir(String workingDir) {
+        this.workingDir = workingDir;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends AbstractStepDescriptorImpl {
+
+       public DescriptorImpl() {
+            super(PodTemplateStepExecution.class);
+        }
+
+        public DescriptorImpl(Class<? extends StepExecution> executionType) {
+            super(executionType);
+        }
+
+        @Override
+        public String getFunctionName() {
+            return "podTemplate";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Define a podTemplate to use in the kubernetes plugin";
+        }
+
+        @Override
+        public boolean takesImplicitBlockArgument() {
+            return true;
+        }
+
+        @Override
+        public boolean isAdvanced() {
+            return true;
+        }
+    }
+}

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerEnvVar/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerEnvVar/config.jelly
@@ -28,23 +28,13 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <f:entry title="${%Description}" help="/help/system-config/master-slave/description.html">
-    <f:textbox field="nodeDescription" />
+
+  <f:entry field="key" title="${%Key}">
+    <f:textbox/>
   </f:entry>
 
-  <f:entry title="${%# of executors}" field="numExecutors">
-    <f:textbox />
+  <f:entry field="value" title="${%Value}">
+    <f:textbox/>
   </f:entry>
 
-  <f:entry title="${%Remote FS root}" field="remoteFs">
-    <f:textbox />
-  </f:entry>
-
-  <f:entry title="${%Labels}" field="labelString">
-    <f:textbox />
-  </f:entry>
-
-  <f:slave-mode name="mode" node="${it}" />
-
-  <f:descriptorList title="${%Node Properties}" descriptors="${h.getNodePropertyDescriptors(descriptor.clazz)}" field="nodeProperties" />
 </j:jelly>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerEnvVar/help-key.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerEnvVar/help-key.html
@@ -1,0 +1,1 @@
+The environment variable key.

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerEnvVar/help-value.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerEnvVar/help-value.html
@@ -1,0 +1,1 @@
+The environment variable value.

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/config.jelly
@@ -53,6 +53,10 @@ THE SOFTWARE.
     <f:textbox/>
   </f:entry>
 
+  <f:entry field="ttyEnabled" title="${%Allocate pseudo-TTY}">
+    <f:checkbox/>
+  </f:entry>
+
   <f:entry field="instanceCapStr" title="${%Max number of instances}">
     <f:textbox/>
   </f:entry>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/config.jelly
@@ -46,15 +46,15 @@ THE SOFTWARE.
   </f:entry>
 
   <f:entry field="command" title="${%Command to run slave agent}">
-    <f:textbox/>
+    <f:textbox default="/bin/sh -c"/>
   </f:entry>
 
   <f:entry field="args" title="${%Arguments to pass to the command}">
-    <f:textbox/>
+    <f:textbox default="cat"/>
   </f:entry>
 
   <f:entry field="ttyEnabled" title="${%Allocate pseudo-TTY}">
-    <f:checkbox/>
+    <f:checkbox default="true"/>
   </f:entry>
 
   <f:entry field="instanceCapStr" title="${%Max number of instances}">

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/config.jelly
@@ -33,20 +33,6 @@ THE SOFTWARE.
     <f:textbox/>
   </f:entry>
 
-  <f:entry field="label" title="${%Labels}">
-    <f:textbox/>
-  </f:entry>
-
-  <f:entry title="${%Containers}" description="${%List of container in the slave pod}">
-      <f:repeatableHeteroProperty field="containers" hasHeader="true" addCaption="Add Container"
-                                    deleteCaption="Delete Container" />
-  </f:entry>
-
-  <f:entry title="${%Volumes}" description="${%List of volumes to mount in slave pod}">
-    <f:repeatableHeteroProperty field="volumes" hasHeader="true" addCaption="Add Volume"
-                                deleteCaption="Delete Volume" />
-  </f:entry>
-
   <f:entry field="image" title="${%Docker image}">
     <f:textbox/>
   </f:entry>
@@ -55,7 +41,7 @@ THE SOFTWARE.
     <f:checkbox/>
   </f:entry>
 
-  <f:entry field="remoteFs" title="${%Jenkins slave root directory}">
+  <f:entry field="workingDir" title="${%Working directory}">
     <f:textbox default="/home/jenkins"/>
   </f:entry>
 
@@ -79,15 +65,6 @@ THE SOFTWARE.
   <f:advanced>
     <f:entry field="privileged" title="${%Run in privileged mode}">
       <f:checkbox/>
-    </f:entry>
-
-    <f:entry field="serviceAccount" title="${%Service Account}">
-          <f:textbox/>
-     </f:entry>
-
-
-    <f:entry field="nodeSelector" title="${%Node Selector}">
-      <f:textbox/>
     </f:entry>
 
     <f:entry field="resourceRequestCpu" title="${%Request CPU}">

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/help-args.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/help-args.html
@@ -1,0 +1,1 @@
+Arguments to pass to the command. The slave secret and name are always added to the arguments. 

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/help-command.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/help-command.html
@@ -1,0 +1,1 @@
+Override the image entrypoint with a different one

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/help-image.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/help-image.html
@@ -1,0 +1,5 @@
+Docker image ID for a jenkins JNLP slave.
+This image is responsible to run a jenkins jnlp bootstrap agent and connect to Jenkins master.
+Secret key and slave name as well as jenkins callback URL are passed as argument as expected
+by <code>hudson.remoting.jnlp.Main</code>.
+

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/help-remoteFs.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/help-remoteFs.html
@@ -1,0 +1,2 @@
+Path to the root of the workspace from the view point of this node, such as "/var/jenkins_home", this need not
+be absolute provided that the launcher establishes a consistent working directory, such as "./.jenkins-slave".

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/help-resourceLimitCpu.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/help-resourceLimitCpu.html
@@ -1,0 +1,6 @@
+Kubernetes Resources Limit of CPU
+This value can be set to control the CPU resource limit passed when creating the jenkins slave docker container in
+Kubernetes. Unlike a resource request, this is the upper limit of resources used by your Jenkins Slave container.
+When left blank, the defaults of your Kubernetes cluster will be used. For more info, see the
+<a href="http://kubernetes.io/docs/user-guide/compute-resources/">Kubernetes docs.</a>
+e.g. `500m`.

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/help-resourceLimitMemory.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/help-resourceLimitMemory.html
@@ -1,0 +1,6 @@
+Kubernetes Resources Limit of Memory
+This value can be set to control the memory resource limit passed when creating the jenkins slave docker container in
+Kubernetes. Unlike a resource request, this is the upper limit of resources used by your Jenkins Slave container.
+When left blank, the defaults of your Kubernetes cluster will be used. For more info, see the
+<a href="http://kubernetes.io/docs/user-guide/compute-resources/">Kubernetes docs.</a>
+e.g. `250Mi`.

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/help-resourceRequestCpu.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/help-resourceRequestCpu.html
@@ -1,0 +1,5 @@
+Kubernetes Resources Request of CPU
+This value can be set to control the CPU resources requested when creating the jenkins slave docker container in
+Kubernetes. When left blank, the defaults of your Kubernetes cluster will be used. For more info, see the
+<a href="http://kubernetes.io/docs/user-guide/compute-resources/">Kubernetes docs.</a>
+e.g. `500m`.

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/help-resourceRequestMemory.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/help-resourceRequestMemory.html
@@ -1,0 +1,5 @@
+Kubernetes Resources Request of Memory
+This value can be set to control the memory resources requested when creating the jenkins slave docker container in
+Kubernetes. When left blank, the defaults of your Kubernetes cluster will be used. For more info, see the
+<a href="http://kubernetes.io/docs/user-guide/compute-resources/">Kubernetes docs.</a>
+e.g. `250Mi`.

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/help-serviceAccount.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/help-serviceAccount.html
@@ -1,0 +1,1 @@
+The service account to use.

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerStep/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerStep/config.jelly
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry field="pod" title="The name of the pod to use">
+		<f:textbox/>
+	</f:entry>
+	<f:entry field="name" title="The name of the container to select">
+		<f:textbox/>
+	</f:entry>
+</j:jelly>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerStep/help.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerStep/help.html
@@ -1,0 +1,3 @@
+<div>
+    Selects a container of the slave pod so that all shell steps are executed in that container.
+</div>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep/config.jelly
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry field="cloud" title="The cloud to use">
+      <f:textbox default="kubernetes"/>
+    </f:entry>
+    <f:entry field="inheritFrom" title="The name of the pod inheritFrom to use">
+      <f:textbox/>
+    </f:entry>
+	<f:entry field="name" title="The name of the template">
+	  <f:textbox/>
+	</f:entry>
+	<f:entry field="label" title="The label">
+      <f:textbox/>
+    </f:entry>
+
+  <f:entry title="${%Containers}" description="${%List of container in the slave pod}">
+      <f:repeatableHeteroProperty field="containers" hasHeader="true" addCaption="Add Container"
+                                    deleteCaption="Delete Container" />
+  </f:entry>
+
+  <f:entry title="${%Volumes}" description="${%List of volumes to mount in slave pod}">
+    <f:repeatableHeteroProperty field="volumes" hasHeader="true" addCaption="Add Volume"
+                                deleteCaption="Delete Volume" />
+  </f:entry>
+
+	<f:advanced>
+		<f:entry field="serviceAccount" title="The service account">
+          <f:textbox/>
+        </f:entry>
+        <f:entry field="nodeSelector" title="The node selector">
+          <f:textbox/>
+        </f:entry>
+        <f:entry field="workingDir" title="${%Working directory}">
+          <f:textbox default="/home/jenkins"/>
+        </f:entry>
+	</f:advanced>
+</j:jelly>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep/help-emptyDirs.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep/help-emptyDirs.html
@@ -1,0 +1,17 @@
+The <!--
+  ~ Copyright (C) 2015 Original Authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~         http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+The list of empty dir mounts. These mounts are passed in the form of key/value pairs, where key represents the mount pathvalue the medium.

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep/help-env.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep/help-env.html
@@ -1,0 +1,17 @@
+The <!--
+  ~ Copyright (C) 2015 Original Authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~         http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+The environment variables to pass to the container.

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep/help-hostPathMounts.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep/help-hostPathMounts.html
@@ -1,0 +1,18 @@
+The <!--
+  ~ Copyright (C) 2015 Original Authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~         http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+The list of host path mounts. These mounts are passed in the form of key/value pairs, where key represents the host path and value
+the mount path.

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep/help-image.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep/help-image.html
@@ -1,0 +1,17 @@
+The <!--
+  ~ Copyright (C) 2015 Original Authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~         http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+The container image.

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep/help-name.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep/help-name.html
@@ -1,0 +1,17 @@
+The <!--
+  ~ Copyright (C) 2015 Original Authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~         http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+The name prefix of the pod.

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep/help-privileged.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep/help-privileged.html
@@ -1,0 +1,17 @@
+The <!--
+  ~ Copyright (C) 2015 Original Authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~         http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+Flag to mark the container as privileged.

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep/help-secrets.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep/help-secrets.html
@@ -1,0 +1,18 @@
+The <!--
+  ~ Copyright (C) 2015 Original Authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~         http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+The list of secrets. Secrets are passed in the form of key/value pairs, where key represents the secret name and value
+the mount path.

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep/help-serviceAccount.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep/help-serviceAccount.html
@@ -1,0 +1,17 @@
+The <!--
+  ~ Copyright (C) 2015 Original Authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~         http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+The service account of the pod.

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep/help.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep/help.html
@@ -1,0 +1,3 @@
+<div>
+    Defines a container inside the kubernetes plugin configuration
+</div>

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlaveTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlaveTest.java
@@ -42,13 +42,14 @@ public class KubernetesSlaveTest {
     @Test
     public void testGetSlaveName() {
         List<? extends PodVolume> volumes = Collections.emptyList();
+        List<ContainerTemplate> containers = Collections.emptyList();
 
-        PodTemplate template = new PodTemplate("image", volumes);
+        PodTemplate template = new PodTemplate("image", volumes, containers);
         String name = KubernetesSlave.getSlaveName(template);
         assertNotNull(name);
         assertTrue("Name does not match regex: '" + name + "'", name.matches("^[0-9a-f]{12,}$"));
-        assertTrue(KubernetesSlave.getSlaveName(new PodTemplate("", "image", volumes)).matches("^[0-9a-f]{12,}$"));
-        assertTrue(KubernetesSlave.getSlaveName(new PodTemplate("a name", "image", volumes))
+        assertTrue(KubernetesSlave.getSlaveName(new PodTemplate("", "image", volumes, containers)).matches("^[0-9a-f]{12,}$"));
+        assertTrue(KubernetesSlave.getSlaveName(new PodTemplate("a name", "image", volumes, containers))
                 .matches("^a-name-[0-9a-f]{12,}$"));
     }
 

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlaveTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlaveTest.java
@@ -47,10 +47,10 @@ public class KubernetesSlaveTest {
         PodTemplate template = new PodTemplate("image", volumes, containers);
         String name = KubernetesSlave.getSlaveName(template);
         assertNotNull(name);
-        assertTrue("Name does not match regex: '" + name + "'", name.matches("^[0-9a-f]{12,}$"));
-        assertTrue(KubernetesSlave.getSlaveName(new PodTemplate("", "image", volumes, containers)).matches("^[0-9a-f]{12,}$"));
+        assertTrue("Name does not match regex: '" + name + "'", name.matches("^[0-9a-f]{10,}$"));
+        assertTrue(KubernetesSlave.getSlaveName(new PodTemplate("", "image", volumes, containers)).matches("^[0-9a-f]{10,}$"));
         assertTrue(KubernetesSlave.getSlaveName(new PodTemplate("a name", "image", volumes, containers))
-                .matches("^a-name-[0-9a-f]{12,}$"));
+                .matches("^a-name-[0-9a-f]{10,}$"));
     }
 
 }


### PR DESCRIPTION
Using multiple containers inside a pod, opens the way to some very interesting possibilities, like using sidecar containers etc. 

So for example we could create a pod that consists of a jnlp container, plus a container with the build tool of our choice.  

My intention is to use this feature as a base and add pipeline capabilities on top of that for executing shell commands in the container of our choice etc.