### PR TITLE
refactoring add/set methods

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -374,9 +374,17 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
     }
 
     @DataBoundSetter
-    public void setEnvVars(List<PodEnvVar> envVars) {
+    public void addEnvVars(List<PodEnvVar> envVars) {
         if (envVars != null) {
             this.envVars.addAll(envVars);
+        }
+    }
+
+    @DataBoundSetter
+    public void setEnvVars(List<PodEnvVar> envVars) {
+        if (envVars != null) {
+            this.envVars = new ArrayList<PodEnvVar>();
+            this.addEnvVars(envVars);
         }
     }
 
@@ -388,9 +396,19 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
     }
 
     @DataBoundSetter
-    public void setAnnotations(List<PodAnnotation> annotations) {
+    public void addAnnotations(List<PodAnnotation> annotations) {
         this.annotations.addAll(annotations);
     }
+
+
+    @DataBoundSetter
+    public void setAnnotations(List<PodAnnotation> annotations) {
+        if (annotations != null) {
+            this.annotations = new ArrayList<PodAnnotation>();
+            this.addAnnotations(annotations);
+        }
+    }
+
 
     public List<PodImagePullSecret> getImagePullSecrets() {
         if (imagePullSecrets == null) {
@@ -400,8 +418,16 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
     }
 
     @DataBoundSetter
-    public void setImagePullSecrets(List<PodImagePullSecret> imagePullSecrets) {
+    public void addImagePullSecrets(List<PodImagePullSecret> imagePullSecrets) {
         this.imagePullSecrets.addAll(imagePullSecrets);
+    }
+
+        @DataBoundSetter
+    public void setImagePullSecrets(List<PodImagePullSecret> imagePullSecrets) {
+        if(imagePullSecrets != null) {
+            this.imagePullSecrets = new ArrayList<PodImagePullSecret>();
+            this.addImagePullSecrets(imagePullSecrets);
+        }
     }
 
     @DataBoundSetter


### PR DESCRIPTION
**Changes**
Rename the methods
- setEnvVars 
- setAnnotations
- setImagePullSecrets
to use `add` syntax

- added methods for setting. i.e. overwrite the existing array.

**Motivation**
The names of the methods currently `set<Object>` indicates that you are setting a new value rather than adding to an existing array.
