### PR TITLE
Adding simple repo field for custom jnlp image override. If there is a pod templa…

### DIFF
--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/config.jelly
@@ -9,14 +9,6 @@
       <f:textbox />
     </f:entry>
 
-    <f:entry title="${%Kubernetes server certificate key}" field="serverCertificate">
-      <f:textarea/>
-    </f:entry>
-
-    <f:entry title="${%Disable https certificate check}" field="skipTlsVerify">
-      <f:checkbox />
-    </f:entry>
-
     <f:entry title="${%Kubernetes Namespace}" field="namespace">
       <f:textbox default="default" />
     </f:entry>
@@ -25,7 +17,15 @@
       <c:select/>
     </f:entry>
 
-    <f:validateButton title="${%Test Connection}" progress="${%Testing...}" method="testConnection" with="serverUrl,credentialsId,serverCertificate,skipTlsVerify,namespace" />
+   <f:advanced>
+       <f:entry title="${%Kubernetes server certificate key}" field="serverCertificate">
+         <f:textarea/>
+       </f:entry>
+
+       <f:entry title="${%Disable https certificate check}" field="skipTlsVerify">
+         <f:checkbox />
+       </f:entry>
+    </f:advanced>
 
     <f:entry title="${%Jenkins URL}" field="jenkinsUrl">
       <f:textbox />
@@ -35,27 +35,33 @@
       <f:textbox />
     </f:entry>
 
-    <f:entry title="${%Connection Timeout (seconds)}" field="connectTimeout">
-        <f:textbox default="5"/>
+    <f:entry title="${%Default JNLP Image}" field="defaultJnlpImage">
+      <f:textbox default='jenkinsci/jnlp-slave:alpine'/>
     </f:entry>
 
-    <f:entry title="${%Read Timeout (seconds)}" field="readTimeout">
-        <f:textbox default="15"/>
-    </f:entry>
+   <f:advanced>
+       <f:entry title="${%Defaults Provider Template Name}" field="defaultsProviderTemplate">
+           <f:textbox default=""/>
+       </f:entry>
 
-    <f:entry title="${%Container Cap}" field="containerCapStr">
-        <f:textbox default="10"/>
-    </f:entry>
+       <f:entry title="${%Container Cap}" field="containerCapStr">
+            <f:textbox default="10"/>
+        </f:entry>
 
-    <f:advanced>
-      <f:entry title="${%Container Cleanup Timeout (minutes)}" field="retentionTimeout">
-        <f:textbox default="5"/>
-      </f:entry>
+       <f:entry title="${%Container Cleanup Timeout (minutes)}" field="retentionTimeout">
+         <f:textbox default="5"/>
+       </f:entry>
+
+       <f:entry title="${%Connection Timeout (seconds)}" field="connectTimeout">
+           <f:textbox default="5"/>
+       </f:entry>
+
+       <f:entry title="${%Read Timeout (seconds)}" field="readTimeout">
+           <f:textbox default="15"/>
+       </f:entry>
     </f:advanced>
 
-    <f:entry title="${%Defaults Provider Template Name}" field="defaultsProviderTemplate">
-        <f:textbox default=""/>
-    </f:entry>
+    <f:validateButton title="${%Test Connection}" progress="${%Testing...}" method="testConnection" with="serverUrl,credentialsId,serverCertificate,skipTlsVerify,namespace" />
 
     <f:entry title="${%Images}" description="${%List of Images to be launched as slaves}">
       <f:repeatableHeteroProperty field="templates" hasHeader="true" addCaption="Add Pod Template"

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/help-connectTimeout0.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/help-connectTimeout0.html
@@ -1,3 +1,0 @@
-<div>
-    (currently unused)
-</div>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/help-connectTimeout0.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/help-connectTimeout0.html
@@ -1,0 +1,3 @@
+<div>
+    (currently unused)
+</div>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/help-defaultJnlpImage.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/help-defaultJnlpImage.html
@@ -1,0 +1,6 @@
+<div>
+    Override For The Default JNLP Image.
+    <br>The JNLP Image establishes the primary connection between the Kubernetes Pod and the Jenkins Master.</br>
+    <br>If left blank, this will fallback to default. If a pod template is named JNLP, it will override this setting.</br>
+    <br>Default: jenkinsci/jnlp-slave:alpine</br>
+</div>


### PR DESCRIPTION
…te named jnlp, pod template will take priority over this option.

Purpose is to provide a quick high level setting to pull the custom jnlp image from the repo, without cluttering the UI with granular JNLP custom settings if it they are not needed. (In addition, custom jnlp route using the pod template did not seem to be pulling in annotations.) 

Re-worked the UI a little bit. 