### PR TITLE
Fix: Spaces in Jenkins project name

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubectlBuildWrapper.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubectlBuildWrapper.java
@@ -101,8 +101,8 @@ public class KubectlBuildWrapper extends SimpleBuildWrapper {
         }
 
         int status = launcher.launch()
-                .cmdAsSingleString("kubectl config --kubeconfig=" + configFile.getRemote()
-                        + " set-cluster k8s --server=" + serverUrl + tlsConfig)
+                .cmdAsSingleString("kubectl config --kubeconfig=\"" + configFile.getRemote()
+                        + "\" set-cluster k8s --server=" + serverUrl + tlsConfig)
                 .join();
         if (status != 0) throw new IOException("Failed to run kubectl config "+status);
 
@@ -150,18 +150,18 @@ public class KubectlBuildWrapper extends SimpleBuildWrapper {
         }
 
         status = launcher.launch()
-                .cmdAsSingleString("kubectl config --kubeconfig=" + configFile.getRemote() + " set-credentials cluster-admin " + login)
+                .cmdAsSingleString("kubectl config --kubeconfig=\"" + configFile.getRemote() + "\" set-credentials cluster-admin " + login)
                 .masks(false, false, false, false, false, false, true)
                 .join();
         if (status != 0) throw new IOException("Failed to run kubectl config "+status);
 
         status = launcher.launch()
-                .cmdAsSingleString("kubectl config --kubeconfig=" + configFile.getRemote() + " set-context k8s --cluster=k8s --user=cluster-admin")
+                .cmdAsSingleString("kubectl config --kubeconfig=\"" + configFile.getRemote() + "\" set-context k8s --cluster=k8s --user=cluster-admin")
                 .join();
         if (status != 0) throw new IOException("Failed to run kubectl config "+status);
 
         status = launcher.launch()
-                .cmdAsSingleString("kubectl config --kubeconfig=" + configFile.getRemote() + " use-context k8s")
+                .cmdAsSingleString("kubectl config --kubeconfig=\"" + configFile.getRemote() + "\" use-context k8s")
                 .join();
         if (status != 0) throw new IOException("Failed to run kubectl config "+status);
 


### PR DESCRIPTION
Where your Jenkins project contains spaces, the temporary kubectl config file will also create spaces.  The file location need to be wrapped in quotes to work with the kubectl shell commands.
For example: 
kubectl config --kubeconfig="My Jenkins Project/.kube8017077765813839285config" use-context k8s
rather than:
kubectl config --kubeconfig=My Jenkins Project/.kube8017077765813839285config use-context k8s