### PR TITLE
Add command liveness probe support

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ The `containerTemplate` is a template of container that will be added to the pod
 * **command** The command the container will execute.
 * **args** The arugments passed to the command.
 * **ttyEnabled** Flag to mark that tty should be enabled.
+* **livenessProbe** Parameters to be added to a exec liveness probe in the container (does not suppot httpGet liveness probes)
+
+#### Liveness Probe Usage
+```groovy
+containerTemplate(name: 'busybox', image: 'busybox', ttyEnabled: true, command: 'cat', livenessProbe: containerLivenessProbe( execArgs: 'some --command', initialDelaySeconds: 30, timeoutSeconds: 1, failureThreshold: 3, periodSeconds: 10, successThreshold: 1))
+```
+See [Defining a liveness command](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#defining-a-liveness-command) for more details.
 
 ### Pod template inheritance 
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerLivenessProbe.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerLivenessProbe.java
@@ -1,0 +1,97 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import hudson.util.FormValidation;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+import java.io.Serializable;
+
+/**
+ * Created by fabricio.leotti on 26/04/17.
+ */
+public class ContainerLivenessProbe extends AbstractDescribableImpl<ContainerLivenessProbe> implements Serializable {
+        private String execArgs;
+        private int timeoutSeconds;
+        private int initialDelaySeconds;
+        private int failureThreshold;
+        private int periodSeconds;
+        private int successThreshold;
+
+    @DataBoundConstructor
+    public ContainerLivenessProbe(String execArgs, int timeoutSeconds, int initialDelaySeconds, int failureThreshold, int periodSeconds, int successThreshold) {
+        this.execArgs = execArgs;
+        this.timeoutSeconds = timeoutSeconds;
+        this.initialDelaySeconds = initialDelaySeconds;
+        this.failureThreshold = failureThreshold;
+        this.periodSeconds = periodSeconds;
+        this.successThreshold = successThreshold;
+    }
+
+    public String getExecArgs() {
+        return execArgs;
+    }
+
+    public void setExecArgs(String execArgs) {
+        this.execArgs = execArgs;
+    }
+
+    public int getTimeoutSeconds() {
+        return timeoutSeconds;
+    }
+
+    public void setTimeoutSeconds(int timeoutSeconds) {
+        this.timeoutSeconds = timeoutSeconds;
+    }
+
+    public int getInitialDelaySeconds() {
+        return initialDelaySeconds;
+    }
+
+    public void setInitialDelaySeconds(int initialDelaySeconds) {
+        this.initialDelaySeconds = initialDelaySeconds;
+    }
+
+    public int getFailureThreshold() {
+        return failureThreshold;
+    }
+
+    public void setFailureThreshold(int failureThreshold) {
+        this.failureThreshold = failureThreshold;
+    }
+
+    public int getPeriodSeconds() {
+        return periodSeconds;
+    }
+
+    public void setPeriodSeconds(int periodSeconds) {
+        this.periodSeconds = periodSeconds;
+    }
+
+    public int getSuccessThreshold() {
+        return successThreshold;
+    }
+
+    public void setSuccessThreshold(int successThreshold) {
+        this.successThreshold = successThreshold;
+    }
+
+    @Extension
+    @Symbol("containerLivenessProbe")
+    public static class DescriptorImpl extends Descriptor<ContainerLivenessProbe> {
+        @Override
+        public String getDisplayName() {
+            return "Container Liveness Probe";
+        }
+
+        public FormValidation doCheckExecArgs(@QueryParameter String execArgs) {
+            if(execArgs == null || execArgs.isEmpty()) {
+                return FormValidation.error("Liveness Probe > Exec Action should not be empty");
+            } else {
+                return FormValidation.ok();
+            }
+        }
+    }
+}

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
@@ -46,6 +46,8 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
 
     private final List<ContainerEnvVar> envVars = new ArrayList<ContainerEnvVar>();
 
+    private ContainerLivenessProbe livenessProbe;
+
     @Deprecated
     public ContainerTemplate(String image) {
         this(null, image);
@@ -149,6 +151,13 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
     @DataBoundSetter
     public void setEnvVars(List<ContainerEnvVar> envVars) {
         this.envVars.addAll(envVars);
+    }
+
+    public ContainerLivenessProbe getLivenessProbe() { return livenessProbe; }
+
+    @DataBoundSetter
+    public void setLivenessProbe(ContainerLivenessProbe livenessProbe) {
+        this.livenessProbe = livenessProbe;
     }
 
     public String getResourceRequestMemory() {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -28,6 +28,9 @@ import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
+import hudson.model.labels.LabelAtom;
+import io.fabric8.kubernetes.api.model.*;
+
 import org.apache.commons.lang.StringUtils;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.PodVolume;
 import org.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution;
@@ -380,6 +383,19 @@ public class KubernetesCloud extends Cloud {
             containerMounts.add(new VolumeMount(containerTemplate.getWorkingDir(), WORKSPACE_VOLUME_NAME, false, null));
         }
 
+        ContainerLivenessProbe clp = containerTemplate.getLivenessProbe();
+        Probe livenessProbe = null;
+        if(clp != null && parseLivenessProbe(clp.getExecArgs()) != null) {
+            livenessProbe = new ProbeBuilder()
+                    .withExec(new ExecAction(parseLivenessProbe(clp.getExecArgs())))
+                    .withInitialDelaySeconds(clp.getInitialDelaySeconds())
+                    .withTimeoutSeconds(clp.getTimeoutSeconds())
+                    .withFailureThreshold(clp.getFailureThreshold())
+                    .withPeriodSeconds(clp.getPeriodSeconds())
+                    .withSuccessThreshold(clp.getSuccessThreshold())
+                    .build();
+        }
+
         return new ContainerBuilder()
                 .withName(substituteEnv(containerTemplate.getName()))
                 .withImage(substituteEnv(containerTemplate.getImage()))
@@ -392,6 +408,7 @@ public class KubernetesCloud extends Cloud {
                 .addToEnv(envVars)
                 .withCommand(parseDockerCommand(containerTemplate.getCommand()))
                 .withArgs(arguments)
+                .withLivenessProbe(livenessProbe)
                 .withTty(containerTemplate.isTtyEnabled())
                 .withNewResources()
                     .withRequests(getResourcesMap(containerTemplate.getResourceRequestMemory(), containerTemplate.getResourceRequestCpu()))
@@ -519,7 +536,7 @@ public class KubernetesCloud extends Cloud {
 
     /**
      * Split a command in the parts that Docker need
-     * 
+     *
      * @param dockerCommand
      * @return
      */
@@ -536,6 +553,26 @@ public class KubernetesCloud extends Cloud {
         return commands;
     }
 
+    /**
+     * Split a command in the parts that LivenessProbe need
+     *
+     * @param livenessProbeExec
+     * @return
+     */
+    List<String> parseLivenessProbe(String livenessProbeExec) {
+        if (StringUtils.isBlank(livenessProbeExec)) {
+            return null;
+        }
+        // handle quoted arguments
+        Matcher m = SPLIT_IN_SPACES.matcher(livenessProbeExec);
+        List<String> commands = new ArrayList<String>();
+        while (m.find()) {
+            commands.add(substituteEnv(m.group(1).replace("\"", "").replace("?:\\\"", "")));
+        }
+        return commands;
+    }
+
+
     @Override
     public synchronized Collection<NodeProvisioner.PlannedNode> provision(@CheckForNull final Label label, final int excessWorkload) {
         try {
@@ -547,6 +584,7 @@ public class KubernetesCloud extends Cloud {
             ArrayList<PodTemplate> templates = getMatchingTemplates(label);
 
             for (PodTemplate t: templates) {
+                LOGGER.log(Level.INFO, "Template: " + t.getDisplayName());
                 for (int i = 1; i <= excessWorkload; i++) {
                     if (!addProvisionedSlave(t, label)) {
                         break;

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerLivenessProbe/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerLivenessProbe/config.jelly
@@ -1,0 +1,30 @@
+<!--
+  Config page
+-->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:entry field="execArgs" title="${%Exec action}">
+    <f:textbox/>
+  </f:entry>
+
+  <f:entry field="initialDelaySeconds" title="${%Initial Delay Seconds}">
+    <f:textbox/>
+  </f:entry>
+
+  <f:entry field="timeoutSeconds" title="${%Timeout Seconds}">
+    <f:textbox/>
+  </f:entry>
+
+  <f:entry field="failureThreshold" title="${%Failure Threshold}">
+    <f:textbox/>
+  </f:entry>
+
+  <f:entry field="periodSeconds" title="${%Period Seconds}">
+    <f:textbox/>
+  </f:entry>
+
+  <f:entry field="successThreshold" title="${%Success Threshold}">
+    <f:textbox/>
+  </f:entry>
+</j:jelly>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/config.jelly
@@ -39,6 +39,14 @@
                                   deleteCaption="Delete Environment Variable" />
     </f:entry>
 
+  <f:entry field="livenessProbe" title="${%Liveness Probe}">
+    <f:rowSet name="${field}">
+      <j:set var="descriptor" value="${attrs.propertyDescriptor ?: app.getDescriptorOrDie(descriptor.getPropertyTypeOrDie(instance,field).clazz)}" />
+      <j:set var="instance" value="${instance[field]}"/>
+      <st:include from="${descriptor}" page="${descriptor.configPage}" />
+    </f:rowSet>
+  </f:entry>
+
   <f:advanced>
     <f:entry field="privileged" title="${%Run in privileged mode}">
       <f:checkbox/>

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudTest.java
@@ -50,4 +50,14 @@ public class KubernetesCloudTest {
         assertEquals(ImmutableList.of("a", "b", "c", "d"), cloud.parseDockerCommand("a b c d"));
     }
 
+    @Test
+    public void testParseLivenessProbe() {
+        assertNull(cloud.parseLivenessProbe(""));
+        assertNull(cloud.parseLivenessProbe(null));
+        assertEquals(ImmutableList.of("docker","info"), cloud.parseLivenessProbe("docker info"));
+        assertEquals(ImmutableList.of("echo","I said: 'I am alive'"), cloud.parseLivenessProbe("echo \"I said: 'I am alive'\""));
+        assertEquals(ImmutableList.of("docker","--version"), cloud.parseLivenessProbe("docker --version"));
+        assertEquals(ImmutableList.of("curl","-k","--silent","--output=/dev/null","https://localhost:8080"), cloud.parseLivenessProbe("curl -k --silent --output=/dev/null \"https://localhost:8080\""));
+    }
+
 }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
@@ -204,6 +204,18 @@ public class KubernetesPipelineTest {
         r.assertLogContains(overriddenNamespace, b);
     }
 
+    @Test
+    public void runInPodWithLivenessProbe() throws Exception {
+        configureCloud(r);
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "pod with liveness probe");
+        p.setDefinition(new CpsFlowDefinition(loadPipelineScript("runInPodWithLivenessProbe.groovy")
+                , true));
+        WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+        assertNotNull(b);
+        r.assertBuildStatusSuccess(r.waitForCompletion(b));
+        r.assertLogContains("Still alive", b);
+    }
+
     // @Test
     public void runInPodWithRestart() throws Exception {
         story.addStep(new Statement() {

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runInPod.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runInPod.groovy
@@ -13,7 +13,5 @@ podTemplate(cloud: 'minikube', label: 'mypod', volumes: [emptyDirVolume(mountPat
                 sh 'mvn -version'
             }
         }
-
-
     }
 }

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runInPodWithLivenessProbe.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runInPodWithLivenessProbe.groovy
@@ -1,0 +1,13 @@
+podTemplate(cloud: 'minikube', label: 'mypod', volumes: [emptyDirVolume(mountPath: '/my-mount')], containers: [
+        containerTemplate(name: 'jnlp', image: 'jenkinsci/jnlp-slave:2.62-alpine', args: '${computer.jnlpmac} ${computer.name}'),
+        containerTemplate(name: 'busybox', image: 'busybox', ttyEnabled: true, command: 'cat', livenessProbe: containerLivenessProbe( execArgs: 'uname -a', initialDelaySeconds: 5, timeoutSeconds: 1, failureThreshold: 3, periodSeconds: 10, successThreshold: 1))
+]) {
+
+    node ('mypod') {
+        stage('Wait for Liveness Probe') {
+            container('busybox') {
+                sh 'sleep 6 && echo "Still alive"'
+            }
+        }
+    }
+}


### PR DESCRIPTION
The changes will allow to add a command liveness probe to a container. You can specify:

command to execute (does not support httpGet) - required field
timeout seconds
initial delay seconds
failure threshold
period seconds
success threshold