### PR TITLE
Limit pod name to 63 characters, and shorten randomly generated string

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.apache.commons.lang.RandomStringUtils;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.durabletask.executors.OnceRetentionStrategy;
 import org.jvnet.localizer.Localizable;
@@ -83,16 +84,16 @@ public class KubernetesSlave extends AbstractCloudSlave {
     }
 
     static String getSlaveName(PodTemplate template) {
-        String hex = Long.toHexString(System.nanoTime());
+        String randString = RandomStringUtils.random(5, "bcdfghjklmnpqrstvwxz0123456789");
         String name = template.getName();
         if (StringUtils.isEmpty(name)) {
-            return hex;
+            return String.format("kubernetes-%s", randString);
         }
         // no spaces
         name = template.getName().replace(" ", "-").toLowerCase();
-        // keep it under 256 chars
-        name = name.substring(0, Math.min(name.length(), 256 - hex.length()));
-        return String.format("%s-%s", name, hex);
+        // keep it under 63 chars (62 is used to account for the '-')
+        name = name.substring(0, Math.min(name.length(), 62 - randString.length()));
+        return String.format("%s-%s", name, randString);
     }
 
     @Override

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
@@ -44,13 +44,11 @@ public class PodTemplateStepExecution extends AbstractStepExecutionImpl {
                     cloud.getClass().getName()));
         }
         KubernetesCloud kubernetesCloud = (KubernetesCloud) cloud;
-        String uuid = UUID.randomUUID().toString().replaceAll("-", "");
-        String name = String.format(NAME_FORMAT, step.getName(), uuid);
 
         PodTemplateAction action = new PodTemplateAction(getContext().get(Run.class));
 
         PodTemplate newTemplate = new PodTemplate();
-        newTemplate.setName(name);
+        newTemplate.setName(step.getName());
         newTemplate.setInheritFrom(!Strings.isNullOrEmpty( action.getParentTemplates()) ? action.getParentTemplates() : step.getInheritFrom());
         newTemplate.setInstanceCap(step.getInstanceCap());
         newTemplate.setLabel(step.getLabel());
@@ -66,7 +64,7 @@ public class PodTemplateStepExecution extends AbstractStepExecutionImpl {
         getContext().newBodyInvoker().withContext(step).withCallback(new PodTemplateCallback(newTemplate)).start();
 
 
-        action.push(name);
+        action.push(step.getName());
         return false;
     }
 

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlaveTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlaveTest.java
@@ -44,10 +44,10 @@ public class KubernetesSlaveTest {
         List<? extends PodVolume> volumes = Collections.emptyList();
         List<ContainerTemplate> containers = Collections.emptyList();
 
-        assertRegex(KubernetesSlave.getSlaveName(new PodTemplate("image", volumes)), "^[0-9a-f]{10,}$");
-        assertRegex(KubernetesSlave.getSlaveName(new PodTemplate("", volumes, containers)), "^[0-9a-f]{10,}$");
+        assertRegex(KubernetesSlave.getSlaveName(new PodTemplate("image", volumes)), "^kubernetes-[0-9a-z]{5}$");
+        assertRegex(KubernetesSlave.getSlaveName(new PodTemplate("", volumes, containers)), "^kubernetes-[0-9a-z]{5}$");
         assertRegex(KubernetesSlave.getSlaveName(new PodTemplate("a name", volumes, containers)),
-                ("^a-name-[0-9a-f]{10,}$"));
+                ("^a-name-[0-9a-z]{5}$"));
     }
 
     private void assertRegex(String name, String regex) {


### PR DESCRIPTION
This PR has two small changes. Hope that it's alright that they're both in one PR. They're closely related.

The first fixes a bug where the plugin fails to use a pod if the pod's name is over 63 characters. I believe this is due to the fact that the JNLP container has a max hostname of 64 bytes (including the null terminator).
```
$ getconf HOST_NAME_MAX
64
```
As as a result, when [`workspace.child(HOSTNAME_FILE).readToString()`](https://github.com/jenkinsci/kubernetes-plugin/blob/master/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerStepExecution.java#L44) is executed, it returns the first 63 characters of the pod name, which causes the plugin to look for the wrong pod.

The second change makes the random string appended to the end of the pod name more like [Kubernetes' string generation](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/util/rand/rand.go#L79). With this PR, only 5 characters are appended (or replaced if it exceeds the max length) to the end of the string.