### PR TITLE
PodEnvVar and PodTemplate are now serializable.

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
@@ -15,6 +15,8 @@ import java.util.List;
 
 public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate> implements Serializable {
 
+    private static final long serialVersionUID = 4212681620316294146L;
+
     public static final String DEFAULT_WORKING_DIR = "/home/jenkins";
 
     private String name;

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodAnnotation.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodAnnotation.java
@@ -5,7 +5,11 @@ import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-public class PodAnnotation extends AbstractDescribableImpl<PodAnnotation> {
+import java.io.Serializable;
+
+public class PodAnnotation extends AbstractDescribableImpl<PodAnnotation> implements Serializable {
+
+    private static final long serialVersionUID = -5667326362260252552L;
 
     private String key;
     private String value;

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodEnvVar.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodEnvVar.java
@@ -4,6 +4,7 @@ import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -13,7 +14,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 /**
  * Environment variables that are meant to be applied to all containers.
  */
-public class PodEnvVar extends AbstractDescribableImpl<PodEnvVar> {
+public class PodEnvVar extends AbstractDescribableImpl<PodEnvVar> implements Serializable {
 
     private String key;
     private String value;

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodImagePullSecret.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodImagePullSecret.java
@@ -7,7 +7,11 @@ import io.fabric8.kubernetes.api.model.LocalObjectReference;
 
 import org.kohsuke.stapler.DataBoundConstructor;
 
-public class PodImagePullSecret extends AbstractDescribableImpl<PodImagePullSecret> {
+import java.io.Serializable;
+
+public class PodImagePullSecret extends AbstractDescribableImpl<PodImagePullSecret> implements Serializable {
+
+    private static final long serialVersionUID = 4701392068377557526L;
 
     private String name;
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -1,6 +1,8 @@
 package org.csanchez.jenkins.plugins.kubernetes;
 
 import hudson.tools.ToolLocationNodeProperty;
+
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -31,7 +33,9 @@ import hudson.model.labels.LabelAtom;
  * 
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
-public class PodTemplate extends AbstractDescribableImpl<PodTemplate> {
+public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements Serializable {
+
+    private static final long serialVersionUID = 3285310269140845583L;
 
     private static final String FALLBACK_ARGUMENTS = "${computer.jnlpmac} ${computer.name}";
 
@@ -39,17 +43,17 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> {
 
     private String name;
 
-    private transient String image;
+    private String image;
 
-    private transient boolean privileged;
+    private boolean privileged;
 
-    private transient boolean alwaysPullImage;
+    private boolean alwaysPullImage;
 
-    private transient String command;
+    private String command;
 
-    private transient String args;
+    private String args;
 
-    private transient String remoteFs;
+    private String remoteFs;
 
     private int instanceCap = Integer.MAX_VALUE;
 
@@ -61,13 +65,13 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> {
 
     private String nodeSelector;
 
-    private transient String resourceRequestCpu;
+    private String resourceRequestCpu;
 
-    private transient String resourceRequestMemory;
+    private String resourceRequestMemory;
 
-    private transient String resourceLimitCpu;
+    private String resourceLimitCpu;
 
-    private transient String resourceLimitMemory;
+    private String resourceLimitMemory;
 
     private boolean customWorkspaceVolumeEnabled;
     private WorkspaceVolume workspaceVolume;
@@ -82,7 +86,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> {
 
     private final List<PodImagePullSecret> imagePullSecrets = new ArrayList<PodImagePullSecret>();
 
-    private List<ToolLocationNodeProperty> nodeProperties;
+    private transient List<ToolLocationNodeProperty> nodeProperties;
 
     @DataBoundConstructor
     public PodTemplate() {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
@@ -77,7 +77,7 @@ public class PodTemplateStepExecution extends AbstractStepExecutionImpl {
 
         private static final long serialVersionUID = 6043919968776851324L;
 
-        private final transient PodTemplate podTemplate;
+        private final PodTemplate podTemplate;
 
         private PodTemplateCallback(PodTemplate podTemplate) {
             this.podTemplate = podTemplate;


### PR DESCRIPTION
I've tried to align the DSL of the `kubernetes-pipeline-plugin` with this plugin. It seems to work fine, but I am having some issues with some of the types referenced by the DSL not being serializable.

This pull requests makes PodEnvVar and PodTemplate Serializable