### PR TITLE
Only add default JNLP container if pod template is empty

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -392,6 +392,7 @@ public class KubernetesCloud extends Cloud {
                 i++;
             }
         }
+
         // add an empty volume to share the workspace across the pod
         volumes.add(new VolumeBuilder().withName(WORKSPACE_VOLUME_NAME).withNewEmptyDir("").build());
         Map<String, Container> containers = new HashMap<>();
@@ -400,7 +401,8 @@ public class KubernetesCloud extends Cloud {
             containers.put(containerTemplate.getName(), createContainer(slave, containerTemplate, template.getEnvVars(), volumeMounts.values()));
         }
 
-        if (!containers.containsKey(JNLP_NAME)) {
+        // If there are currently no containers, add a default JNLP container.
+        if (containers.empty()) {
             ContainerTemplate containerTemplate = new ContainerTemplate(DEFAULT_JNLP_IMAGE);
             containerTemplate.setName(JNLP_NAME);
             containerTemplate.setArgs(DEFAULT_JNLP_ARGUMENTS);

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -402,7 +402,7 @@ public class KubernetesCloud extends Cloud {
         }
 
         // If there are currently no containers, add a default JNLP container.
-        if (containers.empty()) {
+        if (containers.isEmpty()) {
             ContainerTemplate containerTemplate = new ContainerTemplate(DEFAULT_JNLP_IMAGE);
             containerTemplate.setName(JNLP_NAME);
             containerTemplate.setArgs(DEFAULT_JNLP_ARGUMENTS);


### PR DESCRIPTION
Current logic is to add a default JNLP agent container if there is no container specifically named "jnlp" in the pod, without regard for -- and competing with -- any JNLP agents already in the pod. This is despite existing documentation that clearly states an agent must be present, but not what its name should be.

This current behavior cost me quite a number of hours of debug time when my custom JNLP refused to run. Much to my surprise, a `kubectl describe` on those pods showed there was a mystery interloper competing for ports with my own JNLP container!

This change puts the responsibility on the developer to follow the documentation and ensure that a JNLP agent is present; if no containers are presents at all, only then is a default agent added.