### PR TITLE
Remove unused field from ContainerTemplate.

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
@@ -33,8 +33,6 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
 
     private boolean ttyEnabled;
 
-    private int instanceCap;
-
     private String resourceRequestCpu;
 
     private String resourceRequestMemory;
@@ -112,31 +110,6 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
 
     public String getWorkingDir() {
         return workingDir;
-    }
-
-    public void setInstanceCap(int instanceCap) {
-        this.instanceCap = instanceCap;
-    }
-
-    public int getInstanceCap() {
-        return instanceCap;
-    }
-
-    @DataBoundSetter
-    public void setInstanceCapStr(String instanceCapStr) {
-        if ("".equals(instanceCapStr)) {
-            setInstanceCap(Integer.MAX_VALUE);
-        } else {
-            setInstanceCap(Integer.parseInt(instanceCapStr));
-        }
-    }
-
-    public String getInstanceCapStr() {
-        if (getInstanceCap() == Integer.MAX_VALUE) {
-            return "";
-        } else {
-            return String.valueOf(instanceCap);
-        }
     }
 
     @DataBoundSetter

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/config.jelly
@@ -34,10 +34,6 @@
     <f:checkbox default="true"/>
   </f:entry>
 
-  <f:entry field="instanceCapStr" title="${%Max number of instances}">
-    <f:textbox/>
-  </f:entry>
-
     <f:entry title="${%EnvVars}" description="${%List of environment variables to set in slave pod}">
       <f:repeatableHeteroProperty field="envVars" hasHeader="true" addCaption="Add Environment Variable"
                                   deleteCaption="Delete Environment Variable" />


### PR DESCRIPTION
This remove instanceCap from ContainerTemplate. The field shouldn't be there in the first place. It was copied/pasted from PodTemplate by mistake.