### PR TITLE
delete the build pod after we have finished with the template block

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
@@ -130,6 +130,7 @@ public class PodTemplateStepExecution extends AbstractStepExecutionImpl {
             if (cloud instanceof KubernetesCloud) {
                 KubernetesCloud kubernetesCloud = (KubernetesCloud) cloud;
                 kubernetesCloud.removeTemplate(podTemplate);
+                kubernetesCloud.connect().pods().withName(podTemplate.getName()).delete();
             }
         }
     }


### PR DESCRIPTION
after using a build pod it can be common to wait for a pipeline approval, this change means the build pod doesn't hang around once we've finished with it