### PR TITLE
Enable setting slaveConnectTimeout in podTemplate defined in pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Either way it provides access to the following fields:
 * **imagePullSecrets** List of pull secret names
 * **annotations** Annotations to apply to the pod.
 * **inheritFrom** List of one or more pod templates to inherit from *(more details below)*.
+* **slaveConnectTimeout** Timeout in seconds for a slave to be online.
 
 The `containerTemplate` is a template of container that will be added to the pod. Again, its configurable via the user interface or via pipeline and allows you to set the following fields:
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep.java
@@ -47,6 +47,7 @@ public class PodTemplateStep extends Step implements Serializable {
 
     private int instanceCap = Integer.MAX_VALUE;
     private int idleMinutes;
+    private int slaveConnectTimeout;
 
     private String serviceAccount;
     private String nodeSelector;
@@ -149,6 +150,15 @@ public class PodTemplateStep extends Step implements Serializable {
     @DataBoundSetter
     public void setIdleMinutes(int idleMinutes) {
         this.idleMinutes = idleMinutes;
+    }
+
+    public int getSlaveConnectTimeout() {
+        return slaveConnectTimeout;
+    }
+
+    @DataBoundSetter
+    public void setSlaveConnectTimeout(int slaveConnectTimeout) {
+        this.slaveConnectTimeout = slaveConnectTimeout;
     }
 
     public String getServiceAccount() {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
@@ -64,6 +64,7 @@ public class PodTemplateStepExecution extends AbstractStepExecutionImpl {
         newTemplate.setInheritFrom(!Strings.isNullOrEmpty( podTemplateAction.getParentTemplates()) ? podTemplateAction.getParentTemplates() : step.getInheritFrom());
         newTemplate.setInstanceCap(step.getInstanceCap());
         newTemplate.setIdleMinutes(step.getIdleMinutes());
+        newTemplate.setSlaveConnectTimeout(step.getSlaveConnectTimeout());
         newTemplate.setLabel(step.getLabel());
         newTemplate.setEnvVars(step.getEnvVars());
         newTemplate.setVolumes(step.getVolumes());


### PR DESCRIPTION
This PR enable to redefine default slaveConnectTimeout for podTemplate declared in pipeline, eg.
```
podTemplate(
    label: 'mypod', 
    containers: [
        containerTemplate(name: 'busybox', image: 'busybox', ttyEnabled: true, command: '/bin/cat'),
    ],
    slaveConnectTimeout: 200
) {
    node ('mypod') {
        stage('Run') {
            container('busybox') {
                sh 'echo "pwd is -$(pwd)-"'
            }
        }
    }
}
```