### PR TITLE
Add support to command liveness probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ The `containerTemplate` is a template of container that will be added to the pod
 * **command** The command the container will execute.
 * **args** The arugments passed to the command.
 * **ttyEnabled** Flag to mark that tty should be enabled.
+* **livenessProbe** Parameters to be added to a exec liveness probe in the container (does not suppot httpGet liveness probes)
 
 ### Pod template inheritance 
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerLivenessProbe.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerLivenessProbe.java
@@ -1,0 +1,98 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import hudson.util.FormValidation;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+
+import java.io.Serializable;
+
+/**
+ * Created by fabricio.leotti on 30/01/17.
+ */
+public class ContainerLivenessProbe extends AbstractDescribableImpl<ContainerLivenessProbe> implements Serializable {
+    private String execArgs;
+    private Integer timeoutSeconds;
+    private Integer initialDelaySeconds;
+    private Integer failureThreshold;
+    private Integer periodSeconds;
+    private Integer successThreshold;
+
+    @DataBoundConstructor
+    public ContainerLivenessProbe(String execArgs, Integer timeoutSeconds, Integer initialDelaySeconds, Integer failureThreshold, Integer periodSeconds, Integer successThreshold) {
+        this.execArgs = execArgs;
+        this.timeoutSeconds = timeoutSeconds;
+        this.initialDelaySeconds = initialDelaySeconds;
+        this.failureThreshold = failureThreshold;
+        this.periodSeconds = periodSeconds;
+        this.successThreshold = successThreshold;
+    }
+
+    public String getExecArgs() {
+        return execArgs;
+    }
+
+    public void setExecArgs(String execArgs) {
+        this.execArgs = execArgs;
+    }
+
+    public Integer getTimeoutSeconds() {
+        return timeoutSeconds;
+    }
+
+    public void setTimeoutSeconds(Integer timeoutSeconds) {
+        this.timeoutSeconds = timeoutSeconds;
+    }
+
+    public Integer getInitialDelaySeconds() {
+        return initialDelaySeconds;
+    }
+
+    public void setInitialDelaySeconds(Integer initialDelaySeconds) {
+        this.initialDelaySeconds = initialDelaySeconds;
+    }
+
+    public Integer getFailureThreshold() {
+        return failureThreshold;
+    }
+
+    public void setFailureThreshold(Integer failureThreshold) {
+        this.failureThreshold = failureThreshold;
+    }
+
+    public Integer getPeriodSeconds() {
+        return periodSeconds;
+    }
+
+    public void setPeriodSeconds(Integer periodSeconds) {
+        this.periodSeconds = periodSeconds;
+    }
+
+    public Integer getSuccessThreshold() {
+        return successThreshold;
+    }
+
+    public void setSuccessThreshold(Integer successThreshold) {
+        this.successThreshold = successThreshold;
+    }
+
+    @Extension
+    @Symbol("containerLivenessProbe")
+    public static class DescriptorImpl extends Descriptor<ContainerLivenessProbe> {
+        @Override
+        public String getDisplayName() {
+            return "Container Liveness Probe";
+        }
+
+        public FormValidation doCheckExecArgs(@QueryParameter String execArgs) {
+            if(execArgs == null || execArgs.isEmpty()) {
+                return FormValidation.error("Liveness Probe > Exec Action should not be empty");
+            } else {
+                return FormValidation.ok();
+            }
+        }
+    }
+}

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerLivenessProbe.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerLivenessProbe.java
@@ -15,14 +15,14 @@ import java.io.Serializable;
  */
 public class ContainerLivenessProbe extends AbstractDescribableImpl<ContainerLivenessProbe> implements Serializable {
     private String execArgs;
-    private Integer timeoutSeconds;
-    private Integer initialDelaySeconds;
-    private Integer failureThreshold;
-    private Integer periodSeconds;
-    private Integer successThreshold;
+    private int timeoutSeconds;
+    private int initialDelaySeconds;
+    private int failureThreshold;
+    private int periodSeconds;
+    private int successThreshold;
 
     @DataBoundConstructor
-    public ContainerLivenessProbe(String execArgs, Integer timeoutSeconds, Integer initialDelaySeconds, Integer failureThreshold, Integer periodSeconds, Integer successThreshold) {
+    public ContainerLivenessProbe(String execArgs, int timeoutSeconds, int initialDelaySeconds, int failureThreshold, int periodSeconds, int successThreshold) {
         this.execArgs = execArgs;
         this.timeoutSeconds = timeoutSeconds;
         this.initialDelaySeconds = initialDelaySeconds;
@@ -39,43 +39,43 @@ public class ContainerLivenessProbe extends AbstractDescribableImpl<ContainerLiv
         this.execArgs = execArgs;
     }
 
-    public Integer getTimeoutSeconds() {
+    public int getTimeoutSeconds() {
         return timeoutSeconds;
     }
 
-    public void setTimeoutSeconds(Integer timeoutSeconds) {
+    public void setTimeoutSeconds(int timeoutSeconds) {
         this.timeoutSeconds = timeoutSeconds;
     }
 
-    public Integer getInitialDelaySeconds() {
+    public int getInitialDelaySeconds() {
         return initialDelaySeconds;
     }
 
-    public void setInitialDelaySeconds(Integer initialDelaySeconds) {
+    public void setInitialDelaySeconds(int initialDelaySeconds) {
         this.initialDelaySeconds = initialDelaySeconds;
     }
 
-    public Integer getFailureThreshold() {
+    public int getFailureThreshold() {
         return failureThreshold;
     }
 
-    public void setFailureThreshold(Integer failureThreshold) {
+    public void setFailureThreshold(int failureThreshold) {
         this.failureThreshold = failureThreshold;
     }
 
-    public Integer getPeriodSeconds() {
+    public int getPeriodSeconds() {
         return periodSeconds;
     }
 
-    public void setPeriodSeconds(Integer periodSeconds) {
+    public void setPeriodSeconds(int periodSeconds) {
         this.periodSeconds = periodSeconds;
     }
 
-    public Integer getSuccessThreshold() {
+    public int getSuccessThreshold() {
         return successThreshold;
     }
 
-    public void setSuccessThreshold(Integer successThreshold) {
+    public void setSuccessThreshold(int successThreshold) {
         this.successThreshold = successThreshold;
     }
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
@@ -43,6 +43,8 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
 
     private final List<ContainerEnvVar> envVars = new ArrayList<ContainerEnvVar>();
 
+    private final List<ContainerLivenessProbe> livenessProbe = new ArrayList<ContainerLivenessProbe>();
+
     @DataBoundConstructor
     public ContainerTemplate(String image) {
         this(null, image);
@@ -145,6 +147,13 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
     @DataBoundSetter
     public void setEnvVars(List<ContainerEnvVar> envVars) {
         this.envVars.addAll(envVars);
+    }
+
+    public List<ContainerLivenessProbe> getLivenessProbe() { return livenessProbe; }
+
+    @DataBoundSetter
+    public void setLivenessProbe(List<ContainerLivenessProbe> livenessProbe) {
+        this.livenessProbe.addAll(livenessProbe);
     }
 
     public String getResourceRequestMemory() {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -26,6 +26,7 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
 import hudson.model.labels.LabelAtom;
+import io.fabric8.kubernetes.api.model.*;
 import org.apache.commons.lang.StringUtils;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.PodVolume;
 import org.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution;
@@ -60,18 +61,6 @@ import hudson.slaves.NodeProvisioner;
 import hudson.slaves.RetentionStrategy;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
-import io.fabric8.kubernetes.api.model.Container;
-import io.fabric8.kubernetes.api.model.ContainerBuilder;
-import io.fabric8.kubernetes.api.model.ContainerStatus;
-import io.fabric8.kubernetes.api.model.EnvVar;
-import io.fabric8.kubernetes.api.model.LocalObjectReference;
-import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.PodBuilder;
-import io.fabric8.kubernetes.api.model.PodList;
-import io.fabric8.kubernetes.api.model.Quantity;
-import io.fabric8.kubernetes.api.model.Volume;
-import io.fabric8.kubernetes.api.model.VolumeBuilder;
-import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import jenkins.model.Jenkins;
@@ -353,6 +342,20 @@ public class KubernetesCloud extends Cloud {
             containerMounts.add(new VolumeMount(containerTemplate.getWorkingDir(), WORKSPACE_VOLUME_NAME, false, null));
         }
 
+        Probe livenessProbe = null;
+        for (ContainerLivenessProbe clp : containerTemplate.getLivenessProbe()) {
+            if (parseLivenessProbe(clp.getExecArgs()) != null) {
+                livenessProbe = new ProbeBuilder()
+                    .withExec(new ExecAction(parseLivenessProbe(clp.getExecArgs())))
+                    .withInitialDelaySeconds(clp.getInitialDelaySeconds())
+                    .withTimeoutSeconds(clp.getTimeoutSeconds())
+                    .withFailureThreshold(clp.getFailureThreshold())
+                    .withPeriodSeconds(clp.getPeriodSeconds())
+                    .withSuccessThreshold(clp.getSuccessThreshold())
+                    .build();
+            }
+        }
+
         return new ContainerBuilder()
                 .withName(substituteEnv(containerTemplate.getName()))
                 .withImage(substituteEnv(containerTemplate.getImage()))
@@ -364,7 +367,8 @@ public class KubernetesCloud extends Cloud {
                 .withVolumeMounts(containerMounts.toArray(new VolumeMount[containerMounts.size()]))
                 .addToEnv(env.toArray(new EnvVar[env.size()]))
                 .withCommand(parseDockerCommand(containerTemplate.getCommand()))
-                .withArgs(arguments)
+				.withArgs(arguments)
+                .withLivenessProbe(livenessProbe)
                 .withTty(containerTemplate.isTtyEnabled())
                 .withNewResources()
                     .withRequests(getResourcesMap(containerTemplate.getResourceRequestMemory(), containerTemplate.getResourceRequestCpu()))
@@ -502,6 +506,25 @@ public class KubernetesCloud extends Cloud {
         }
         // handle quoted arguments
         Matcher m = SPLIT_IN_SPACES.matcher(dockerCommand);
+        List<String> commands = new ArrayList<String>();
+        while (m.find()) {
+            commands.add(substituteEnv(m.group(1).replace("\"", "")));
+        }
+        return commands;
+    }
+
+    /**
+     * Split a command in the parts that LivenessProbe need
+     * 
+     * @param livenessProbeExec
+     * @return
+     */
+    List<String> parseLivenessProbe(String livenessProbeExec) {
+        if (livenessProbeExec == null || livenessProbeExec.isEmpty()) {
+            return null;
+        }
+        // handle quoted arguments
+        Matcher m = SPLIT_IN_SPACES.matcher(livenessProbeExec);
         List<String> commands = new ArrayList<String>();
         while (m.find()) {
             commands.add(substituteEnv(m.group(1).replace("\"", "")));

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerLivenessProbe/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerLivenessProbe/config.jelly
@@ -1,0 +1,30 @@
+<!--
+  Config page
+-->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:entry field="execArgs" title="${%Exec action}">
+    <f:textbox/>
+  </f:entry>
+
+  <f:entry field="initialDelaySeconds" title="${%Initial Delay Seconds}">
+    <f:textbox/>
+  </f:entry>
+
+  <f:entry field="timeoutSeconds" title="${%Timeout Seconds}">
+    <f:textbox/>
+  </f:entry>
+
+  <f:entry field="failureThreshold" title="${%Failure Threshold}">
+    <f:textbox/>
+  </f:entry>
+
+  <f:entry field="periodSeconds" title="${%Period Seconds}">
+    <f:textbox/>
+  </f:entry>
+
+  <f:entry field="successThreshold" title="${%Success Threshold}">
+    <f:textbox/>
+  </f:entry>
+</j:jelly>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerLivenessProbe/help-failureThreshold.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerLivenessProbe/help-failureThreshold.html
@@ -1,0 +1,1 @@
+Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. (from Kubernetes <a href="https://kubernetes.io/docs/api-reference/v1/definitions/#_v1_probe">Probe</a>)

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerLivenessProbe/help-initialDelaySeconds.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerLivenessProbe/help-initialDelaySeconds.html
@@ -1,0 +1,1 @@
+Number of seconds after the container has started before liveness probes are initiated. (from Kubernetes <a href="https://kubernetes.io/docs/api-reference/v1/definitions/#_v1_probe">Probe</a>)

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerLivenessProbe/help-periodSeconds.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerLivenessProbe/help-periodSeconds.html
@@ -1,0 +1,1 @@
+How often (in seconds) to perform the probe. Default to 10 seconds. (from Kubernetes <a href="https://kubernetes.io/docs/api-reference/v1/definitions/#_v1_probe">Probe</a>)

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerLivenessProbe/help-successThreshold.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerLivenessProbe/help-successThreshold.html
@@ -1,0 +1,1 @@
+Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. (from Kubernetes <a href="https://kubernetes.io/docs/api-reference/v1/definitions/#_v1_probe">Probe</a>)

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerLivenessProbe/help-timeoutSeconds.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerLivenessProbe/help-timeoutSeconds.html
@@ -1,0 +1,1 @@
+Number of seconds after which the probe times out. Defaults to 1 second. (from Kubernetes <a href="https://kubernetes.io/docs/api-reference/v1/definitions/#_v1_probe">Probe</a>)

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/config.jelly
@@ -32,7 +32,7 @@
 
     <f:entry title="${%Liveness Probe}" description="${%Liveness Probe for the Container}">
       <f:repeatableHeteroProperty field="livenessProbe" oneEach="true" hasHeader="true" addCaption="Add Liveness Probe"
-                                  deleteCaption="Delete Liveness Probe for the Container" />
+                                  deleteCaption="Delete Liveness Probe" />
     </f:entry>
 
   <f:entry field="ttyEnabled" title="${%Allocate pseudo-TTY}">

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/config.jelly
@@ -30,6 +30,11 @@
     <f:textbox default="cat"/>
   </f:entry>
 
+    <f:entry title="${%Liveness Probe}" description="${%Liveness Probe for the Container}">
+      <f:repeatableHeteroProperty field="livenessProbe" oneEach="true" hasHeader="true" addCaption="Add Liveness Probe"
+                                  deleteCaption="Delete Liveness Probe for the Container" />
+    </f:entry>
+
   <f:entry field="ttyEnabled" title="${%Allocate pseudo-TTY}">
     <f:checkbox default="true"/>
   </f:entry>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/help-livenessProbe.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/help-livenessProbe.html
@@ -1,0 +1,1 @@
+Add a liveness probe to the container

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
@@ -117,7 +117,9 @@ public class KubernetesPipelineTest {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("" //
                 + "podTemplate(label: 'mypod', volumes: [emptyDirVolume(mountPath: '/my-mount')], containers: [\n" //
-                + "        containerTemplate(name: 'jnlp', image: 'jenkinsci/jnlp-slave:2.62-alpine', args: '${computer.jnlpmac} ${computer.name}'),\n" //
+                + "        containerTemplate(name: 'jnlp', image: 'jenkinsci/jnlp-slave:2.62-alpine', args: '${computer.jnlpmac} ${computer.name}', livenessProbe: [ \n" //
+                + "                containerLivenessProbe( execArgs: 'docker info', initialDelaySeconds: 30, timeoutSeconds: 1, failureThreshold: 3, periodSeconds: 10, successThreshold: 1) \n" //
+                + "            ]),\n" //
                 + "        containerTemplate(name: 'maven', image: 'maven:3.3.9-jdk-8-alpine', ttyEnabled: true, command: 'cat'),\n" //
                 + "        containerTemplate(name: 'golang', image: 'golang:1.6.3-alpine', ttyEnabled: true, command: 'cat')\n" //
                 + "    ]) {\n" //


### PR DESCRIPTION
The changes will allow to add one command liveness probe to a container. You can specify:
- command to execute (does not suppot httpGet) - required field
- timeout seconds
- initial delay seconds
- failure threshold
- period seconds
- success threshold