### PR TITLE
Improve slave startup time

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -398,12 +398,11 @@ public class KubernetesCloud extends Cloud {
                 ImmutableList<String> validStates = ImmutableList.of("Running");
 
                 int i = 0;
-                int j = 100; // wait 600 seconds
+                int j = 600; // wait 600 seconds
 
                 // wait for Pod to be running
                 for (; i < j; i++) {
                     LOGGER.log(Level.INFO, "Waiting for Pod to be scheduled ({1}/{2}): {0}", new Object[] {podId, i, j});
-                    Thread.sleep(6000);
                     pod = connect().pods().inNamespace(namespace).withName(podId).get();
                     if (pod == null) {
                         throw new IllegalStateException("Pod no longer exists: " + podId);
@@ -424,6 +423,8 @@ public class KubernetesCloud extends Cloud {
                     if (validStates.contains(pod.getStatus().getPhase())) {
                         break;
                     }
+
+                    Thread.sleep(1000);
                 }
                 String status = pod.getStatus().getPhase();
                 if (!validStates.contains(status)) {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
@@ -5,8 +5,8 @@ import java.util.Collections;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import hudson.slaves.*;
 import org.apache.commons.lang.StringUtils;
-import org.jenkinsci.plugins.durabletask.executors.OnceRetentionStrategy;
 import org.jvnet.localizer.Localizable;
 import org.jvnet.localizer.ResourceBundleHolder;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -16,10 +16,6 @@ import hudson.model.Descriptor;
 import hudson.model.Label;
 import hudson.model.Node;
 import hudson.model.TaskListener;
-import hudson.slaves.AbstractCloudSlave;
-import hudson.slaves.JNLPLauncher;
-import hudson.slaves.NodeProperty;
-import hudson.slaves.OfflineCause;
 
 /**
  * @author Carlos Sanchez carlos@apache.org
@@ -49,7 +45,7 @@ public class KubernetesSlave extends AbstractCloudSlave {
                 Node.Mode.NORMAL,
                 label == null ? null : label.toString(),
                 new JNLPLauncher(),
-                new OnceRetentionStrategy(cloud.getRetentionTimeout()),
+                new CloudRetentionStrategy(cloud.getRetentionTimeout()),
                 Collections.<NodeProperty<Node>> emptyList());
 
         // this.pod = pod;


### PR DESCRIPTION
Before I spend more time on this (cleaning up the gui, etc.), I wanted to see what you guys think of my changes.

We were having problems with the kubernetes plugin as-is - even with large queues, and plenty of capacity, it would take 30-60s+ to spin up slaves, and it would do so very slow (one slave at a time). After some research, I made a few tweaks to the plugin that significantly improved the experience. They are in this PR.

1. Keep slaves idle for a bit (using the retention timeout, aka
'Container Cleanup Timeout' in the Jenkins UI). Having one shot slaves
destroys the effectiveness of the Jenkins cloud algorithm to maintain a
stable state, introducing significant delays in slave startup.

2. Remove the 6 second sleep in KubernetesCloud that always occurred when spinning up a
slave.

New slaves now spin up within seconds to handle load, and then spin down nicely again when idle.