### PR TITLE
Create hostPath instructions for minikube install

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,11 @@ Based on the [official image](https://registry.hub.docker.com/_/jenkins/).
 A local testing cluster with one node can be created with [minukube](https://github.com/kubernetes/minikube)
 
     minikube start
+    
+SSH into the minikube machine and create the storage directory for Jenkins data:
+
+    sudo mkdir -p /data/kubernetes-plugin-jenkins
+    sudo chown 1000 /data/kubernetes-plugin-jenkins
 
 Then create the Jenkins ReplicationController and Service with
 


### PR DESCRIPTION
Make sure we crate the hostPath on the minikube machine to prevent privilege errors during startup.