### PR TITLE
Restore random naming for pipeline managed pod templates.

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
@@ -1,7 +1,6 @@
 package org.csanchez.jenkins.plugins.kubernetes;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -37,6 +36,7 @@ public class KubernetesSlave extends AbstractCloudSlave {
     private static final Logger LOGGER = Logger.getLogger(KubernetesSlave.class.getName());
 
     private static final long serialVersionUID = -8642936855413034232L;
+    private static final String DEFAULT_AGENT_PREFIX = "jenkins-agent";
 
     /**
      * The resource bundle reference
@@ -95,10 +95,10 @@ public class KubernetesSlave extends AbstractCloudSlave {
         String randString = RandomStringUtils.random(5, "bcdfghjklmnpqrstvwxz0123456789");
         String name = template.getName();
         if (StringUtils.isEmpty(name)) {
-            return String.format("kubernetes-%s", randString);
+            return String.format("%s-%s", DEFAULT_AGENT_PREFIX,  randString);
         }
         // no spaces
-        name = template.getName().replace(" ", "-").toLowerCase();
+        name = name.replaceAll("[ _]", "-").toLowerCase();
         // keep it under 63 chars (62 is used to account for the '-')
         name = name.substring(0, Math.min(name.length(), 62 - randString.length()));
         return String.format("%s-%s", name, randString);

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep.java
@@ -47,7 +47,7 @@ public class PodTemplateStep extends Step implements Serializable {
     @DataBoundConstructor
     public PodTemplateStep(String label, String name) {
         this.label = label;
-        this.name = name == null ? "kubernetes" : name;
+        this.name = name == null ? "jenkins-slave" : name;
     }
 
     public String getLabel() {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.apache.commons.lang.RandomStringUtils;
 import org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud;
 import org.csanchez.jenkins.plugins.kubernetes.PodTemplate;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
@@ -47,8 +48,13 @@ public class PodTemplateStepExecution extends AbstractStepExecutionImpl {
 
         PodTemplateAction action = new PodTemplateAction(getContext().get(Run.class));
 
+        //Let's generate a random name based on the user specified to make sure that we don't have
+        //issues with concurrent builds, or messing with pre-existing configuration
+        String randString = RandomStringUtils.random(5, "bcdfghjklmnpqrstvwxz0123456789");
+        String name = String.format(NAME_FORMAT, step.getName(), randString);
+
         PodTemplate newTemplate = new PodTemplate();
-        newTemplate.setName(step.getName());
+        newTemplate.setName(name);
         newTemplate.setInheritFrom(!Strings.isNullOrEmpty( action.getParentTemplates()) ? action.getParentTemplates() : step.getInheritFrom());
         newTemplate.setInstanceCap(step.getInstanceCap());
         newTemplate.setLabel(step.getLabel());
@@ -64,7 +70,7 @@ public class PodTemplateStepExecution extends AbstractStepExecutionImpl {
         getContext().newBodyInvoker().withContext(step).withCallback(new PodTemplateCallback(newTemplate)).start();
 
 
-        action.push(step.getName());
+        action.push(name);
         return false;
     }
 

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlaveTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlaveTest.java
@@ -44,10 +44,12 @@ public class KubernetesSlaveTest {
         List<? extends PodVolume> volumes = Collections.emptyList();
         List<ContainerTemplate> containers = Collections.emptyList();
 
-        assertRegex(KubernetesSlave.getSlaveName(new PodTemplate("image", volumes)), "^kubernetes-[0-9a-z]{5}$");
-        assertRegex(KubernetesSlave.getSlaveName(new PodTemplate("", volumes, containers)), "^kubernetes-[0-9a-z]{5}$");
+        assertRegex(KubernetesSlave.getSlaveName(new PodTemplate("image", volumes)), "^jenkins-agent-[0-9a-z]{5}$");
+        assertRegex(KubernetesSlave.getSlaveName(new PodTemplate("", volumes, containers)), "^jenkins-agent-[0-9a-z]{5}$");
         assertRegex(KubernetesSlave.getSlaveName(new PodTemplate("a name", volumes, containers)),
                 ("^a-name-[0-9a-z]{5}$"));
+        assertRegex(KubernetesSlave.getSlaveName(new PodTemplate("an_other_name", volumes, containers)),
+                ("^an-other-name-[0-9a-z]{5}$"));
     }
 
     private void assertRegex(String name, String regex) {


### PR DESCRIPTION
We need the random names because the PodTemplates that we generate using the pipeline are added to the cloud configuration. Using user provides names has the following side effects:

- Two builds using podTemplates with the same name can get in each other way
- It's possible to mess up with preconfigured podTemplate (found in config.xml)
