### PR TITLE
Fixing checkbox serialization by jelly views

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
@@ -21,9 +21,9 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
 
     private String image;
 
-    private Boolean privileged;
+    private boolean privileged;
 
-    private Boolean alwaysPullImage;
+    private boolean alwaysPullImage;
 
     private String workingDir = DEFAULT_WORKING_DIR;
 
@@ -31,7 +31,7 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
 
     private String args;
 
-    private Boolean ttyEnabled;
+    private boolean ttyEnabled;
 
     private String resourceRequestCpu;
 
@@ -99,11 +99,11 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
     }
 
     @DataBoundSetter
-    public void setTtyEnabled(Boolean ttyEnabled) {
+    public void setTtyEnabled(boolean ttyEnabled) {
         this.ttyEnabled = ttyEnabled;
     }
 
-    public Boolean isTtyEnabled() {
+    public boolean isTtyEnabled() {
         return ttyEnabled;
     }
 
@@ -121,20 +121,20 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
     }
 
     @DataBoundSetter
-    public void setPrivileged(Boolean privileged) {
+    public void setPrivileged(boolean privileged) {
         this.privileged = privileged;
     }
 
-    public Boolean isPrivileged() {
+    public boolean isPrivileged() {
         return privileged;
     }
 
     @DataBoundSetter
-    public void setAlwaysPullImage(Boolean alwaysPullImage) {
+    public void setAlwaysPullImage(boolean alwaysPullImage) {
         this.alwaysPullImage = alwaysPullImage;
     }
 
-    public Boolean isAlwaysPullImage() {
+    public boolean isAlwaysPullImage() {
         return alwaysPullImage;
     }
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -353,7 +353,7 @@ public class KubernetesCloud extends Cloud {
         return new ContainerBuilder()
                 .withName(substituteEnv(containerTemplate.getName()))
                 .withImage(substituteEnv(containerTemplate.getImage()))
-                .withImagePullPolicy(containerTemplate.isAlwaysPullImage() != null && containerTemplate.isAlwaysPullImage() ? "Always" : "IfNotPresent")
+                .withImagePullPolicy(containerTemplate.isAlwaysPullImage() ? "Always" : "IfNotPresent")
                 .withNewSecurityContext()
                     .withPrivileged(containerTemplate.isPrivileged())
                 .endSecurityContext()

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
@@ -43,12 +43,12 @@ public class PodTemplateUtils {
 
         String name = template.getName();
         String image = Strings.isNullOrEmpty(template.getImage()) ? parent.getImage() : template.getImage();
-        Boolean privileged = template.isPrivileged() != null ? template.isPrivileged() : (parent.isPrivileged() != null ? parent.isPrivileged() : false);
-        Boolean alwaysPullImage = template.isAlwaysPullImage() != null ? template.isAlwaysPullImage() : (parent.isAlwaysPullImage() != null ? parent.isAlwaysPullImage() : false);
+        boolean privileged = template.isPrivileged() ? template.isPrivileged() : (parent.isPrivileged() ? parent.isPrivileged() : false);
+        boolean alwaysPullImage = template.isAlwaysPullImage() ? template.isAlwaysPullImage() : (parent.isAlwaysPullImage() ? parent.isAlwaysPullImage() : false);
         String workingDir = Strings.isNullOrEmpty(template.getWorkingDir()) ? (Strings.isNullOrEmpty(parent.getWorkingDir()) ? DEFAULT_WORKING_DIR : parent.getWorkingDir()) : template.getCommand();
         String command = Strings.isNullOrEmpty(template.getCommand()) ? parent.getCommand() : template.getCommand();
         String args = Strings.isNullOrEmpty(template.getArgs()) ? parent.getArgs() : template.getArgs();
-        Boolean ttyEnabled = template.isTtyEnabled() != null ? template.isTtyEnabled() : (parent.isTtyEnabled() != null ? parent.isTtyEnabled() : false);;
+        boolean ttyEnabled = template.isTtyEnabled() ? template.isTtyEnabled() : (parent.isTtyEnabled() ? parent.isTtyEnabled() : false);;
         String resourceRequestCpu = Strings.isNullOrEmpty(template.getResourceRequestCpu()) ? parent.getResourceRequestCpu() : template.getResourceRequestCpu();
         String resourceRequestMemory = Strings.isNullOrEmpty(template.getResourceRequestMemory()) ? parent.getResourceRequestMemory() : template.getResourceRequestMemory();
         String resourceLimitCpu = Strings.isNullOrEmpty(template.getResourceLimitCpu()) ? parent.getResourceLimitCpu() : template.getResourceLimitCpu();


### PR DESCRIPTION
Checkboxes in the PodTemplate were being reset to default state in the Views since it seems like Jelly expects the boolean primitive not the Boolean type.