### PR TITLE
Fix #162 error PodEnvVar is missing its descriptor

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerEnvVar.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerEnvVar.java
@@ -23,12 +23,16 @@ public class ContainerEnvVar extends KeyValueEnvVar {
         return "ContainerEnvVar [getValue()=" + getValue() + ", getKey()=" + getKey() + "]";
     }
 
+    public Descriptor<KeyValueEnvVar> getDescriptor() {
+        return new DescriptorImpl();
+    }
+
     @Extension
     @Symbol("containerEnvVar")
     /**
      * deprecated, use envVar
      */
-    public static class DescriptorImplContainer extends Descriptor<KeyValueEnvVar> {
+    public static class DescriptorImpl extends Descriptor<KeyValueEnvVar> {
         @Override
         public String getDisplayName() {
             return "Environment Variable";

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodEnvVar.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodEnvVar.java
@@ -1,13 +1,19 @@
 package org.csanchez.jenkins.plugins.kubernetes;
 
 import org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
 
 /**
  * Deprecated, use KeyValueEnvVar
  */
 @Deprecated
 public class PodEnvVar extends KeyValueEnvVar {
+
+    private static final long serialVersionUID = 5426623531408300311L;
 
     @DataBoundConstructor
     public PodEnvVar(String key, String value) {
@@ -17,5 +23,18 @@ public class PodEnvVar extends KeyValueEnvVar {
     @Override
     public String toString() {
         return "PodEnvVar [getValue()=" + getValue() + ", getKey()=" + getKey() + "]";
+    }
+
+    public Descriptor<KeyValueEnvVar> getDescriptor() {
+        return new DescriptorImpl();
+    }
+
+    @Extension
+    @Symbol("podEnvVar")
+    public static class DescriptorImpl extends Descriptor<KeyValueEnvVar> {
+        @Override
+        public String getDisplayName() {
+            return "Global Environment Variable (applied to all containers)";
+        }
     }
 }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 import org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.EmptyDirVolume;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.HostPathVolume;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -47,22 +48,28 @@ public class KubernetesTest {
     @Rule
     public JenkinsRule r = new JenkinsRule();
 
-    @Test
-    @LocalData()
-    public void upgradeFrom_0_8() {
-        KubernetesCloud cloud = r.jenkins.clouds.get(KubernetesCloud.class);
-        List<PodTemplate> templates = cloud.getTemplates();
-        assertPodTemplates(templates);
+    private KubernetesCloud cloud;
+
+    @Before
+    public void before() throws Exception {
+        cloud = r.jenkins.clouds.get(KubernetesCloud.class);
+        r.configRoundtrip();
     }
 
     @Test
     @LocalData()
-    public void upgradeFrom_0_12() {
-        KubernetesCloud cloud = r.jenkins.clouds.get(KubernetesCloud.class);
+    public void upgradeFrom_0_12() throws Exception {
         List<PodTemplate> templates = cloud.getTemplates();
         assertPodTemplates(templates);
         assertEquals(Arrays.asList(new KeyValueEnvVar("pod_a_key", "pod_a_value"),
                 new KeyValueEnvVar("pod_b_key", "pod_b_value")), templates.get(0).getEnvVars());
+    }
+
+    @Test
+    @LocalData()
+    public void upgradeFrom_0_8() throws Exception {
+        List<PodTemplate> templates = cloud.getTemplates();
+        assertPodTemplates(templates);
     }
 
     private void assertPodTemplates(List<PodTemplate> templates) {

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest/upgradeFrom_0_12/config.xml
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest/upgradeFrom_0_12/config.xml
@@ -5,13 +5,8 @@
   <numExecutors>2</numExecutors>
   <mode>NORMAL</mode>
   <useSecurity>true</useSecurity>
-  <authorizationStrategy class="hudson.security.FullControlOnceLoggedInAuthorizationStrategy">
-    <denyAnonymousReadAccess>true</denyAnonymousReadAccess>
-  </authorizationStrategy>
-  <securityRealm class="hudson.security.HudsonPrivateSecurityRealm">
-    <disableSignup>true</disableSignup>
-    <enableCaptcha>false</enableCaptcha>
-  </securityRealm>
+  <authorizationStrategy class="hudson.security.AuthorizationStrategy$Unsecured"/>
+  <securityRealm class="hudson.security.SecurityRealm$None"/>
   <disableRememberMe>false</disableRememberMe>
   <projectNamingStrategy class="jenkins.model.ProjectNamingStrategy$DefaultProjectNamingStrategy"/>
   <workspaceDir>/var/jenkins_home/workspace/</workspaceDir>


### PR DESCRIPTION
Upgrading from 0.12 causes
class org.csanchez.jenkins.plugins.kubernetes.PodEnvVar is missing its descriptor