### PR TITLE
Make Slave 🠦 Jenkins conn. timeout configurable

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -697,6 +697,8 @@ public class KubernetesCloud extends Cloud {
                     throw new IllegalStateException("Container is not running after " + j + " attempts, status: " + status);
                 }
 
+                j = t.getSlaveConnectTimeout();
+
                 // now wait for slave to be online
                 for (; i < j; i++) {
                     if (slave.getComputer() == null) {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -8,6 +8,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javax.annotation.Nonnull;
 
@@ -39,6 +41,10 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
 
     private static final String FALLBACK_ARGUMENTS = "${computer.jnlpmac} ${computer.name}";
 
+    private static final Logger LOGGER = Logger.getLogger(PodTemplate.class.getName());
+
+    private static final int DEFAULT_SLAVE_JENKINS_CONNECTION_TIMEOUT = 100;
+
     private String inheritFrom;
 
     private String name;
@@ -56,6 +62,8 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
     private String remoteFs;
 
     private int instanceCap = Integer.MAX_VALUE;
+
+    private int slaveConnectTimeout = DEFAULT_SLAVE_JENKINS_CONNECTION_TIMEOUT;
 
     private int idleMinutes;
 
@@ -102,6 +110,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
         this.setInheritFrom(from.getInheritFrom());
         this.setNodeSelector(from.getNodeSelector());
         this.setServiceAccount(from.getServiceAccount());
+        this.setSlaveConnectTimeout(from.getSlaveConnectTimeout());
         this.setVolumes(from.getVolumes());
         this.setWorkspaceVolume(from.getWorkspaceVolume());
     }
@@ -202,6 +211,23 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
         return instanceCap;
     }
 
+    public void setSlaveConnectTimeout(int slaveConnectTimeout) {
+        if (slaveConnectTimeout <= 0) {
+            LOGGER.log(Level.WARNING, "Slave -> Jenkins connection timeout " +
+                    "cannot be <= 0. Falling back to the default value: " +
+                    DEFAULT_SLAVE_JENKINS_CONNECTION_TIMEOUT);
+            this.slaveConnectTimeout = DEFAULT_SLAVE_JENKINS_CONNECTION_TIMEOUT;
+        } else {
+            this.slaveConnectTimeout = slaveConnectTimeout;
+        }
+    }
+
+    public int getSlaveConnectTimeout() {
+        if (slaveConnectTimeout == 0)
+            return DEFAULT_SLAVE_JENKINS_CONNECTION_TIMEOUT;
+        return slaveConnectTimeout;
+    }
+
     @DataBoundSetter
     public void setInstanceCapStr(String instanceCapStr) {
         if (StringUtils.isBlank(instanceCapStr)) {
@@ -217,6 +243,19 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
         } else {
             return String.valueOf(instanceCap);
         }
+    }
+
+    @DataBoundSetter
+    public void setSlaveConnectTimeoutStr(String slaveConnectTimeoutStr) {
+        if (StringUtils.isBlank(slaveConnectTimeoutStr)) {
+            setSlaveConnectTimeout(DEFAULT_SLAVE_JENKINS_CONNECTION_TIMEOUT);
+        } else {
+            setSlaveConnectTimeout(Integer.parseInt(slaveConnectTimeoutStr));
+        }
+    }
+
+    public String getSlaveConnectTimeoutStr() {
+        return String.valueOf(slaveConnectTimeout);
     }
 
     public void setIdleMinutes(int i) {

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
@@ -40,6 +40,10 @@
     <f:textbox/>
   </f:entry>
 
+  <f:entry field="slaveConnectTimeoutStr" title="${%Timeout in seconds for Jenkins connection}">
+    <f:textbox/>
+  </f:entry>
+
     <f:entry title="${%Annotations}" description="${%List of annotations to set in slave pod}" field="annotations">
       <f:repeatableHeteroProperty field="annotations" hasHeader="true" addCaption="Add Annotation"
                                   deleteCaption="Delete annotation Variable" />

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/help-slaveConnectTimeoutStr.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/help-slaveConnectTimeoutStr.html
@@ -1,0 +1,2 @@
+Specify time in seconds up to which Jenkins should wait for the JNLP slave to
+estabilish a connection. Value should be a positive integer, default being 100.


### PR DESCRIPTION
For certain slaves, there might be a need to perform some runtime
configuration/steps after getting scheduled, but before starting the
jenkins job. The default timeout of 100s might not be sufficient for
such a scenario. To cater to this use case, this patch introduces the
ability to configure the slave to jenkins connection timeout, defaulting
to 100s for backwards compatibility.