### PR TITLE
Allow to create non-configurable instances programmatically.

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -30,6 +30,7 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.servlet.ServletException;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
 import org.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution;
@@ -147,6 +148,28 @@ public class KubernetesCloud extends Cloud {
     @DataBoundConstructor
     public KubernetesCloud(String name) {
         super(name);
+    }
+
+    /**
+     * Copy constructor.
+     * Allows to create copies of the original kubernetes cloud. Since it's a singleton
+     * by design, this method also allows specifying a new name.
+     * @param name Name of the cloud to be created
+     * @param source Source Kubernetes cloud implementation
+     * @since 0.13
+     */
+    public KubernetesCloud(@NonNull String name, @NonNull KubernetesCloud source) {
+        super(name);
+        this.defaultsProviderTemplate = source.defaultsProviderTemplate;
+        this.templates.addAll(source.templates);
+        this.serverUrl = source.serverUrl;
+        this.skipTlsVerify = source.skipTlsVerify;
+        this.namespace = source.namespace;
+        this.jenkinsUrl = source.jenkinsUrl;
+        this.credentialsId = source.credentialsId;
+        this.containerCap = source.containerCap;
+        this.retentionTimeout = source.retentionTimeout;
+        this.connectTimeout = source.connectTimeout;
     }
 
     @Deprecated

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/NonConfigurableKubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/NonConfigurableKubernetesCloud.java
@@ -1,0 +1,48 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.model.Descriptor;
+import hudson.model.DescriptorVisibilityFilter;
+import hudson.slaves.Cloud;
+import jenkins.model.Jenkins;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.StaplerRequest;
+
+public class NonConfigurableKubernetesCloud extends KubernetesCloud {
+    public NonConfigurableKubernetesCloud(@NonNull String name, @NonNull KubernetesCloud source) {
+        super(name, source);
+    }
+
+    @Extension
+    public static class FilterImpl extends DescriptorVisibilityFilter {
+        @Override
+        public boolean filter(Object context, Descriptor descriptor) {
+            return !(descriptor instanceof DescriptorImpl);
+        }
+    }
+
+    @Extension
+    public static class DescriptorImpl extends KubernetesCloud.DescriptorImpl {
+        @Override
+        public String getDisplayName() {
+            return Messages.NonConfigurableKubernetesCloud_displayName();
+        }
+
+        @Override
+        public boolean configure(StaplerRequest request, JSONObject object) throws Descriptor.FormException {
+            return true;
+        }
+
+        @Override
+        public Cloud newInstance(StaplerRequest req, JSONObject formData) throws Descriptor.FormException {
+            if (req != null) {
+                // We prevent the cloud reconfiguration from the web UI
+                String cloudName = req.getParameter("cloudName");
+                return Jenkins.getInstance().getCloud(cloudName);
+            } else {
+                throw new IllegalStateException("Expecting req to be non-null");
+            }
+        }
+    }
+}

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/Messages.properties
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/Messages.properties
@@ -1,1 +1,2 @@
 offline=Kubernetes agent is going offline
+NonConfigurableKubernetesCloud.displayName=Kubernetes (predefined settings)

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/NonConfigurableKubernetesCloud/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/NonConfigurableKubernetesCloud/config.jelly
@@ -1,0 +1,6 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
+  <f:invisibleEntry title="${%Cloud name}">
+    <f:readOnlyTextbox name="cloudName" value="${instance.displayName}"/>
+  </f:invisibleEntry>
+</j:jelly>


### PR DESCRIPTION
The idea behind this change is to manage configuration of Kubernetes Cloud through other means than the UI, in the context of multiple Jenkins instance infrastructure, and prevent the configuration from being modified when accessing the Manage Jenkins/Configure system page.