### PR TITLE
allow setting dynamic pod volumes in pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,13 @@ podTemplate(label: 'mypod', containers: [
         ]
     ),
     ...
+],
+volumes: [
+    emptyDirVolume(mountPath: '/etc/mount', memory: false),
+    secretVolume(mountPath: '/etc/mount', secretName: 'my-secret'),
+    configMapVolume(mountPath: '/etc/mount', configMapName: 'my-config'),
+    hostPathVolume(mountPath: '/etc/mount', hostPath: '/mnt/my-mount'),
+    nfsVolume(mountPath: '/etc/mount', serverAddress: '127.0.0.1', serverPath: '/', readOnly: true)
 ]) {
    ...
 }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodVolumes.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodVolumes.java
@@ -3,6 +3,7 @@ package org.csanchez.jenkins.plugins.kubernetes;
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
+import org.jenkinsci.Symbol;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeBuilder;
 import io.fabric8.kubernetes.api.model.VolumeMount;
@@ -54,6 +55,7 @@ public class PodVolumes {
         }
 
         @Extension
+        @Symbol("emptyDirVolume")
         public static class DescriptorImpl extends Descriptor<PodVolume> {
             @Override
             public String getDisplayName() {
@@ -91,6 +93,7 @@ public class PodVolumes {
         }
 
         @Extension
+        @Symbol("secretVolume")
         public static class DescriptorImpl extends Descriptor<PodVolume> {
             @Override
             public String getDisplayName() {
@@ -130,6 +133,7 @@ public class PodVolumes {
         }
 
         @Extension
+        @Symbol("configMapVolume")
         public static class DescriptorImpl extends Descriptor<PodVolume> {
             @Override
             public String getDisplayName() {
@@ -164,6 +168,7 @@ public class PodVolumes {
         }
 
         @Extension
+        @Symbol("hostPathVolume")
         public static class DescriptorImpl extends Descriptor<PodVolume> {
             @Override
             public String getDisplayName() {
@@ -210,6 +215,7 @@ public class PodVolumes {
         }
 
         @Extension
+        @Symbol("nfsVolume")
         public static class DescriptorImpl extends Descriptor<PodVolume> {
             @Override
             public String getDisplayName() {
@@ -255,6 +261,7 @@ public class PodVolumes {
         }
 
         @Extension
+        @Symbol("pvcVolume")
         public static class DescriptorImpl extends Descriptor<PodVolume> {
             @Override
             public String getDisplayName() {

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
@@ -115,7 +115,7 @@ public class KubernetesPipelineTest {
 
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("" //
-                + "podTemplate(label: 'mypod', containers: [\n" //
+                + "podTemplate(label: 'mypod', volumes: [emptyDirVolume(mountPath: '/my-mount')], containers: [\n" //
                 + "        containerTemplate(name: 'jnlp', image: 'jenkinsci/jnlp-slave:2.62-alpine', args: '${computer.jnlpmac} ${computer.name}'),\n" //
                 + "        containerTemplate(name: 'maven', image: 'maven:3.3.9-jdk-8-alpine', ttyEnabled: true, command: 'cat'),\n" //
                 + "        containerTemplate(name: 'golang', image: 'golang:1.6.3-alpine', ttyEnabled: true, command: 'cat')\n" //
@@ -123,6 +123,7 @@ public class KubernetesPipelineTest {
                 + "\n" //
                 + "    node ('mypod') {\n" //
                 + "    sh \"echo My Kubernetes Pipeline\" \n" //
+                + "    sh \"ls /\" \n" //
                 // + " stage 'Get a Maven project'\n" //
                 // + " git 'https://github.com/jenkinsci/kubernetes-plugin.git'\n" //
                 // + " container('maven') {\n" //
@@ -148,6 +149,7 @@ public class KubernetesPipelineTest {
         assertNotNull(b);
         r.assertBuildStatusSuccess(r.waitForCompletion(b));
         r.assertLogContains("My Kubernetes Pipeline", b);
+        r.assertLogContains("my-mount", b);
     }
 
     // @Test


### PR DESCRIPTION
As the title says, this allows you to do something like this:

```groovy
volumes = [secretVolume(secretName: 'shared-secrets', mountPath: '/etc/shared-secrets')]
podTemplate(label: 'runner', containers: [], volumes: volumes) {
  // ...
}
```

Added documentation and tests (didn't run the tests locally though). Tested this on our local Jenkins installation.

Solves my problem mentioned in https://github.com/jenkinsci/kubernetes-plugin/pull/77.