### PR TITLE
Use name instead of label for the nesting stack

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
@@ -66,7 +66,7 @@ public class PodTemplateStepExecution extends AbstractStepExecutionImpl {
         getContext().newBodyInvoker().withContext(step).withCallback(new PodTemplateCallback(newTemplate)).start();
 
 
-        action.push(step.getLabel());
+        action.push(name);
         return false;
     }
 


### PR DESCRIPTION
I'm not entirely sure on this one, but since the `inheritFrom` field is supposed to contain a `name`, the nesting stack should also contain `name` instead of `label`.
I was not able to run all tests, but this fixes my problems with nesting `podTemplate` on my Jenkins instance.