### PR TITLE
The workspace volume is now configurable.

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -11,6 +11,7 @@ import javax.annotation.Nonnull;
 
 import org.apache.commons.lang.StringUtils;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.PodVolume;
+import org.csanchez.jenkins.plugins.kubernetes.volumes.workspace.WorkspaceVolume;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -68,6 +69,9 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> {
 
     private transient String resourceLimitMemory;
 
+    private boolean customWorkspaceVolumeEnabled;
+    private WorkspaceVolume workspaceVolume;
+
     private final List<PodVolume> volumes = new ArrayList<PodVolume>();
 
     private List<ContainerTemplate> containers = new ArrayList<ContainerTemplate>();
@@ -95,6 +99,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> {
         this.setNodeSelector(from.getNodeSelector());
         this.setServiceAccount(from.getServiceAccount());
         this.setVolumes(from.getVolumes());
+        this.setWorkspaceVolume(from.getWorkspaceVolume());
     }
 
     @Deprecated
@@ -397,6 +402,24 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> {
             return Collections.emptyList();
         }
         return volumes;
+    }
+
+    public boolean isCustomWorkspaceVolumeEnabled() {
+        return customWorkspaceVolumeEnabled;
+    }
+
+    @DataBoundSetter
+    public void setCustomWorkspaceVolumeEnabled(boolean customWorkspaceVolumeEnabled) {
+        this.customWorkspaceVolumeEnabled = customWorkspaceVolumeEnabled;
+    }
+
+    public WorkspaceVolume getWorkspaceVolume() {
+        return workspaceVolume;
+    }
+
+    @DataBoundSetter
+    public void setWorkspaceVolume(WorkspaceVolume workspaceVolume) {
+        this.workspaceVolume = workspaceVolume;
     }
 
     @DataBoundSetter

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
@@ -4,6 +4,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 
 import org.csanchez.jenkins.plugins.kubernetes.volumes.PodVolume;
+import org.csanchez.jenkins.plugins.kubernetes.volumes.workspace.WorkspaceVolume;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -122,6 +123,8 @@ public class PodTemplateUtils {
         combinedVolumes.putAll(parentVolumes);
         combinedVolumes.putAll(template.getVolumes().stream().collect(Collectors.toMap(v -> v.getMountPath(), v -> v)));
 
+        WorkspaceVolume workspaceVolume = template.isCustomWorkspaceVolumeEnabled() && template.getWorkspaceVolume() != null ? template.getWorkspaceVolume() : parent.getWorkspaceVolume();
+
         //Tool location node properties
         List<ToolLocationNodeProperty> toolLocationNodeProperties = new ArrayList<>();
         toolLocationNodeProperties.addAll(parent.getNodeProperties());
@@ -134,6 +137,7 @@ public class PodTemplateUtils {
         podTemplate.setServiceAccount(serviceAccount);
         podTemplate.setEnvVars(combinedEnvVars.entrySet().stream().map(e -> new PodEnvVar(e.getKey(), e.getValue())).collect(Collectors.toList()));
         podTemplate.setContainers(new ArrayList<>(combinedContainers.values()));
+        podTemplate.setWorkspaceVolume(workspaceVolume);
         podTemplate.setVolumes(new ArrayList<>(combinedVolumes.values()));
         podTemplate.setImagePullSecrets(new ArrayList<>(imagePullSecrets));
         podTemplate.setNodeProperties(toolLocationNodeProperties);

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.PodVolume;
+import org.csanchez.jenkins.plugins.kubernetes.volumes.workspace.WorkspaceVolume;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
 import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
@@ -30,6 +31,7 @@ public class PodTemplateStep extends AbstractStepImpl implements Serializable {
 
     private List<ContainerTemplate> containers = new ArrayList<>();
     private List<PodVolume> volumes = new ArrayList<PodVolume>();
+    private WorkspaceVolume workspaceVolume;
 
     private int instanceCap;
     private String serviceAccount;
@@ -91,6 +93,15 @@ public class PodTemplateStep extends AbstractStepImpl implements Serializable {
     @DataBoundSetter
     public void setVolumes(List<PodVolume> volumes) {
         this.volumes = volumes;
+    }
+
+    public WorkspaceVolume getWorkspaceVolume() {
+        return workspaceVolume;
+    }
+
+    @DataBoundSetter
+    public void setWorkspaceVolume(WorkspaceVolume workspaceVolume) {
+        this.workspaceVolume = workspaceVolume;
     }
 
     public int getInstanceCap() {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
@@ -38,6 +38,8 @@ public class PodTemplateStepExecution extends AbstractStepExecutionImpl {
             newTemplate.setInstanceCap(step.getInstanceCap());
             newTemplate.setLabel(step.getLabel());
             newTemplate.setVolumes(step.getVolumes());
+            newTemplate.setCustomWorkspaceVolumeEnabled(step.getWorkspaceVolume() != null);
+            newTemplate.setWorkspaceVolume(step.getWorkspaceVolume());
             newTemplate.setContainers(step.getContainers());
             newTemplate.setNodeSelector(step.getNodeSelector());
             newTemplate.setServiceAccount(step.getServiceAccount());

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes/workspace/EmptyDirWorkspaceVolume.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes/workspace/EmptyDirWorkspaceVolume.java
@@ -1,0 +1,73 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.csanchez.jenkins.plugins.kubernetes.volumes.workspace;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeBuilder;
+
+public class EmptyDirWorkspaceVolume extends WorkspaceVolume {
+
+    private static final String DEFAULT_MEDIUM = "";
+    private static final String MEMORY_MEDIUM = "Memory";
+
+    @CheckForNull
+    private Boolean memory;
+
+    @DataBoundConstructor
+    public EmptyDirWorkspaceVolume(Boolean memory) {
+        this.memory = memory;
+    }
+
+    public String getMedium() {
+        return getMemory() ? MEMORY_MEDIUM : DEFAULT_MEDIUM;
+    }
+
+    @Nonnull
+    public Boolean getMemory() {
+        return memory != null && memory;
+    }
+
+    @Override
+    public Volume buildVolume(String volumeName) {
+        return new VolumeBuilder().withName(volumeName).withNewEmptyDir(getMedium()).build();
+    }
+
+    @Extension
+    @Symbol("emptyDirWorkspaceVolume")
+    public static class DescriptorImpl extends Descriptor<WorkspaceVolume> {
+        @Override
+        public String getDisplayName() {
+            return "Empty Dir Workspace Volume";
+        }
+    }
+}

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes/workspace/HostPathWorkspaceVolume.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes/workspace/HostPathWorkspaceVolume.java
@@ -1,0 +1,62 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.csanchez.jenkins.plugins.kubernetes.volumes.workspace;
+
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeBuilder;
+
+public class HostPathWorkspaceVolume extends WorkspaceVolume {
+    private String hostPath;
+
+    @DataBoundConstructor
+    public HostPathWorkspaceVolume(String hostPath) {
+        this.hostPath = hostPath;
+    }
+
+    public Volume buildVolume(String volumeName) {
+        return new VolumeBuilder()
+                .withName(volumeName)
+                .withNewHostPath(getHostPath())
+                .build();
+    }
+
+    public String getHostPath() {
+        return hostPath;
+    }
+
+    @Extension
+    @Symbol("hostPathWorkspaceVolume")
+    public static class DescriptorImpl extends Descriptor<WorkspaceVolume> {
+        @Override
+        public String getDisplayName() {
+            return "Host Path Workspace Volume";
+        }
+    }
+}

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes/workspace/NfsWorkspaceVolume.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes/workspace/NfsWorkspaceVolume.java
@@ -1,0 +1,79 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.csanchez.jenkins.plugins.kubernetes.volumes.workspace;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeBuilder;
+
+public class NfsWorkspaceVolume extends WorkspaceVolume {
+    private String serverAddress;
+    private String serverPath;
+    @CheckForNull
+    private Boolean readOnly;
+
+    @DataBoundConstructor
+    public NfsWorkspaceVolume(String serverAddress, String serverPath, Boolean readOnly) {
+        this.serverAddress = serverAddress;
+        this.serverPath = serverPath;
+        this.readOnly = readOnly;
+    }
+
+    public Volume buildVolume(String volumeName) {
+        return new VolumeBuilder()
+                .withName(volumeName)
+                .withNewNfs(getServerPath(), getReadOnly(), getServerAddress())
+                .build();
+    }
+
+    public String getServerAddress() {
+        return serverAddress;
+    }
+
+    public String getServerPath() {
+        return serverPath;
+    }
+
+    @Nonnull
+    public Boolean getReadOnly() {
+        return readOnly != null && readOnly;
+    }
+
+    @Extension
+    @Symbol("nfsWorkspaceVolume")
+    public static class DescriptorImpl extends Descriptor<WorkspaceVolume> {
+        @Override
+        public String getDisplayName() {
+            return "NFS Workspace Volume";
+        }
+    }
+}

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes/workspace/PersistentVolumeClaimWorkspaceVolume.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes/workspace/PersistentVolumeClaimWorkspaceVolume.java
@@ -1,0 +1,77 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.csanchez.jenkins.plugins.kubernetes.volumes.workspace;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeBuilder;
+
+public class PersistentVolumeClaimWorkspaceVolume extends WorkspaceVolume {
+    private String claimName;
+    @CheckForNull
+    private Boolean readOnly;
+
+    @DataBoundConstructor
+    public PersistentVolumeClaimWorkspaceVolume(String claimName, Boolean readOnly) {
+        this.claimName = claimName;
+        this.readOnly = readOnly;
+    }
+
+    public String getClaimName() {
+        return claimName;
+    }
+
+    @Nonnull
+    public Boolean getReadOnly() {
+        return readOnly != null && readOnly;
+    }
+
+    @Override
+    public Volume buildVolume(String volumeName) {
+        return new VolumeBuilder()
+                .withName(volumeName)
+                .withNewPersistentVolumeClaim()
+                    .withClaimName(getClaimName())
+                    .withReadOnly(getReadOnly())
+                .and()
+                .build();
+    }
+
+    @Extension
+    @Symbol("persistentVolumeClaimWorkspaceVolume")
+    public static class DescriptorImpl extends Descriptor<WorkspaceVolume> {
+        @Override
+        public String getDisplayName() {
+            return "Persistent Volume Claim Workspace Volume";
+        }
+    }
+}

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes/workspace/WorkspaceVolume.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes/workspace/WorkspaceVolume.java
@@ -1,0 +1,41 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.csanchez.jenkins.plugins.kubernetes.volumes.workspace;
+
+import java.io.Serializable;
+
+import hudson.model.AbstractDescribableImpl;
+import io.fabric8.kubernetes.api.model.Volume;
+
+/**
+ * Base class for all Kubernetes volume types
+ */
+public abstract class WorkspaceVolume extends AbstractDescribableImpl<WorkspaceVolume> implements Serializable {
+
+    private static final long serialVersionUID = 5367004248055474414L;
+
+    // Builds a Volume model with the given name.
+    public abstract Volume buildVolume(String volumeName);
+}

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
@@ -62,7 +62,16 @@
     </f:entry>
 
     <f:descriptorList title="${%Node Properties}" descriptors="${h.getNodePropertyDescriptors(descriptor.clazz)}" field="nodeProperties" />
-
+    <f:block>
+      <table>
+        <f:optionalBlock title="${%Use custom workspace volume}" field="customWorkspaceVolumeEnabled" inline="true">
+          <f:entry title="${%Workspace Volume}" description="${%Volume to use for sharing the workspace}">
+            <f:dropdownDescriptorSelector field="workspaceVolume" oneEach="true" hasHeader="true" addCaption="Add Workspace Volume"
+                                          deleteCaption="Delete Workspace Volume" />
+          </f:entry>
+        </f:optionalBlock>
+      </table>
+    </f:block>
   </f:advanced>
 
 </j:jelly>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep/config.jelly
@@ -25,7 +25,6 @@
                                 deleteCaption="Delete Volume" />
   </f:entry>
 
-
 	<f:advanced>
         <f:entry field="instanceCap" title="${%Max number of instances}">
           <f:textbox default="0"/>
@@ -39,5 +38,15 @@
         <f:entry field="workingDir" title="${%Working directory}">
           <f:textbox default="/home/jenkins"/>
         </f:entry>
+        <f:block>
+          <table>
+            <f:optionalBlock title="${%Use custom workspace volume}" checked="${instance.workspaceVolume != null}" inline="true">
+              <f:entry title="${%Workspace Volume}" description="${%Volume to use for sharing the workspace}">
+                <f:dropdownDescriptorSelector field="workspaceVolume" oneEach="true" hasHeader="true" addCaption="Add Workspace Volume"
+                                              deleteCaption="Delete Workspace Volume" />
+              </f:entry>
+            </f:optionalBlock>
+          </table>
+        </f:block>
 	</f:advanced>
 </j:jelly>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/volumes/workspace/EmptyDirWorkspaceVolume/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/volumes/workspace/EmptyDirWorkspaceVolume/config.jelly
@@ -1,0 +1,9 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+
+  <f:entry title="${%In Memory}" field="memory">
+    <f:checkbox />
+  </f:entry>
+
+</j:jelly>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/volumes/workspace/EmptyDirWorkspaceVolume/help-memory.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/volumes/workspace/EmptyDirWorkspaceVolume/help-memory.html
@@ -1,0 +1,1 @@
+Flag for in-memory volume.

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/volumes/workspace/HostPathWorkspaceVolume/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/volumes/workspace/HostPathWorkspaceVolume/config.jelly
@@ -1,0 +1,9 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+
+  <f:entry title="${%Host path}" field="hostPath">
+    <f:textbox />
+  </f:entry>
+
+</j:jelly>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/volumes/workspace/HostPathWorkspaceVolume/help-hostPath.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/volumes/workspace/HostPathWorkspaceVolume/help-hostPath.html
@@ -1,0 +1,1 @@
+File or directory on the host node's filesystem to mount into the pod.

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/volumes/workspace/NfsWorkspaceVolume/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/volumes/workspace/NfsWorkspaceVolume/config.jelly
@@ -1,0 +1,17 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+
+  <f:entry title="${%Server address}" field="serverAddress">
+    <f:textbox />
+  </f:entry>
+
+  <f:entry title="${%Server path}" field="serverPath">
+    <f:textbox />
+  </f:entry>
+
+  <f:entry title="${%Read-only}" field="readOnly">
+    <f:checkbox />
+  </f:entry>
+
+</j:jelly>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/volumes/workspace/NfsWorkspaceVolume/help-serverAddress.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/volumes/workspace/NfsWorkspaceVolume/help-serverAddress.html
@@ -1,0 +1,1 @@
+NFS Server Address.

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/volumes/workspace/NfsWorkspaceVolume/help-serverPath.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/volumes/workspace/NfsWorkspaceVolume/help-serverPath.html
@@ -1,0 +1,1 @@
+NFS Server Path.

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/volumes/workspace/PersistentVolumeClaimWorkspaceVolume/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/volumes/workspace/PersistentVolumeClaimWorkspaceVolume/config.jelly
@@ -1,0 +1,13 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+
+  <f:entry title="${%Claim Name}" field="claimName">
+    <f:textbox />
+  </f:entry>
+
+  <f:entry title="${%Read Only}" field="readOnly">
+    <f:checkbox />
+  </f:entry>
+
+</j:jelly>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/volumes/workspace/PersistentVolumeClaimWorkspaceVolume/help-claimName.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/volumes/workspace/PersistentVolumeClaimWorkspaceVolume/help-claimName.html
@@ -1,0 +1,1 @@
+The claim name.

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/volumes/workspace/PersistentVolumeClaimWorkspaceVolume/help-readOnly.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/volumes/workspace/PersistentVolumeClaimWorkspaceVolume/help-readOnly.html
@@ -1,0 +1,1 @@
+Flag for read-only volume.


### PR DESCRIPTION
Currently containers share workspace by accessing an empty dir volume inside the pod.

We should also allow the use of other means, like pvc, nfs and hostpath volumes.

This pull request adds an option that alllows the user to choose and configure one of the above.

This is still work in progress (still need to do some more testing), but I am creating the PR for feedback etc.