### PR TITLE
Fix nodeSelector in podTemplate

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
@@ -62,6 +62,7 @@ public class PodTemplateStepExecution extends AbstractStepExecutionImpl {
 
             newTemplate.setLabel(step.getLabel());
             newTemplate.setName(name);
+            newTemplate.setNodeSelector(step.getNodeSelector());
 
             kubernetesCloud.addTemplate(newTemplate);
             getContext().newBodyInvoker()


### PR DESCRIPTION
When creating a podTemplate via pipeline nodeSelector wasn't being used.
