### PR TITLE
Ignore Failed and Succeeded slaves in addProvisionedSlave

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
+import com.google.common.collect.Lists;
 import hudson.model.labels.LabelAtom;
 import io.fabric8.kubernetes.api.model.*;
 
@@ -788,8 +789,10 @@ public class KubernetesCloud extends Cloud {
         }
 
         KubernetesClient client = connect();
-        PodList slaveList = client.pods().inNamespace(template.getNamespace()).withLabels(POD_LABEL).list();
-        List<Pod> slaveListItems = slaveList.getItems();
+
+        List<Pod> slaveListItems = client.pods().inNamespace(template.getNamespace()).withLabels(POD_LABEL).list()
+                                  .getItems().stream().filter(pod -> !Lists.newArrayList("Failed", "Succeeded").contains(pod.getStatus().getPhase()))
+                                  .collect(Collectors.toList());
 
         Map<String, String> labelsMap = getLabelsMap(template.getLabelSet());
         PodList namedList = client.pods().inNamespace(template.getNamespace()).withLabels(labelsMap).list();


### PR DESCRIPTION
When checking we have not exceeded the container cap we should not consider
Failed or Succeeded slaves as they do not take up resources.  Not doing so means
you hit the container cap even when there are no active slaves present stopping
the plugin from creating new slaves.