### PR TITLE
[JENKINS-40847] When upgrading from <0.9 set the container name to jnlp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,10 @@
 CHANGELOG
 =========
 
-* **NOTE if you have defined a JNLP container in your Pod definition**, you need to remove it or rename it to `jnlp`, otherwise a new container called `jnlp` will be created.
-
 * Pod Template "Annotations" Field [#105](https://github.com/jenkinsci/kubernetes-plugin/pull/105)
 * The workspace volume is now configurable [#114](https://github.com/jenkinsci/kubernetes-plugin/pull/114)
 
+* When upgrading from <0.9 set the container name to jnlp. To avoid creating an extra container, the one that exists and the new jnlp auto generated [#132](https://github.com/jenkinsci/kubernetes-plugin/pull/132)
 * Remove node if pod startup fails [#122](https://github.com/jenkinsci/kubernetes-plugin/pull/122)
 * Avoid NPE if cloud is deleted or renamed [#118](https://github.com/jenkinsci/kubernetes-plugin/pull/118)
 * Fixing deletion of containers in pod templates, containers property is databound [#113](https://github.com/jenkinsci/kubernetes-plugin/pull/113)

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -97,7 +97,7 @@ public class KubernetesCloud extends Cloud {
     private static final String DEFAULT_ID = "jenkins/slave-default";
     private static final String WORKSPACE_VOLUME_NAME = "workspace-volume";
 
-    private static final String JNLP_NAME = "jnlp";
+    public static final String JNLP_NAME = "jnlp";
     private static final String DEFAULT_JNLP_ARGUMENTS = "${computer.jnlpmac} ${computer.name}";
 
     private static final String DEFAULT_JNLP_IMAGE = System

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -447,7 +447,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
         if (containers == null) {
             // upgrading from 0.8
             containers = new ArrayList<ContainerTemplate>();
-            ContainerTemplate containerTemplate = new ContainerTemplate(this.name, this.image);
+            ContainerTemplate containerTemplate = new ContainerTemplate(KubernetesCloud.JNLP_NAME, this.image);
             containerTemplate.setCommand(command);
             containerTemplate.setArgs(Strings.isNullOrEmpty(args) ? FALLBACK_ARGUMENTS : args);
             containerTemplate.setPrivileged(privileged);

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest.java
@@ -60,7 +60,7 @@ public class KubernetesTest {
         assertEquals(1, podTemplate.getContainers().size());
         ContainerTemplate containerTemplate = podTemplate.getContainers().get(0);
         assertEquals("jenkinsci/jnlp-slave", containerTemplate.getImage());
-        assertEquals("java", containerTemplate.getName());
+        assertEquals("jnlp", containerTemplate.getName());
         assertEquals(Arrays.asList(new ContainerEnvVar("a", "b"), new ContainerEnvVar("c", "d")),
                 containerTemplate.getEnvVars());
         assertEquals(2, podTemplate.getVolumes().size());


### PR DESCRIPTION
To avoid creating an extra container, the one that exists and the new jnlp auto generated

This would solve the problem for people upgrading from 0.8 and earlier