### PR TITLE
Substitute env variables in cloud config

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
@@ -354,7 +354,9 @@ public class KubernetesLauncher extends JNLPLauncher {
             );
         }
 
-        EnvVar[] envVars = envVarsMap.values().stream().toArray(EnvVar[]::new);
+        EnvVar[] envVars = envVarsMap.values().stream()
+                .map(entry -> new EnvVar(entry.getName(), substituteEnv(entry.getValue()), entry.getValueFrom()))
+                .toArray(EnvVar[]::new);
 
         List<String> arguments = Strings.isNullOrEmpty(containerTemplate.getArgs()) ? Collections.emptyList()
                 : parseDockerCommand(containerTemplate.getArgs() //


### PR DESCRIPTION
So env variables can be used in cloud configuration to define jenkins url or default namespace for instance.
This is so we can use the same jenkins config for different environments.