### PR TITLE
JENKINS-40825 close resource leak, fix broken pipe error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <jackson.version>2.5.0</jackson.version>
     <jenkins.version>2.32.1</jenkins.version>
 
-    <kubernetes-client.version>2.3.1</kubernetes-client.version>
+    <kubernetes-client.version>2.5.8</kubernetes-client.version>
     <spring.version>3.2.14.RELEASE</spring.version>
     <slf4j.version>1.7.7</slf4j.version>
     <hamcrest.version>1.3</hamcrest.version>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <jackson.version>2.5.0</jackson.version>
     <jenkins.version>2.32.1</jenkins.version>
 
-    <kubernetes-client.version>2.5.8</kubernetes-client.version>
+    <kubernetes-client.version>2.6.1</kubernetes-client.version>
     <spring.version>3.2.14.RELEASE</spring.version>
     <slf4j.version>1.7.7</slf4j.version>
     <hamcrest.version>1.3</hamcrest.version>

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFactoryAdapter.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFactoryAdapter.java
@@ -126,12 +126,10 @@ public class KubernetesFactoryAdapter {
             // JENKINS-38829 CaCertData expects a Base64 encoded certificate
             builder.withCaCertData(Base64.encodeBase64String(caCertData.getBytes(UTF_8)));
         }
-        LOGGER.log(Level.FINE, "Creating Kubernetes client: {0}", this.toString());
-        DefaultKubernetesClient client = new DefaultKubernetesClient(builder.build());
+        builder.withMaxConcurrentRequestsPerHost(maxRequestsPerHost);
 
-        // TODO when Config gets a maxRequestsPerHost setting, use that instead
-        client.getHttpClient().dispatcher().setMaxRequestsPerHost(maxRequestsPerHost);
-        return client;
+        LOGGER.log(Level.FINE, "Creating Kubernetes client: {0}", this.toString());
+        return new DefaultKubernetesClient(builder.build());
     }
 
     private static String pemEncodeKey(Key key) {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -37,6 +37,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import hudson.FilePath;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.fabric8.kubernetes.client.KubernetesClientTimeoutException;
 import org.apache.commons.io.output.TeeOutputStream;
 
@@ -70,6 +71,8 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
     private static final Logger LOGGER = Logger.getLogger(ContainerExecDecorator.class.getName());
 
     private final transient KubernetesClient client;
+
+    @SuppressFBWarnings(value = "SE_TRANSIENT_FIELD_NOT_RESTORED", justification = "not needed on deserialization")
     private final transient List<Closeable> closables = new ArrayList<>();
     private final String podName;
     private final String namespace;

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -19,6 +19,7 @@ package org.csanchez.jenkins.plugins.kubernetes.pipeline;
 import static org.csanchez.jenkins.plugins.kubernetes.pipeline.Constants.*;
 
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.Serializable;
@@ -175,7 +176,7 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
                     started.await();
                 } catch (InterruptedException e) {
                     closeWatch(watch);
-                    throw new IOException("interrupted while waiting for websocket connection");
+                    throw new InterruptedIOException("interrupted while waiting for websocket connection");
                 }
 
                 try {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -261,7 +261,7 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
             // We need to exit so that we know when the command has finished.
             sb.append(ExitCodeOutputStream.EXIT_COMMAND);
             out.print(ExitCodeOutputStream.EXIT_COMMAND);
-            LOGGER.log(Level.FINEST, "Executing command: {0}", sb.toString());
+            LOGGER.log(Level.FINEST, "Executing command: {0}", sb);
             watch.getInput().write(ExitCodeOutputStream.EXIT_COMMAND.getBytes(StandardCharsets.UTF_8));
 
             out.flush();

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -37,6 +37,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import hudson.FilePath;
+import io.fabric8.kubernetes.client.KubernetesClientTimeoutException;
 import org.apache.commons.io.output.TeeOutputStream;
 
 import com.google.common.io.NullOutputStream;
@@ -233,10 +234,10 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
                 try {
                     client.pods().inNamespace(namespace).withName(podName)
                             .waitUntilReady(CONTAINER_READY_TIMEOUT, TimeUnit.MINUTES);
-                } catch (InterruptedException e) {
-                    throw new InterruptedIOException("Failed to execute shell script inside container " +
+                } catch (InterruptedException | KubernetesClientTimeoutException e) {
+                    throw new IOException("Failed to execute shell script inside container " +
                             "[" + containerName + "] of pod [" + podName + "]." +
-                            " Timed out waiting for container to become ready!");
+                            " Timed out waiting for container to become ready!", e);
                 }
             }
         };

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -257,7 +257,7 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
             out.println();
             watch.getInput().write(NEWLINE.getBytes(StandardCharsets.UTF_8));
 
-            // get the command exit code and print it padded so it is easier to parse in ConatinerExecProc
+            // get the command exit code and print it padded so it is easier to parse in ContainerExecProc
             // We need to exit so that we know when the command has finished.
             sb.append(ExitCodeOutputStream.EXIT_COMMAND);
             out.print(ExitCodeOutputStream.EXIT_COMMAND);

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecProc.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecProc.java
@@ -64,17 +64,21 @@ public class ContainerExecProc extends Proc {
 
     @Override
     public int join() throws IOException, InterruptedException {
-        LOGGER.log(Level.FINEST, "Waiting for websocket to close on command finish ({0})", finished);
-        finished.await();
-        LOGGER.log(Level.FINEST, "Command is finished ({0})", finished);
         try {
+            LOGGER.log(Level.FINEST, "Waiting for websocket to close on command finish ({0})", finished);
+            finished.await();
+            LOGGER.log(Level.FINEST, "Command is finished ({0})", finished);
             return exitCode.call();
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Error getting exit code", e);
             return -1;
         } finally {
             //We are calling explicitly close, in order to cleanup websockets and threads (are not closed implicitly).
-            watch.close();
+            try {
+                watch.close();
+            } catch (Exception e) {
+                LOGGER.log(Level.INFO, "failed to close watch", e);
+            }
         }
     }
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecProc.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecProc.java
@@ -2,6 +2,7 @@ package org.csanchez.jenkins.plugins.kubernetes.pipeline;
 
 import static org.csanchez.jenkins.plugins.kubernetes.pipeline.Constants.*;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -19,7 +20,7 @@ import io.fabric8.kubernetes.client.dsl.ExecWatch;
  * Handle the liveness of the processes executed in containers, wait for them to finish and process exit codes.
  *
  */
-public class ContainerExecProc extends Proc {
+public class ContainerExecProc extends Proc implements Closeable {
 
     private static final Logger LOGGER = Logger.getLogger(ContainerExecProc.class.getName());
 
@@ -59,6 +60,8 @@ public class ContainerExecProc extends Proc {
             watch.getInput().flush();
         } catch (IOException e) {
             LOGGER.log(Level.FINE, "Proc kill failed, ignoring", e);
+        } finally {
+            close();
         }
     }
 
@@ -73,12 +76,7 @@ public class ContainerExecProc extends Proc {
             LOGGER.log(Level.WARNING, "Error getting exit code", e);
             return -1;
         } finally {
-            //We are calling explicitly close, in order to cleanup websockets and threads (are not closed implicitly).
-            try {
-                watch.close();
-            } catch (Exception e) {
-                LOGGER.log(Level.INFO, "failed to close watch", e);
-            }
+            close();
         }
     }
 
@@ -97,4 +95,13 @@ public class ContainerExecProc extends Proc {
         return watch.getInput();
     }
 
+    @Override
+    public void close() throws IOException {
+        try {
+            //We are calling explicitly close, in order to cleanup websockets and threads (are not closed implicitly).
+            watch.close();
+        } catch (Exception e) {
+            LOGGER.log(Level.INFO, "failed to close watch", e);
+        }
+    }
 }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerStepExecution.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerStepExecution.java
@@ -61,7 +61,7 @@ public class ContainerStepExecution extends AbstractStepExecutionImpl {
         getContext().newBodyInvoker()
                 .withContext(BodyInvoker
                         .mergeLauncherDecorators(getContext().get(LauncherDecorator.class), decorator))
-                .withCallback(new ContainerExecCallback(decorator))
+                .withCallback(new ContainerExecCallback())
                 .start();
         return false;
     }
@@ -69,7 +69,7 @@ public class ContainerStepExecution extends AbstractStepExecutionImpl {
     @Override
     public void stop(Throwable cause) throws Exception {
         LOGGER.log(Level.FINE, "Stopping container step.");
-        closeQuietly(client, decorator);
+        closeQuietly(client);
     }
 
     private void closeQuietly(Closeable... closeables) {

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/config.jelly
@@ -47,6 +47,10 @@
         <f:textbox default="10"/>
     </f:entry>
 
+    <f:entry title="${%Max connections to Kubernetes API}" field="maxRequestsPerHostStr">
+        <f:textbox default="32"/>
+    </f:entry>
+
     <f:advanced>
       <f:entry title="${%Container Cleanup Timeout (minutes)}" field="retentionTimeout">
         <f:textbox default="5"/>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/help-maxRequestsPerHostStr.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/help-maxRequestsPerHostStr.html
@@ -1,0 +1,3 @@
+<div>
+    The maximum number of concurrent requests to the Kubernetes API. If you set this too low, you might run into <a href="https://issues.jenkins-ci.org/browse/JENKINS-40825">JENKINS-40825</a>.
+</div>


### PR DESCRIPTION
# resource leak

First of all, `Launcher.launch` is called not once, but again and again.
I.e. overwriting shared members of the enclosing class that a different
thread is still using (and only cleaning the ones that were written last).
That is a bad idea, and caused the thread and connection leak.

So, move them (`watch` and `proc`) to local variables, and close them
elsewhere:
* `watch` was already cleaned up in `ContainerExecProc`
* `proc.kill()` was not correctly executed anyway, and this is still broken. See discussion below.

# pipe not connected

Second of all, `waitQuietly` on the `started` latch was what caused
the "pipe not connected" errors:

In case of InterruptedException, it caused the launcher to just continue
as if `started` had already been counted down (i.e. the websocket connection
established), when in reality the thread  just interrupted itself because of a timeout
(probably from [`DurableTaskStep.check()`][1]).

# still TODO: `proc.kill` when step is interrupted

If the `sh` step inside `container` is interrupted, `DefaultStepContext` will create a new `Launcher` and `DurableTaskStep` will call `kill` on it - not call `kill` on existing `procs` that have finished (or not). If that one does not kill the process (which `DurableTaskStep` checks), `ContainerStepExecution.stop` will also not be called. 

Keeping a single reference of `proc` around and calling `kill` on it when `ContainerStepExecution.stop` is called (that is what the current master does) would not work anyway.

This is because both `ContainerExecDecorator.decorate` and `Launcher.launch` are called multiple times (at least to start the actual script, and then to run a number of `ps` executions every 10 seconds to check on the process) - so we are very likely to call kill on the wrong instance.

Even if we keep track of all the `procs` we created - how will we know which is the right one?

The "right" solution is one like in [the Docker Pipeline Plugin](https://github.com/jenkinsci/docker-workflow-plugin/blob/master/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java#L249):
I.e. open a new connection to the container, find the right process to kill (using the environment variable `JENKINS_SERVER_COOKIE=durable*`, and kill it.

I can implement that solution, but as it has little to do with JENKINS-40825, do you want it on a new pull request?

Sorry for writing such a "novel", I hope I can make myself clear.

[1]: https://github.com/jenkinsci/workflow-durable-task-step-plugin/blob/workflow-durable-task-step-2.13/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java#L303