### PR TITLE
Add namespace support on PodTemplate.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The `podTemplate` is a template of a pod that will be used to create slaves. It 
 Either way it provides access to the following fields:
 
 * **name** The name of the pod.
+* **namespace** The namespace of the pod.
 * **label** The label of the pod.
 * **container** The container templates that are use to create the containers of the pod *(see below)*.
 * **serviceAccount** The service account of the pod.
@@ -162,7 +163,13 @@ Then consumers of the library could just express the need for a maven pod with d
             """
         }
     }
+
+#### Using a different namespace
  
+There might be cases, where you need to have the slave pod run inside a different namespace than the one configured with the cloud definition.
+For example you may need the slave to run inside an `ephemeral` namespace for the shake of testing. 
+For those cases you can explicitly configure a namespace either using the ui or the pipeline.
+
 
 ## Container Configuration
 When configuring a container in a pipeline podTemplate the following options are available:

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>org.csanchez.jenkins.plugins</groupId>
   <artifactId>kubernetes</artifactId>
-  <version>0.12-SNAPSHOT</version>
+  <version>0.11.redhat-ipaas-009</version>
   <name>Kubernetes plugin</name>
   <description>Jenkins plugin to run dynamic slaves in a Kubernetes/Docker environment</description>
   <packaging>hpi</packaging>

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -595,13 +595,13 @@ public class KubernetesCloud extends Cloud {
         /**
          * Log the last lines of containers logs
          */
-        private void logLastLines(List<ContainerStatus> containers, String podId, KubernetesSlave slave,
+        private void logLastLines(List<ContainerStatus> containers, String podId, String namespace, KubernetesSlave slave,
                 Map<String, Integer> errors) {
             for (ContainerStatus containerStatus : containers) {
                 String containerName = containerStatus.getName();
 
                 try {
-                    PrettyLoggable<String, LogWatch> tailingLines = connect().pods().withName(podId)
+                    PrettyLoggable<String, LogWatch> tailingLines = connect().pods().inNamespace(namespace).withName(podId)
                             .inContainer(containerStatus.getName()).tailingLines(30);
                     String log = tailingLines.getLog();
                     if (!StringUtils.isBlank(log)) {
@@ -631,11 +631,15 @@ public class KubernetesCloud extends Cloud {
                 LOGGER.log(Level.FINER, "Adding Jenkins node: {0}", slave.getNodeName());
                 Jenkins.getActiveInstance().addNode(slave);
 
+                KubernetesClient client = connect();
                 Pod pod = getPodTemplate(slave, label);
-                // Why the hell doesn't createPod return a Pod object ?
-                pod = connect().pods().create(pod);
 
                 String podId = pod.getMetadata().getName();
+                String namespace = Strings.isNullOrEmpty(t.getNamespace())
+                        ? client.getNamespace()
+                        : t.getNamespace();
+
+                pod = client.pods().inNamespace(namespace).create(pod);
                 LOGGER.log(Level.INFO, "Created Pod: {0}", podId);
 
                 // We need the pod to be running and connected before returning
@@ -651,7 +655,7 @@ public class KubernetesCloud extends Cloud {
                 for (; i < j; i++) {
                     LOGGER.log(Level.INFO, "Waiting for Pod to be scheduled ({1}/{2}): {0}", new Object[] {podId, i, j});
                     Thread.sleep(6000);
-                    pod = connect().pods().withName(podId).get();
+                    pod = connect().pods().inNamespace(namespace).withName(podId).get();
                     if (pod == null) {
                         throw new IllegalStateException("Pod no longer exists: " + podId);
                     }
@@ -680,7 +684,7 @@ public class KubernetesCloud extends Cloud {
                                 ContainerStatus::getName, (info) -> info.getState().getTerminated().getExitCode()));
 
                         // Print the last lines of failed containers
-                        logLastLines(terminatedContainers, podId, slave, errors);
+                        logLastLines(terminatedContainers, podId, namespace, slave, errors);
                         throw new IllegalStateException("Containers are terminated with exit codes: " + errors);
                     }
 
@@ -713,7 +717,7 @@ public class KubernetesCloud extends Cloud {
                 }
                 if (!slave.getComputer().isOnline()) {
                     if (containerStatuses != null) {
-                        logLastLines(containerStatuses, podId, slave, null);
+                        logLastLines(containerStatuses, podId, namespace, slave, null);
                     }
                     throw new IllegalStateException("Slave is not connected after " + j + " attempts, status: " + status);
                 }
@@ -740,11 +744,11 @@ public class KubernetesCloud extends Cloud {
         }
 
         KubernetesClient client = connect();
-        PodList slaveList = client.pods().withLabels(POD_LABEL).list();
+        PodList slaveList = client.pods().inNamespace(template.getNamespace()).withLabels(POD_LABEL).list();
         List<Pod> slaveListItems = slaveList.getItems();
 
         Map<String, String> labelsMap = getLabelsMap(template.getLabelSet());
-        PodList namedList = client.pods().withLabels(labelsMap).list();
+        PodList namedList = client.pods().inNamespace(template.getNamespace()).withLabels(labelsMap).list();
         List<Pod> namedListItems = namedList.getItems();
 
         if (slaveListItems != null && containerCap <= slaveListItems.size()) {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
@@ -44,6 +44,7 @@ public class KubernetesSlave extends AbstractCloudSlave {
     private final static ResourceBundleHolder HOLDER = ResourceBundleHolder.get(Messages.class);
 
     private final String cloudName;
+    private final String namespace;
 
     public KubernetesSlave(PodTemplate template, String nodeDescription, KubernetesCloud cloud, String labelStr)
             throws Descriptor.FormException, IOException {
@@ -81,10 +82,15 @@ public class KubernetesSlave extends AbstractCloudSlave {
 
         // this.pod = pod;
         this.cloudName = cloudName;
+        this.namespace = template.getNamespace();
     }
 
     public String getCloudName() {
         return cloudName;
+    }
+
+    public String getNamespace() {
+        return namespace;
     }
 
     public Cloud getCloud() {
@@ -144,7 +150,7 @@ public class KubernetesSlave extends AbstractCloudSlave {
                 return;
             }
             KubernetesClient client = ((KubernetesCloud) cloud).connect();
-            PodResource<Pod, DoneablePod> pods = client.pods().withName(name);
+            PodResource<Pod, DoneablePod> pods = client.pods().inNamespace(namespace).withName(name);
             pods.delete();
             String msg = String.format("Terminated Kubernetes instance for slave %s", name);
             LOGGER.log(Level.INFO, msg);

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -49,6 +49,8 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
 
     private String name;
 
+    private String namespace;
+
     private String image;
 
     private boolean privileged;
@@ -155,6 +157,15 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
 
     public String getName() {
         return name;
+    }
+
+    public String getNamespace() {
+        return namespace;
+    }
+
+    @DataBoundSetter
+    public void setNamespace(String namespace) {
+        this.namespace = namespace;
     }
 
     @Deprecated

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
@@ -137,6 +137,7 @@ public class PodTemplateUtils {
 
         PodTemplate podTemplate = new PodTemplate();
         podTemplate.setName(name);
+        podTemplate.setNamespace(!Strings.isNullOrEmpty(template.getNamespace()) ? template.getNamespace() : parent.getNamespace());
         podTemplate.setLabel(label);
         podTemplate.setNodeSelector(nodeSelector);
         podTemplate.setServiceAccount(serviceAccount);

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/NamespaceAction.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/NamespaceAction.java
@@ -1,0 +1,84 @@
+package org.csanchez.jenkins.plugins.kubernetes.pipeline;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.EmptyStackException;
+import java.util.List;
+import java.util.Stack;
+import java.util.logging.Logger;
+
+import hudson.BulkChange;
+import hudson.model.InvisibleAction;
+import hudson.model.Run;
+
+public class NamespaceAction extends InvisibleAction {
+
+    private static final Logger LOGGER = Logger.getLogger(NamespaceAction.class.getName());
+
+    private final Stack<String> namespaces = new Stack<>();
+    private final Run run;
+
+
+    public NamespaceAction(Run run) {
+        this.run = run;
+    }
+
+    public void push(String namespace) throws IOException {
+        if (run == null) {
+            LOGGER.warning("run is null, cannot push");
+            return;
+        }
+        synchronized (run) {
+            BulkChange bc = new BulkChange(run);
+            try {
+                NamespaceAction action = run.getAction(NamespaceAction.class);
+                if (action == null) {
+                    action = new NamespaceAction(run);
+                    run.addAction(action);
+                }
+                action.namespaces.push(namespace);
+                bc.commit();
+            } finally {
+                bc.abort();
+            }
+        }
+    }
+
+    public String pop() throws IOException {
+        if (run == null) {
+            LOGGER.warning("run is null, cannot pop");
+            return null;
+        }
+        synchronized (run) {
+            BulkChange bc = new BulkChange(run);
+            try {
+                NamespaceAction action = run.getAction(NamespaceAction.class);
+                if (action == null) {
+                    action = new NamespaceAction(run);
+                    run.addAction(action);
+                }
+                String namespace = action.namespaces.pop();
+                bc.commit();
+                return namespace;
+            } finally {
+                bc.abort();
+                return null;
+            }
+        }
+    }
+
+    public String getNamespace() {
+        synchronized (run) {
+            NamespaceAction action = run.getAction(NamespaceAction.class);
+            if (action == null) {
+                action = new NamespaceAction(run);
+                run.addAction(action);
+            }
+            try {
+                return action.namespaces.peek();
+            } catch (EmptyStackException e) {
+                return null;
+            }
+        }
+    }
+}

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep.java
@@ -34,6 +34,7 @@ public class PodTemplateStep extends Step implements Serializable {
     private final String label;
     private final String name;
 
+    private String namespace;
     private List<ContainerTemplate> containers = new ArrayList<>();
     private List<PodVolume> volumes = new ArrayList<PodVolume>();
     private WorkspaceVolume workspaceVolume;
@@ -56,6 +57,15 @@ public class PodTemplateStep extends Step implements Serializable {
 
     public String getName() {
         return name;
+    }
+
+    public String getNamespace() {
+        return namespace;
+    }
+
+    @DataBoundSetter
+    public void setNamespace(String namespace) {
+        this.namespace = namespace;
     }
 
     public String getCloud() {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
@@ -1,6 +1,5 @@
 package org.csanchez.jenkins.plugins.kubernetes.pipeline;
 
-import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -46,16 +45,19 @@ public class PodTemplateStepExecution extends AbstractStepExecutionImpl {
         }
         KubernetesCloud kubernetesCloud = (KubernetesCloud) cloud;
 
-        PodTemplateAction action = new PodTemplateAction(getContext().get(Run.class));
+        PodTemplateAction podTemplateAction = new PodTemplateAction(getContext().get(Run.class));
+        NamespaceAction namespaceAction = new NamespaceAction(getContext().get(Run.class));
 
         //Let's generate a random name based on the user specified to make sure that we don't have
         //issues with concurrent builds, or messing with pre-existing configuration
         String randString = RandomStringUtils.random(5, "bcdfghjklmnpqrstvwxz0123456789");
         String name = String.format(NAME_FORMAT, step.getName(), randString);
+        String namespace = checkNamespace(kubernetesCloud, namespaceAction);
 
         PodTemplate newTemplate = new PodTemplate();
         newTemplate.setName(name);
-        newTemplate.setInheritFrom(!Strings.isNullOrEmpty( action.getParentTemplates()) ? action.getParentTemplates() : step.getInheritFrom());
+        newTemplate.setNamespace(namespace);
+        newTemplate.setInheritFrom(!Strings.isNullOrEmpty( podTemplateAction.getParentTemplates()) ? podTemplateAction.getParentTemplates() : step.getInheritFrom());
         newTemplate.setInstanceCap(step.getInstanceCap());
         newTemplate.setLabel(step.getLabel());
         newTemplate.setVolumes(step.getVolumes());
@@ -69,14 +71,37 @@ public class PodTemplateStepExecution extends AbstractStepExecutionImpl {
         kubernetesCloud.addTemplate(newTemplate);
         getContext().newBodyInvoker().withContext(step).withCallback(new PodTemplateCallback(newTemplate)).start();
 
-
-        action.push(name);
+        podTemplateAction.push(name);
+        namespaceAction.push(namespace);
         return false;
     }
 
     @Override
     public void stop(Throwable cause) throws Exception {
         new PodTemplateAction(getContext().get(Run.class)).pop();
+    }
+
+
+    private String checkNamespace(KubernetesCloud kubernetesCloud, NamespaceAction namespaceAction) {
+        String namespace = null;
+        if (!Strings.isNullOrEmpty(namespaceAction.getNamespace())) {
+            namespace = namespaceAction.getNamespace();
+        } else if (!Strings.isNullOrEmpty(step.getNamespace())) {
+            namespace = step.getNamespace();
+        } else if (!Strings.isNullOrEmpty(kubernetesCloud.getNamespace())) {
+            namespace = kubernetesCloud.getNamespace();
+        } else {
+            try {
+                namespace = kubernetesCloud.connect().getNamespace();
+            } catch (Throwable t) {
+                //We can just ignore...
+            }
+        }
+
+        if (Strings.isNullOrEmpty(namespace)) {
+            throw new IllegalStateException("No target namespace has been found.");
+        }
+        return namespace;
     }
 
     private class PodTemplateCallback extends BodyExecutionCallback.TailCall {

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
@@ -9,6 +9,10 @@
     <f:textbox/>
   </f:entry>
 
+  <f:entry field="namespace" title="${%Namespace}">
+    <f:textbox/>
+  </f:entry>
+
   <f:entry field="label" title="${%Labels}">
     <f:textbox/>
   </f:entry>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep/config.jelly
@@ -11,6 +11,9 @@
 	<f:entry field="name" title="The name of the template">
 	  <f:textbox/>
 	</f:entry>
+	<f:entry field="namespace" title="The namespace of the template">
+	  <f:textbox/>
+	</f:entry>
 	<f:entry field="label" title="The label">
       <f:textbox/>
     </f:entry>

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runDirContext.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runDirContext.groovy
@@ -1,0 +1,18 @@
+podTemplate(cloud: 'minikube', label: 'mypod', containers: [
+        containerTemplate(name: 'busybox', image: 'busybox', ttyEnabled: true, command: '/bin/cat'),
+]) {
+
+    node ('mypod') {
+        stage('Run') {
+            container('busybox') {
+                sh 'mkdir hz'
+                sh 'echo "initpwd is -$(pwd)-"'
+                dir('hz') {
+                    sh 'echo "dirpwd is -$(pwd)-"'
+                }
+                sh 'echo "postpwd is -$(pwd)-"'
+            }
+        }
+
+    }
+}

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runInPod.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runInPod.groovy
@@ -1,0 +1,19 @@
+podTemplate(cloud: 'minikube', label: 'mypod', volumes: [emptyDirVolume(mountPath: '/my-mount')], containers: [
+        containerTemplate(name: 'jnlp', image: 'jenkinsci/jnlp-slave:2.62-alpine', args: '${computer.jnlpmac} ${computer.name}'),
+        containerTemplate(name: 'maven', image: 'maven:3.3.9-jdk-8-alpine', ttyEnabled: true, command: 'cat'),
+        containerTemplate(name: 'golang', image: 'golang:1.6.3-alpine', ttyEnabled: true, command: 'cat')
+]) {
+
+    node ('mypod') {
+        sh "echo My Kubernetes Pipeline"
+        sh "ls /"
+
+        stage('Run maven') {
+            container('maven') {
+                sh 'mvn -version'
+            }
+        }
+
+
+    }
+}

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runInPodWithExistingTemplate.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runInPodWithExistingTemplate.groovy
@@ -1,0 +1,9 @@
+node ('busybox') {
+    sh 'echo outside container'
+
+    stage('Run busybox') {
+        container('busybox') {
+            sh 'echo inside container'
+        }
+    }
+}

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runInPodWithRestart.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runInPodWithRestart.groovy
@@ -1,0 +1,20 @@
+package org.csanchez.jenkins.plugins.kubernetes.pipeline
+
+podTemplate(cloud: 'minikube', label: 'mypod', containers: [
+        containerTemplate(name: 'busybox', image: 'busybox', ttyEnabled: true, command: '/bin/cat'),
+]) {
+
+    node ('mypod') {
+        stage('Run') {
+            container('busybox') {
+                sh 'mkdir hz'
+                sh 'echo "initpwd is -$(pwd)-"'
+                dir('hz') {
+                    sh 'echo "dirpwd is -$(pwd)-"'
+                }
+                sh 'echo "postpwd is -$(pwd)-"'
+            }
+        }
+
+    }
+}

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runJobWithSpaces.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runJobWithSpaces.groovy
@@ -1,0 +1,13 @@
+podTemplate(cloud: 'minikube', label: 'mypod', containers: [
+        containerTemplate(name: 'busybox', image: 'busybox', ttyEnabled: true, command: '/bin/cat'),
+]) {
+
+    node ('mypod') {
+        stage('Run') {
+            container('busybox') {
+                sh 'echo "pwd is -$(pwd)-"'
+            }
+        }
+
+    }
+}

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runWithOverriddenNamespace.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runWithOverriddenNamespace.groovy
@@ -1,0 +1,10 @@
+podTemplate(cloud: 'minikube', label: 'mypod', volumes: [emptyDirVolume(mountPath: '/my-mount')], containers: [
+        containerTemplate(name: 'jnlp', image: 'jenkinsci/jnlp-slave:2.62-alpine', args: '${computer.jnlpmac} ${computer.name}')
+]) {
+
+    node ('mypod') {
+        container(name: 'jnlp') {
+            sh "cat /var/run/secrets/kubernetes.io/serviceaccount/namespace"
+        }
+    }
+}


### PR DESCRIPTION
This pull request, adds support for namespaces inside the PodTemplates.

This feature can be really useful, if we need to create `ephemeral` namespace to run our builds and tests. For example: 

- create a namespace 
- deploy all apps and services 
- run end to end tests 
- then destroy namespace.