### PR TITLE
[JENKINS-41287] Fix error when job contains spaces

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -122,7 +122,7 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
 
                 //We need to get into the project workspace.
                 //The workspace is not known in advance, so we have to execute a cd command.
-                watch.getInput().write(("cd " + path + NEWLINE).getBytes(StandardCharsets.UTF_8));
+                watch.getInput().write(String.format("cd \"%s\"%s", path, NEWLINE).getBytes(StandardCharsets.UTF_8));
                 doExec(watch, launcher.getListener().getLogger(), getCommands(starter));
                 proc = new ContainerExecProc(watch, alive, finished);
                 return proc;


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-41287

```
[job with spaces] Running shell script
Executing shell script inside container [busybox] of pod [kubernetes-8557fdf9781e4cf2a61886465194237f-38066e920443]
Executing command: sh -c echo $$ > '/home/jenkins/workspace/job with spaces@tmp/durable-aa4b60a9/pid'; jsc=durable-e34518f433054f84ad6d3027eca192a2; JENKINS_SERVER_COOKIE=$jsc '/home/jenkins/workspace/job with spaces@tmp/durable-aa4b60a9/script.sh' > '/home/jenkins/workspace/job with spaces@tmp/durable-aa4b60a9/jenkins-log.txt' 2>&1; echo $? > '/home/jenkins/workspace/job with spaces@tmp/durable-aa4b60a9/jenkins-result.txt'
/home/jenkins # cd "/home/jenkins/workspace/job with spaces"
/home/jenkins/workspace/job with spaces # sh -c echo $$ > '/home/jenkins/workspa

ce/job with spaces@tmp/durable-aa4b60a9/pid'; jsc=durable-e34518f433054f84ad6d30

27eca192a2; JENKINS_SERVER_COOKIE=$jsc '/home/jenkins/workspace/job with spaces@

tmp/durable-aa4b60a9/script.sh' > '/home/jenkins/workspace/job with spaces@tmp/d

urable-aa4b60a9/jenkins-log.txt' 2>&1; echo $? > '/home/jenkins/workspace/job wi

th spaces@tmp/durable-aa4b60a9/jenkins-result.txt'
/home/jenkins/workspace/job with spaces # exit
+ pwd
/home/jenkins/workspace/job with spaces
```