### PR TITLE
Don't provision nodes if there are no PodTemplates set to usage mode Normal

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -833,7 +833,7 @@ public class KubernetesCloud extends Cloud {
     public ArrayList<PodTemplate> getMatchingTemplates(@CheckForNull Label label) {
         ArrayList<PodTemplate> podList = new ArrayList<PodTemplate>();
         for (PodTemplate t : templates) {
-            if (label == null || label.matches(t.getLabelSet())) {
+            if ((label == null && t.getNodeUsageMode() == Node.Mode.NORMAL) || (label != null && label.matches(t.getLabelSet()))) {
                 podList.add(t);
             }
         }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
@@ -212,7 +212,7 @@ public class PodTemplateUtils {
      */
     public static PodTemplate getTemplateByLabel(@CheckForNull Label label, Collection<PodTemplate> templates) {
         for (PodTemplate t : templates) {
-            if (label == null || label.matches(t.getLabelSet())) {
+            if ((label == null && t.getNodeUsageMode() == Node.Mode.NORMAL) || (label != null && label.matches(t.getLabelSet()))) {
                 return t;
             }
         }


### PR DESCRIPTION
This fixes an issue where if you only had PodTemplates defined that were set to usage mode Exclusive containers would get scheduled but Jenkins would be unable to schedule any jobs on them.

The Kubernetes plugin now returns false to canProvision() if it doesn't have any templates it can use and which can be used to schedule the requested workload.