### PR TITLE
Implement Port Mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ The `containerTemplate` is a template of container that will be added to the pod
 * **command** The command the container will execute.
 * **args** The arugments passed to the command.
 * **ttyEnabled** Flag to mark that tty should be enabled.
+* **ports** Expose ports on the container.
 
 ### Pod template inheritance 
 
@@ -185,7 +186,8 @@ podTemplate(label: 'mypod', containers: [
         envVars: [
             containerEnvVar(key: 'MYSQL_ALLOW_EMPTY_PASSWORD', value: 'true'),
             ...
-        ]
+        ],
+        ports: [portMapping(name: 'mysql', containerPort: 3306, hostPort: 3306)]
     ),
     ...
 ],

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
@@ -45,6 +45,7 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
     private String resourceLimitMemory;
 
     private final List<ContainerEnvVar> envVars = new ArrayList<ContainerEnvVar>();
+    private final List<PortMapping> ports = new ArrayList<PortMapping>();
 
     @DataBoundConstructor
     public ContainerTemplate(String image) {
@@ -148,6 +149,15 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
     @DataBoundSetter
     public void setEnvVars(List<ContainerEnvVar> envVars) {
         this.envVars.addAll(envVars);
+    }
+
+    public List<PortMapping> getPorts() {
+        return ports != null ? ports : Collections.emptyList();
+    }
+
+    @DataBoundSetter
+    public void setPorts(List<PortMapping> ports) {
+        this.ports.addAll(ports);
     }
 
     public String getResourceRequestMemory() {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -65,6 +65,7 @@ import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
@@ -374,6 +375,8 @@ public class KubernetesCloud extends Cloud {
 
         List<VolumeMount> containerMounts = new ArrayList<>(volumeMounts);
 
+        ContainerPort[] ports = containerTemplate.getPorts().stream().map(entry -> entry.toPort()).toArray(size -> new ContainerPort[size]);
+
         if (!Strings.isNullOrEmpty(containerTemplate.getWorkingDir())
                 && !PodVolume.volumeMountExists(containerTemplate.getWorkingDir(), volumeMounts)) {
             containerMounts.add(new VolumeMount(containerTemplate.getWorkingDir(), WORKSPACE_VOLUME_NAME, false, null));
@@ -389,6 +392,7 @@ public class KubernetesCloud extends Cloud {
                 .withWorkingDir(substituteEnv(containerTemplate.getWorkingDir()))
                 .withVolumeMounts(containerMounts.toArray(new VolumeMount[containerMounts.size()]))
                 .addToEnv(envVars)
+                .addToPorts(ports)
                 .withCommand(parseDockerCommand(containerTemplate.getCommand()))
                 .withArgs(arguments)
                 .withTty(containerTemplate.isTtyEnabled())

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PortMapping.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PortMapping.java
@@ -1,0 +1,118 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import org.jenkinsci.Symbol;
+import io.fabric8.kubernetes.api.model.ContainerPort;
+
+import java.io.Serializable;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+public class PortMapping extends AbstractDescribableImpl<PortMapping> implements Serializable {
+
+    private String name;
+    private Integer containerPort;
+    private Integer hostPort;
+
+    @DataBoundConstructor
+    public PortMapping(String name, Integer containerPort) {
+        this.name = name;
+        this.containerPort = containerPort;
+    }
+
+    public PortMapping(String name, Integer containerPort, Integer hostPort) {
+        this.name = name;
+        this.containerPort = containerPort;
+        this.hostPort = hostPort;
+    }
+
+    @DataBoundSetter
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @DataBoundSetter
+    public void setContainerPort(Integer containerPort) {
+        this.containerPort = containerPort;
+    }
+
+    public Integer getContainerPort() {
+        return containerPort;
+    }
+
+    @DataBoundSetter
+    public void setHostPort(Integer hostPort) {
+        this.hostPort = hostPort;
+    }
+
+    public Integer getHostPort() {
+        return hostPort;
+    }
+
+    public ContainerPort toPort() {
+        ContainerPort p = new ContainerPort();
+        p.setName(name);
+        p.setContainerPort(containerPort);
+        if(hostPort != null) {
+            p.setHostPort(hostPort);
+        }
+        return p;
+    }
+
+    public String toString() {
+        return String.format("%s,%d", name, containerPort);
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        result = prime * result + ((containerPort == null) ? 0 : containerPort);
+        result = prime * result + ((hostPort == null) ? 0 : hostPort);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        PortMapping other = (PortMapping) obj;
+        if (name == null) {
+            if (other.name != null)
+                return false;
+        } else if (!name.equals(other.name))
+            return false;
+        if (containerPort == null) {
+            if (other.containerPort != null)
+                return false;
+        } else if (!containerPort.equals(other.containerPort))
+            return false;
+        if (hostPort == null) {
+            if (other.hostPort != null)
+                return false;
+        } else if (!hostPort.equals(other.hostPort))
+            return false;
+        return true;
+    }
+
+    @Extension
+    @Symbol("portMapping")
+    public static class DescriptorImpl extends Descriptor<PortMapping> {
+        @Override
+        public String getDisplayName() {
+            return "Container Exposed Ports";
+        }
+    }
+}


### PR DESCRIPTION
This adds the capability to expose ports on the pods like this:
```
podTemplate(label: 'mypod', containers: [
    containerTemplate(
        name: 'mariadb', 
        ports: [portMapping(name: 'mysql', containerPort: 3306)]
    ),
    ...
],
```