### PR TITLE
Improve the inheritFrom functionality to better cover containers and volumes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,29 @@ The jnlp agent image used can be customized by adding it to the template
 containerTemplate(name: 'jnlp', image: 'jenkinsci/jnlp-slave:2.62-alpine', args: '${computer.jnlpmac} ${computer.name}'),
 ```
 
+### Pod and container template configuration
+
+The `podTemplate` is a template of a pod that will be used to create slaves. It can be either configured via the user interface, or via pipeline. 
+Either way it provides access to the following fields:
+
+* **name** The name of the pod.
+* **label** The label of the pod.
+* **container** The container templates that are use to create the containers of the pod *(see below)*.
+* **serviceAccount** The service account of the pod.
+* **nodeSelector** The node selector of the pod.
+* **volumes** Volumes that are defined for the pod and are mounted by **ALL** containers.
+* **envVars*** Environment variables that are applied to **ALL** containers. 
+* **inheritFrom** List of one or more pod templates to inherit from *(more details below)*.
+
+The `containerTemplate` is a template of container that will be added to the pod. Again, its configurable via the user interface or via pipeline and allows you to set the following fields:
+
+* **name** The name of the container.
+* **image** The image of the container.
+* **envVars** Environment variables that are applied to the container **(supplementing and overriding env vars that are set on pod level)**.
+* **command** The command the container will execute.
+* **args** The arugments passed to the command.
+* **ttyEnabled** Flag to mark that tty should be enabled.
+
 ### Pod template inheritance 
 
 A podTemplate may or may not inherit from an existing template. This means that the podTemplate will inherit node selector, service account, image pull secrets, containerTemplates and volumes from the template it inheritsFrom.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ The jnlp agent image used can be customized by adding it to the template
 containerTemplate(name: 'jnlp', image: 'jenkinsci/jnlp-slave:2.62-alpine', args: '${computer.jnlpmac} ${computer.name}'),
 ```
 
+### Pod template inheritance 
+
 A podTemplate may or may not inherit from an existing template. This means that the podTemplate will inherit node selector, service account, image pull secrets, containerTemplates and volumes from the template it inheritsFrom.
 
 **Service account** and **Node selector** when are overridden completely substitute any possible value found on the 'parent'. 
@@ -85,6 +87,11 @@ podTemplate(label: 'anotherpod', inheritFrom: 'mypod'  containers: [
 
 Note that we only need to specify the things that are different. So, `ttyEnabled` and `command` are not specified, as they are inherited. Also the `golang` container will be added as is defined in the 'parent' template. 
 
+#### Multiple Pod template inheritance
+
+Field `inheritFrom` may refer a single podTemplate or multiple separated by space. In the later case each template will be processed in the order they appear in the list *(later items overriding earlier ones)*.
+In any case if the referenced template is not found it will be ignored.
+ 
 
 ## Container Configuration
 When configuring a container in a pipeline podTemplate the following options are available:

--- a/README.md
+++ b/README.md
@@ -61,6 +61,31 @@ The jnlp agent image used can be customized by adding it to the template
 containerTemplate(name: 'jnlp', image: 'jenkinsci/jnlp-slave:2.62-alpine', args: '${computer.jnlpmac} ${computer.name}'),
 ```
 
+A podTemplate may or may not inherit from an existing template. This means that the podTemplate will inherit node selector, service account, image pull secrets, containerTemplates and volumes from the template it inheritsFrom.
+
+**Service account** and **Node selector** when are overridden completely substitute any possible value found on the 'parent'. 
+
+**Container templates** that are added to the podTemplate, that has a matching containerTemplate (a containerTemplate with the same name) in the 'parent' template, will inherit the configuration of the parent containerTemplate.
+If no matching containerTemplate is found, the template is added as is.
+
+**Volume** inheritance works exactly as **Container templates**.
+
+**Image Pull Secrets** are combined (all secrets defined both on 'parent' and 'current' template are used).
+
+In the example below, we will inherit the podTemplate we created previously, and will just override the version of 'maven' so that it uses jdk-7 instead:
+
+```groovy
+podTemplate(label: 'anotherpod', inheritFrom: 'mypod'  containers: [
+    containerTemplate(name: 'maven', image: 'maven:3.3.9-jdk-7-alpine')    
+  ]) {
+      
+      //Let's not repeat ourselves and ommit this part
+}
+```
+
+Note that we only need to specify the things that are different. So, `ttyEnabled` and `command` are not specified, as they are inherited. Also the `golang` container will be added as is defined in the 'parent' template. 
+
+
 ## Container Configuration
 When configuring a container in a pipeline podTemplate the following options are available:
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
     <jackson.version>2.5.0</jackson.version>
     <spring.version>3.2.14.RELEASE</spring.version>
     <jenkins.version>2.7.4</jenkins.version>
+    <powermock.version>1.6.5</powermock.version>
   </properties>
 
   <dependencies>
@@ -88,6 +89,20 @@
       <artifactId>workflow-durable-task-step</artifactId>
       <version>2.4</version>
     </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-job</artifactId>
@@ -106,6 +121,7 @@
       <version>2.3</version>
       <classifier>tests</classifier>
       <scope>test</scope>
+
     </dependency>
     <dependency> <!-- SemaphoreStep -->
       <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
@@ -21,9 +21,9 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
 
     private String image;
 
-    private boolean privileged;
+    private Boolean privileged;
 
-    private boolean alwaysPullImage;
+    private Boolean alwaysPullImage;
 
     private String workingDir = DEFAULT_WORKING_DIR;
 
@@ -31,7 +31,7 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
 
     private String args;
 
-    private boolean ttyEnabled;
+    private Boolean ttyEnabled;
 
     private String resourceRequestCpu;
 
@@ -52,6 +52,14 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
         Preconditions.checkArgument(!StringUtils.isBlank(image));
         this.name = name;
         this.image = image;
+    }
+
+    ContainerTemplate(String name, String image, String command, String args) {
+        Preconditions.checkArgument(!StringUtils.isBlank(image));
+        this.name = name;
+        this.image = image;
+        this.command = command;
+        this.args = args;
     }
 
     @DataBoundSetter
@@ -91,11 +99,11 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
     }
 
     @DataBoundSetter
-    public void setTtyEnabled(boolean ttyEnabled) {
+    public void setTtyEnabled(Boolean ttyEnabled) {
         this.ttyEnabled = ttyEnabled;
     }
 
-    public boolean isTtyEnabled() {
+    public Boolean isTtyEnabled() {
         return ttyEnabled;
     }
 
@@ -113,20 +121,20 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
     }
 
     @DataBoundSetter
-    public void setPrivileged(boolean privileged) {
+    public void setPrivileged(Boolean privileged) {
         this.privileged = privileged;
     }
 
-    public boolean isPrivileged() {
+    public Boolean isPrivileged() {
         return privileged;
     }
 
     @DataBoundSetter
-    public void setAlwaysPullImage(boolean alwaysPullImage) {
+    public void setAlwaysPullImage(Boolean alwaysPullImage) {
         this.alwaysPullImage = alwaysPullImage;
     }
 
-    public boolean isAlwaysPullImage() {
+    public Boolean isAlwaysPullImage() {
         return alwaysPullImage;
     }
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodEnvVar.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodEnvVar.java
@@ -7,6 +7,7 @@ import hudson.model.Descriptor;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -39,6 +40,42 @@ public class PodEnvVar extends AbstractDescribableImpl<PodEnvVar> {
         this.value = value;
     }
 
+    public String toString() {
+        return String.format("%s=%s", key, value);
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((key == null) ? 0 : key.hashCode());
+        result = prime * result + ((value == null) ? 0 : value.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        PodEnvVar other = (PodEnvVar) obj;
+        if (key == null) {
+            if (other.key != null)
+                return false;
+        } else if (!key.equals(other.key))
+            return false;
+        if (value == null) {
+            if (other.value != null)
+                return false;
+        } else if (!value.equals(other.value))
+            return false;
+        return true;
+    }
+
+
     static List<ContainerEnvVar> asContainerEnvVar(List<PodEnvVar> list) {
         return list.stream().map((var) -> new ContainerEnvVar(var.getKey(), var.getValue()))
                 .collect(Collectors.toList());
@@ -49,6 +86,7 @@ public class PodEnvVar extends AbstractDescribableImpl<PodEnvVar> {
     }
 
     @Extension
+    @Symbol("podEnvVar")
     public static class DescriptorImpl extends Descriptor<PodEnvVar> {
         @Override
         public String getDisplayName() {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodEnvVar.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodEnvVar.java
@@ -4,15 +4,13 @@ import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import org.kohsuke.stapler.DataBoundConstructor;
 
-@Deprecated
 /**
- * @deprecated Use ContainerEnvVar instead. This will be removed in future versions
+ * Environment variables that are meant to be applied to all containers.
  */
 public class PodEnvVar extends AbstractDescribableImpl<PodEnvVar> {
 
@@ -54,7 +52,7 @@ public class PodEnvVar extends AbstractDescribableImpl<PodEnvVar> {
     public static class DescriptorImpl extends Descriptor<PodEnvVar> {
         @Override
         public String getDisplayName() {
-            return "Container Environment Variable";
+            return "Global Environment Variable (applied to all containers)";
         }
     }
 }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodImagePullSecret.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodImagePullSecret.java
@@ -22,6 +22,23 @@ public class PodImagePullSecret extends AbstractDescribableImpl<PodImagePullSecr
         this.name = name;
     }
 
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        PodImagePullSecret that = (PodImagePullSecret) o;
+
+        return name != null ? name.equals(that.name) : that.name == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        return name != null ? name.hashCode() : 0;
+    }
+
     @Extension
     public static class DescriptorImpl extends Descriptor<PodImagePullSecret> {
         @Override

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -33,6 +33,8 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> {
 
     private static final String FALLBACK_ARGUMENTS = "${computer.jnlpmac} ${computer.name}";
 
+    private String inheritFrom;
+
     private String name;
 
     private transient String image;
@@ -87,6 +89,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> {
         this.setInstanceCap(from.getInstanceCap());
         this.setLabel(from.getLabel());
         this.setName(from.getName());
+        this.setInheritFrom(from.getInheritFrom());
         this.setNodeSelector(from.getNodeSelector());
         this.setServiceAccount(from.getServiceAccount());
         this.setVolumes(from.getVolumes());
@@ -114,6 +117,15 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> {
 
     private Optional<ContainerTemplate> getFirstContainer() {
         return Optional.ofNullable(getContainers().isEmpty() ? null : getContainers().get(0));
+    }
+
+    public String getInheritFrom() {
+        return inheritFrom;
+    }
+
+    @DataBoundSetter
+    public void setInheritFrom(String inheritFrom) {
+        this.inheritFrom = inheritFrom;
     }
 
     @DataBoundSetter

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -69,8 +69,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> {
 
     private List<ContainerTemplate> containers = new ArrayList<ContainerTemplate>();
 
-    @SuppressWarnings("deprecation")
-    private transient final List<PodEnvVar> envVars = new ArrayList<PodEnvVar>();
+    private final List<PodEnvVar> envVars = new ArrayList<PodEnvVar>();
 
     private final List<PodAnnotation> annotations = new ArrayList<PodAnnotation>();
 
@@ -257,18 +256,18 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> {
         return getFirstContainer().map(ContainerTemplate::isAlwaysPullImage).orElse(false);
     }
 
-    @Deprecated
-    @SuppressWarnings("deprecation")
     public List<PodEnvVar> getEnvVars() {
-        return getFirstContainer().map((i) -> PodEnvVar.fromContainerEnvVar(i.getEnvVars()))
-                .orElse(Collections.emptyList());
+        if (envVars == null) {
+            return Collections.emptyList();
+        }
+        return envVars;
     }
 
-    @Deprecated
-    @SuppressWarnings("deprecation")
     @DataBoundSetter
     public void setEnvVars(List<PodEnvVar> envVars) {
-        getFirstContainer().ifPresent((i) -> i.setEnvVars(PodEnvVar.asContainerEnvVar(envVars)));
+        if (envVars != null) {
+            this.envVars.addAll(envVars);
+        }
     }
 
     public List<PodAnnotation> getAnnotations() {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -272,6 +272,9 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> {
     }
 
     public List<PodAnnotation> getAnnotations() {
+        if (annotations == null) {
+            return Collections.emptyList();
+        }
         return annotations;
     }
 
@@ -281,6 +284,9 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> {
     }
 
     public List<PodImagePullSecret> getImagePullSecrets() {
+        if (imagePullSecrets == null) {
+            return Collections.emptyList();
+        }
         return imagePullSecrets;
     }
 
@@ -356,6 +362,9 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> {
 
     @Nonnull
     public List<PodVolume> getVolumes() {
+        if (volumes == null) {
+            return Collections.emptyList();
+        }
         return volumes;
     }
 
@@ -369,6 +378,9 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> {
 
     @Nonnull
     public List<ContainerTemplate> getContainers() {
+        if (containers == null) {
+            return Collections.emptyList();
+        }
         return containers;
     }
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
@@ -12,6 +12,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
 import hudson.model.Label;
@@ -103,6 +104,11 @@ public class PodTemplateUtils {
         Map<String, PodVolume> combinedVolumes = new HashMap<>();
 
         //Containers
+        Map<String, String> combinedEnvVars = new HashMap<>();
+        combinedEnvVars.putAll(parent.getEnvVars().stream().collect(Collectors.toMap(e -> e.getKey(),e -> e.getValue())));
+        combinedEnvVars.putAll(template.getEnvVars().stream().collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue())));
+
+        //Containers
         Map<String, ContainerTemplate> parentContainers = parent.getContainers().stream().collect(Collectors.toMap(c -> c.getName(), c -> c));
         combinedContainers.putAll(parentContainers);
         combinedContainers.putAll(template.getContainers().stream().collect(Collectors.toMap(c -> c.getName(), c -> combine(parentContainers.get(c.getName()), c))));
@@ -122,6 +128,7 @@ public class PodTemplateUtils {
         podTemplate.setLabel(label);
         podTemplate.setNodeSelector(nodeSelector);
         podTemplate.setServiceAccount(serviceAccount);
+        podTemplate.setEnvVars(combinedEnvVars.entrySet().stream().map(e -> new PodEnvVar(e.getKey(), e.getValue())).collect(Collectors.toList()));
         podTemplate.setContainers(new ArrayList<>(combinedContainers.values()));
         podTemplate.setVolumes(new ArrayList<>(combinedVolumes.values()));
         podTemplate.setImagePullSecrets(new ArrayList<>(imagePullSecrets));

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
@@ -1,0 +1,165 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+
+import org.csanchez.jenkins.plugins.kubernetes.volumes.PodVolume;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import hudson.model.Label;
+import hudson.tools.ToolLocationNodeProperty;
+
+import static org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate.DEFAULT_WORKING_DIR;
+
+public class PodTemplateUtils {
+
+    /**
+     * Combines a {@link ContainerTemplate} with its parent.
+     * @param parent        The parent container template (nullable).
+     * @param template      The actual container template
+     * @return              The combined container template.
+     */
+    public static ContainerTemplate combine(ContainerTemplate parent, ContainerTemplate template) {
+        Preconditions.checkNotNull(template, "Container template should not be null");
+        if (parent == null) {
+            return template;
+        }
+
+        String name = template.getName();
+        String image = Strings.isNullOrEmpty(template.getImage()) ? parent.getImage() : template.getImage();
+        Boolean privileged = template.isPrivileged() != null ? template.isPrivileged() : (parent.isPrivileged() != null ? parent.isPrivileged() : false);
+        Boolean alwaysPullImage = template.isAlwaysPullImage() != null ? template.isAlwaysPullImage() : (parent.isAlwaysPullImage() != null ? parent.isAlwaysPullImage() : false);
+        String workingDir = Strings.isNullOrEmpty(template.getWorkingDir()) ? (Strings.isNullOrEmpty(parent.getWorkingDir()) ? DEFAULT_WORKING_DIR : parent.getWorkingDir()) : template.getCommand();
+        String command = Strings.isNullOrEmpty(template.getCommand()) ? parent.getCommand() : template.getCommand();
+        String args = Strings.isNullOrEmpty(template.getArgs()) ? parent.getArgs() : template.getArgs();
+        Boolean ttyEnabled = template.isTtyEnabled() != null ? template.isTtyEnabled() : (parent.isTtyEnabled() != null ? parent.isTtyEnabled() : false);;
+        String resourceRequestCpu = Strings.isNullOrEmpty(template.getResourceRequestCpu()) ? parent.getResourceRequestCpu() : template.getResourceRequestCpu();
+        String resourceRequestMemory = Strings.isNullOrEmpty(template.getResourceRequestMemory()) ? parent.getResourceRequestMemory() : template.getResourceRequestMemory();
+        String resourceLimitCpu = Strings.isNullOrEmpty(template.getResourceLimitCpu()) ? parent.getResourceLimitCpu() : template.getResourceLimitCpu();
+        String resourceLimitMemory = Strings.isNullOrEmpty(template.getResourceLimitMemory()) ? parent.getResourceLimitMemory() : template.getResourceLimitMemory();
+
+        List<ContainerEnvVar> combinedEnvVars = new ArrayList<ContainerEnvVar>();
+
+        Map<String, String> envVars = new HashMap<>();
+        for (ContainerEnvVar envVar : parent.getEnvVars()) {
+            envVars.put(envVar.getKey(), envVar.getValue());
+        }
+
+        for (ContainerEnvVar envVar : template.getEnvVars()) {
+            envVars.put(envVar.getKey(), envVar.getValue());
+        }
+
+        for (Map.Entry<String, String> e : envVars.entrySet()) {
+            combinedEnvVars.add(new ContainerEnvVar(e.getKey(), e.getValue()));
+        }
+
+        ContainerTemplate combined = new ContainerTemplate(image);
+        combined.setName(name);
+        combined.setImage(image);
+        combined.setAlwaysPullImage(alwaysPullImage);
+        combined.setCommand(command);
+        combined.setArgs(args);
+        combined.setTtyEnabled(ttyEnabled);
+        combined.setResourceLimitCpu(resourceLimitCpu);
+        combined.setResourceLimitMemory(resourceLimitMemory);
+        combined.setResourceRequestCpu(resourceRequestCpu);
+        combined.setResourceRequestMemory(resourceRequestMemory);
+        combined.setWorkingDir(workingDir);
+        combined.setPrivileged(privileged);
+        combined.setEnvVars(combinedEnvVars);
+        return combined;
+    }
+
+    /**
+     * Combines a {@link PodTemplate} with its parent.
+     * @param parent        The parent container template (nullable).
+     * @param template      The actual container template
+     * @return              The combined container template.
+     */
+    public static PodTemplate combine(PodTemplate parent, PodTemplate template) {
+        Preconditions.checkNotNull(template, "Pod template should not be null");
+        if (parent == null) {
+            return template;
+        }
+
+        String name = template.getName();
+        String label = template.getLabel();
+        String nodeSelector = Strings.isNullOrEmpty(template.getNodeSelector()) ? parent.getNodeSelector() : template.getNodeSelector();
+        String serviceAccount = Strings.isNullOrEmpty(template.getServiceAccount()) ? parent.getServiceAccount() : template.getServiceAccount();
+
+        Set<PodImagePullSecret> imagePullSecrets = new LinkedHashSet<>();
+        imagePullSecrets.addAll(parent.getImagePullSecrets());
+        imagePullSecrets.addAll(template.getImagePullSecrets());
+
+        Map<String, ContainerTemplate> combinedContainers = new HashMap<>();
+        Map<String, PodVolume> combinedVolumes = new HashMap<>();
+
+        //Containers
+        Map<String, ContainerTemplate> parentContainers = parent.getContainers().stream().collect(Collectors.toMap(c -> c.getName(), c -> c));
+        combinedContainers.putAll(parentContainers);
+        combinedContainers.putAll(template.getContainers().stream().collect(Collectors.toMap(c -> c.getName(), c -> combine(parentContainers.get(c.getName()), c))));
+
+        //Volumes
+        Map<String, PodVolume> parentVolumes = parent.getVolumes().stream().collect(Collectors.toMap(v -> v.getMountPath(), v -> v));
+        combinedVolumes.putAll(parentVolumes);
+        combinedVolumes.putAll(template.getVolumes().stream().collect(Collectors.toMap(v -> v.getMountPath(), v -> v)));
+
+        //Tool location node properties
+        List<ToolLocationNodeProperty> toolLocationNodeProperties = new ArrayList<>();
+        toolLocationNodeProperties.addAll(parent.getNodeProperties());
+        toolLocationNodeProperties.addAll(template.getNodeProperties());
+
+        PodTemplate podTemplate = new PodTemplate();
+        podTemplate.setName(name);
+        podTemplate.setLabel(label);
+        podTemplate.setNodeSelector(nodeSelector);
+        podTemplate.setServiceAccount(serviceAccount);
+        podTemplate.setContainers(new ArrayList<>(combinedContainers.values()));
+        podTemplate.setVolumes(new ArrayList<>(combinedVolumes.values()));
+        podTemplate.setImagePullSecrets(new ArrayList<>(imagePullSecrets));
+        podTemplate.setNodeProperties(toolLocationNodeProperties);
+        return podTemplate;
+    }
+
+    /**
+     * Unwraps the hierarchy of the PodTemplate.
+     * @param template
+     * @return
+     */
+    static PodTemplate unwrap(PodTemplate template, Collection<PodTemplate> allTemplates) {
+        if (template == null) {
+            return null;
+        }
+
+        if (Strings.isNullOrEmpty(template.getInheritFrom())) {
+            return template;
+        } else {
+            String[] parentLabels = template.getInheritFrom().split("[ ]+");
+            PodTemplate parent = null;
+            for (String label : parentLabels) {
+                PodTemplate next = getTemplate(Label.get(label), allTemplates);
+                if (next != null) {
+                    parent = combine(parent, unwrap(next, allTemplates));
+                }
+            }
+            return combine(parent, template);
+        }
+    }
+
+    public static PodTemplate getTemplate(Label label, Collection<PodTemplate> templates) {
+        for (PodTemplate t : templates) {
+            if (label == null || label.matches(t.getLabelSet())) {
+                return t;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
@@ -1,32 +1,21 @@
 package org.csanchez.jenkins.plugins.kubernetes.pipeline;
 
-import java.util.Collection;
-import java.util.UUID;
-
-import javax.inject.Inject;
-
-import org.apache.commons.lang.StringUtils;
-import org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate;
+import hudson.slaves.Cloud;
+import jenkins.model.Jenkins;
 import org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud;
 import org.csanchez.jenkins.plugins.kubernetes.PodTemplate;
-import org.csanchez.jenkins.plugins.kubernetes.PodVolumes;
-import org.csanchez.jenkins.plugins.kubernetes.volumes.PodVolume;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
 import org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 
-import hudson.model.Label;
-import hudson.slaves.Cloud;
-import jenkins.model.Jenkins;
+import javax.inject.Inject;
+import java.util.UUID;
 
 public class PodTemplateStepExecution extends AbstractStepExecutionImpl {
 
     private static final long serialVersionUID = -6139090518333729333L;
 
     private static final transient String NAME_FORMAT = "kubernetes-%s";
-
-    private static final String DEFAULT_JNLP_IMAGE = System
-            .getProperty(PodTemplateStepExecution.class.getName() + ".defaultImage", "jenkinsci/jnlp-slave:alpine");
 
     @Inject
     private PodTemplateStep step;
@@ -38,30 +27,14 @@ public class PodTemplateStepExecution extends AbstractStepExecutionImpl {
         if (cloud instanceof KubernetesCloud) {
             KubernetesCloud kubernetesCloud = (KubernetesCloud) cloud;
 
-            PodTemplate newTemplate;
             String name = String.format(NAME_FORMAT, UUID.randomUUID().toString().replaceAll("-", ""));
 
-            PodTemplate podTemplate = StringUtils.isBlank(step.getInheritFrom())
-                    ? null
-                    : kubernetesCloud.getTemplate(Label.get(step.getInheritFrom()));
-
-            if (podTemplate != null) {
-                newTemplate = new PodTemplate(podTemplate);
-                newTemplate.getContainers().addAll(getContainersWithDefaults(step));
-                for (PodVolume volume : step.getVolumes()) {
-                    String mountPath = volume.getMountPath();
-                    if (!PodVolume.podVolumeExists(mountPath, podTemplate.getVolumes())) {
-                        newTemplate.getVolumes().add(volume);
-                    }
-                }
-            } else {
-                newTemplate = new PodTemplate();
-                newTemplate.setVolumes(step.getVolumes());
-                newTemplate.setContainers(step.getContainers());
-            }
-
-            newTemplate.setLabel(step.getLabel());
+            PodTemplate newTemplate = new PodTemplate();
             newTemplate.setName(name);
+            newTemplate.setInheritFrom(step.getInheritFrom());
+            newTemplate.setLabel(step.getLabel());
+            newTemplate.setVolumes(step.getVolumes());
+            newTemplate.setContainers(step.getContainers());
             newTemplate.setNodeSelector(step.getNodeSelector());
             newTemplate.setServiceAccount(step.getServiceAccount());
 
@@ -74,16 +47,6 @@ public class PodTemplateStepExecution extends AbstractStepExecutionImpl {
             getContext().onFailure(new IllegalStateException("Could not find cloud with name:[" + step.getCloud() + "]."));
             return true;
         }
-    }
-
-    private Collection<? extends ContainerTemplate> getContainersWithDefaults(PodTemplateStep step) {
-        if (step.getContainers().stream().noneMatch(c -> "jnlp".equals(c.getName()))) {
-            ContainerTemplate containerTemplate = new ContainerTemplate(DEFAULT_JNLP_IMAGE);
-            containerTemplate.setName("jnlp");
-            containerTemplate.setArgs("${computer.jnlpmac} ${computer.name}");
-            step.getContainers().add(containerTemplate);
-        }
-        return step.getContainers();
     }
 
     @Override

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes/PodVolume.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes/PodVolume.java
@@ -53,7 +53,7 @@ public abstract class PodVolume extends AbstractDescribableImpl<PodVolume> imple
         return false;
     }
 
-    public static boolean volumeMountExists(String path, List<VolumeMount> existingMounts) {
+    public static boolean volumeMountExists(String path, Iterable<VolumeMount> existingMounts) {
         for (VolumeMount mount : existingMounts) {
             if (mount.getMountPath().equals(path)) {
                 return true;

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodEnvVar/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodEnvVar/config.jelly
@@ -1,0 +1,16 @@
+<!--
+  Config page
+-->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+
+  <f:entry field="key" title="${%Key}">
+    <f:textbox/>
+  </f:entry>
+
+  <f:entry field="value" title="${%Value}">
+    <f:textbox/>
+  </f:entry>
+
+</j:jelly>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodEnvVar/help-key.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodEnvVar/help-key.html
@@ -1,0 +1,1 @@
+The environment variable key.

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodEnvVar/help-value.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodEnvVar/help-value.html
@@ -1,0 +1,1 @@
+The environment variable value.

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
@@ -13,6 +13,10 @@
     <f:textbox/>
   </f:entry>
 
+  <f:entry field="inheritFrom" title="The name of the pod template to inherit from">
+    <f:textbox/>
+  </f:entry>
+
   <f:entry title="${%Containers}" description="${%List of container in the slave pod}">
       <f:repeatableProperty field="containers" hasHeader="true" addCaption="Add Container"
                                     deleteCaption="Delete Container" />

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
@@ -22,6 +22,11 @@
                                     deleteCaption="Delete Container" />
   </f:entry>
 
+  <f:entry title="${%EnvVars}" description="${%List of environment variables to set in all container of the pod}">
+        <f:repeatableHeteroProperty field="envVars" hasHeader="true" addCaption="Add Environment Variable"
+                                    deleteCaption="Delete Environment Variable" />
+  </f:entry>
+
   <f:entry title="${%Volumes}" description="${%List of volumes to mount in slave pod}">
     <f:repeatableHeteroProperty field="volumes" hasHeader="true" addCaption="Add Volume"
                                 deleteCaption="Delete Volume" />

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/help-inheritFrom.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/help-inheritFrom.html
@@ -1,0 +1,10 @@
+A podTemplate may or may not inherit from an existing template. This means that the podTemplate will inherit node selector, service account, image pull secrets, containerTemplates and volumes from the template it inheritsFrom.
+
+Service account and Node selector when are overridden completely substitute any possible value found on the 'parent'.
+
+Container templates that are added to the podTemplate, that has a matching containerTemplate (a containerTemplate with the same name) in the 'parent' template, will inherit the configuration of the parent containerTemplate.
+If no matching containerTemplate is found, the template is added as is.
+
+Volume inheritance works exactly as Container templates.
+
+Image Pull Secrets** are combined (all secrets defined both on 'parent' and 'current' template are used).

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep/config.jelly
@@ -5,7 +5,7 @@
     <f:entry field="cloud" title="The cloud to use">
       <f:textbox default="kubernetes"/>
     </f:entry>
-    <f:entry field="inheritFrom" title="The name of the pod inheritFrom to use">
+    <f:entry field="inheritFrom" title="The name of the pod template to inherit from">
       <f:textbox/>
     </f:entry>
 	<f:entry field="name" title="The name of the template">

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudTest.java
@@ -2,14 +2,44 @@ package org.csanchez.jenkins.plugins.kubernetes;
 
 import static org.junit.Assert.*;
 
+import org.csanchez.jenkins.plugins.kubernetes.volumes.EmptyDirVolume;
+import org.csanchez.jenkins.plugins.kubernetes.volumes.PodVolume;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
+
+import java.util.Arrays;
 
 public class KubernetesCloudTest {
 
     private KubernetesCloud cloud = new KubernetesCloud("test", null, "http://localhost:8080", "default", null, "", 0,
             0, /* retentionTimeoutMinutes= */ 5);
+
+
+    @Test
+    public void testInheritance() {
+
+        ContainerTemplate jnlp = new ContainerTemplate("jnlp", "jnlp:1");
+        ContainerTemplate maven = new ContainerTemplate("maven", "maven:1");
+        maven.setTtyEnabled(true);
+        maven.setCommand("cat");
+
+        PodVolume podVolume = new EmptyDirVolume("/some/path", true);
+        PodTemplate parent = new PodTemplate();
+        parent.setName("parent");
+        parent.setLabel("parent");
+        parent.setContainers(Arrays.asList(jnlp));
+        parent.setVolumes(Arrays.asList(podVolume));
+
+
+        ContainerTemplate maven2 = new ContainerTemplate("maven", "maven:2");
+        PodTemplate withNewMavenVersion = new PodTemplate();
+        withNewMavenVersion.setContainers(Arrays.asList(maven2));
+
+        PodTemplate result = PodTemplateUtils.combine(parent, withNewMavenVersion);
+
+
+    }
 
     @Test
     public void testParseDockerCommand() {

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
@@ -14,6 +14,8 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 import hudson.model.Label;
 import hudson.model.labels.LabelAtom;

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
@@ -1,0 +1,215 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import com.google.common.base.Preconditions;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.Arrays;
+
+import hudson.model.Label;
+import hudson.model.labels.LabelAtom;
+import jenkins.model.Jenkins;
+
+import static org.junit.Assert.*;
+import static org.csanchez.jenkins.plugins.kubernetes.PodTemplateUtils.*;
+import static org.mockito.Matchers.anyString;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Jenkins.class})
+public class PodTemplateUtilsTest {
+
+    private static final PodImagePullSecret SECRET_1 = new PodImagePullSecret("secret1");
+    private static final PodImagePullSecret SECRET_2 = new PodImagePullSecret("secret2");
+    private static final PodImagePullSecret SECRET_3 = new PodImagePullSecret("secret3");
+
+    private static final ContainerTemplate JNLP_1 = new ContainerTemplate("jnlp", "jnlp:1");
+    private static final ContainerTemplate JNLP_2 = new ContainerTemplate("jnlp", "jnlp:2");
+
+    private static final ContainerTemplate MAVEN_1 = new ContainerTemplate("maven", "maven:1", "sh -c", "cat");
+    private static final ContainerTemplate MAVEN_2 = new ContainerTemplate("maven", "maven:2");
+    private static final ContainerTemplate GOLANG_1 = new ContainerTemplate("golang", "golang:1");
+
+    private static final PodTemplate TEMPLATE_1 = new PodTemplate();
+
+    @Mock
+    private Jenkins jenkins;
+
+    @Before
+    public void setUp() {
+        PowerMockito.mockStatic(Jenkins.class);
+        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
+        Answer<Label> labeler = invocation -> {
+            Preconditions.checkArgument(invocation != null && invocation.getArguments().length == 1 && invocation.getArguments()[0] instanceof String);
+            return new LabelAtom((String)invocation.getArguments()[0]);
+        };
+
+        PowerMockito.doAnswer(labeler).when(jenkins).getLabel(anyString());
+        PowerMockito.doAnswer(labeler).when(jenkins).getLabelAtom(anyString());
+    }
+
+    @Test
+    public void shouldReturnContainerTemplateWhenParentIsNull() {
+        ContainerTemplate result = combine(null, JNLP_2);
+        assertEquals(result, JNLP_2);
+    }
+
+    @Test
+    public void shouldOverrideTheImageAndInheritTheRest() {
+        ContainerTemplate result = combine(MAVEN_1, MAVEN_2);
+        assertEquals("maven:2", result.getImage());
+        assertEquals("cat", result.getArgs());
+    }
+
+
+    @Test
+    public void shouldReturnPodTemplateWhenParentIsNull() {
+        PodTemplate template = new PodTemplate();
+        template.setName("template");
+        template.setServiceAccount("sa1");
+        PodTemplate result = combine(null, template);
+        assertEquals(result, template);
+    }
+
+
+    @Test
+    public void shouldOverrideServiceAccountIfSpecified() {
+        PodTemplate parent = new PodTemplate();
+        parent.setName("parent");
+        parent.setServiceAccount("sa");
+
+        PodTemplate template1 = new PodTemplate();
+        template1.setName("template1");
+        template1.setServiceAccount("sa1");
+
+        PodTemplate template2 = new PodTemplate();
+        template1.setName("template2");
+
+        PodTemplate result = combine(parent, template1);
+        assertEquals("sa1", result.getServiceAccount());
+
+        result = combine(parent, template2);
+        assertEquals("sa", result.getServiceAccount());
+    }
+
+    @Test
+    public void shouldOverrideNodeSelectorIfSpecified() {
+        PodTemplate parent = new PodTemplate();
+        parent.setName("parent");
+        parent.setNodeSelector("key:value");
+
+        PodTemplate template1 = new PodTemplate();
+        template1.setName("template1");
+        template1.setNodeSelector("key:value1");
+
+        PodTemplate template2 = new PodTemplate();
+        template2.setName("template2");
+
+        PodTemplate result = combine(parent, template1);
+        assertEquals("key:value1", result.getNodeSelector());
+
+        result = combine(parent, template2);
+        assertEquals("key:value", result.getNodeSelector());
+    }
+
+
+
+    @Test
+    public void shouldCombineAllImagePullSecrets() {
+        PodTemplate parent = new PodTemplate();
+        parent.setName("parent");
+        parent.setNodeSelector("key:value");
+        parent.setImagePullSecrets(Arrays.asList(SECRET_1));
+
+        PodTemplate template1 = new PodTemplate();
+        template1.setName("template1");
+        template1.setImagePullSecrets(Arrays.asList(SECRET_1, SECRET_2, SECRET_3));
+
+        PodTemplate template2 = new PodTemplate();
+        template2.setName("template2");
+        template2.setImagePullSecrets(Arrays.asList(SECRET_2, SECRET_3));
+
+        PodTemplate template3 = new PodTemplate();
+        template3.setName("template3");
+
+        PodTemplate result = combine(parent, template1);
+        assertEquals(3, result.getImagePullSecrets().size());
+
+        result = combine(parent, template2);
+        assertEquals(3, result.getImagePullSecrets().size());
+
+        result = combine(parent, template3);
+        assertEquals(1, result.getImagePullSecrets().size());
+    }
+
+
+    @Test
+    public void shouldUnwrapParent() {
+        PodTemplate parent = new PodTemplate();
+        parent.setName("parent");
+        parent.setLabel("parent");
+        parent.setServiceAccount("sa");
+        parent.setNodeSelector("key:value");
+        parent.setImagePullSecrets(Arrays.asList(SECRET_1));
+
+        PodTemplate template1 = new PodTemplate();
+        template1.setName("template1");
+        template1.setInheritFrom("parent");
+        template1.setServiceAccount("sa1");
+        template1.setImagePullSecrets(Arrays.asList(SECRET_2, SECRET_3));
+
+
+        PodTemplate result = unwrap(template1, Arrays.asList(parent, template1));
+        assertEquals(3, result.getImagePullSecrets().size());
+        assertEquals("sa1", result.getServiceAccount());
+        assertEquals("key:value", result.getNodeSelector());
+    }
+
+    @Test
+    public void shouldUnwrapMultipleParents() {
+        PodTemplate parent = new PodTemplate();
+        parent.setName("parent");
+        parent.setLabel("parent");
+        parent.setServiceAccount("sa");
+        parent.setNodeSelector("key:value");
+        parent.setImagePullSecrets(Arrays.asList(SECRET_1));
+        parent.setContainers(Arrays.asList(JNLP_1, MAVEN_2));
+
+        PodTemplate template1 = new PodTemplate();
+        template1.setName("template1");
+        template1.setLabel("template1");
+        template1.setInheritFrom("parent");
+        template1.setServiceAccount("sa1");
+        template1.setImagePullSecrets(Arrays.asList(SECRET_2));
+        template1.setContainers(Arrays.asList(JNLP_2));
+
+        PodTemplate template2 = new PodTemplate();
+        template2.setName("template2");
+        template2.setLabel("template2");
+        template2.setImagePullSecrets(Arrays.asList(SECRET_3));
+        template2.setContainers(Arrays.asList(MAVEN_2));
+
+        PodTemplate toUnwrap = new PodTemplate();
+        toUnwrap.setName("toUnwrap");
+        toUnwrap.setInheritFrom("template1 template2");
+
+
+        PodTemplate result = unwrap(toUnwrap, Arrays.asList(parent, template1, template2));
+        assertEquals(3, result.getImagePullSecrets().size());
+        assertEquals("sa1", result.getServiceAccount());
+        assertEquals("key:value", result.getNodeSelector());
+        assertEquals(2, result.getContainers().size());
+
+        ContainerTemplate mavenTemplate = result.getContainers().stream().filter(c -> c.getName().equals("maven")).findFirst().orElse(null);
+        assertNotNull(mavenTemplate);
+        assertEquals("maven:2", mavenTemplate.getImage());
+    }
+}

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/SubstituteTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/SubstituteTest.java
@@ -1,0 +1,51 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.csanchez.jenkins.plugins.kubernetes.PodTemplateUtils.substitute;
+import static org.junit.Assert.assertEquals;
+
+public class SubstituteTest {
+
+
+    @Test
+    public void shouldIgnoreMissingProperties() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("key1", "value1");
+        assertEquals("${key2}", substitute("${key2}", properties));
+    }
+
+    @Test
+    public void shouldSubstituteSingleEnvVar() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("key1", "value1");
+        assertEquals("value1", substitute("${key1}", properties));
+    }
+
+    @Test
+    public void shouldSubstituteMultipleEnvVars() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("key1", "value1");
+        properties.put("key2", "value2");
+        assertEquals("value1 or value2", substitute("${key1} or ${key2}", properties));
+    }
+
+    @Test
+    public void shouldSubstituteMultipleEnvVarsAndIgnoreMissing() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("key1", "value1");
+        properties.put("key2", "value2");
+        assertEquals("value1 or value2 or ${key3}", substitute("${key1} or ${key2} or ${key3}", properties));
+    }
+
+    @Test
+    public void shouldSubstituteMultipleEnvVarsAndUseDefaultsForMissing() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("key1", "value1");
+        properties.put("key2", "value2");
+        assertEquals("value1 or value2 or defaultValue", substitute("${key1} or ${key2} or ${key3}", properties, "defaultValue"));
+    }
+}


### PR DESCRIPTION
This pull request allows a PodTemplate to define a parent template that will be used as a base.

This allows the user to remove repeating/boilerplate code from pipeline and move it in the plugin configuration.

The main benefits are reusability (e.g. don't add the jnlp container everywhere), readability, and more importantly decoupling the pipelines from specific configurations, that might change between environments.

For example: There are environments that may or may not allow the use of hostPath mounts, privileged containers etc. So instead of maintaining two different sets of `Jenkinsfile` inside a project one could just move those `environment sensitive details` in the parent pod, that could even be defined inside the jenkins docker image. 