### PR TITLE
Remove unneeded dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,47 +87,27 @@
       <version>${jenkins-credentials.version}</version>
     </dependency>
 
-    <dependency>
+    <dependency> <!-- OnceRetentionStrategy -->
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>durable-task</artifactId>
       <version>${jenkins-durable-task.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-durable-task-step</artifactId>
-      <version>${jenkins-durable-task-step.version}</version>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>variant</artifactId>
+      <version>1.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
       <version>${jenkins-workflow-step-api.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-cps</artifactId>
-      <version>${jenkins-workflow-cps.version}</version>
-    </dependency>
-    <dependency>
+    <dependency> <!-- DeclarativeAgent -->
       <groupId>org.jenkinsci.plugins</groupId>
       <artifactId>pipeline-model-extensions</artifactId>
       <version>${jenkins-declarative.version}</version>
+      <optional>true</optional>
     </dependency>
-    <dependency>
-      <groupId>org.jenkinsci.plugins</groupId>
-      <artifactId>pipeline-model-api</artifactId>
-      <version>${jenkins-declarative.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>script-security</artifactId>
-      <version>${jenkins-script-security.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-support</artifactId>
-      <version>${jenkins-workflow-support.version}</version>
-    </dependency>
-
 
     <!-- for testing -->
     <dependency>
@@ -147,6 +127,18 @@
       <artifactId>workflow-step-api</artifactId>
       <version>${jenkins-workflow-step-api.version}</version>
       <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-support</artifactId>
+      <version>${jenkins-workflow-support.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-durable-task-step</artifactId>
+      <version>${jenkins-durable-task-step.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency> <!-- SemaphoreStep -->
@@ -178,6 +170,12 @@
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-api</artifactId>
       <version>${jenkins-workflow-api.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-cps</artifactId>
+      <version>${jenkins-workflow-cps.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgent.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgent.java
@@ -1,11 +1,11 @@
 package org.csanchez.jenkins.plugins.kubernetes.pipeline;
 
-import hudson.Extension;
 import org.apache.commons.lang.StringUtils;
 import org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgent;
 import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentDescriptor;
+import org.jenkinsci.plugins.variant.OptionalExtension;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
@@ -123,7 +123,7 @@ public class KubernetesDeclarativeAgent extends DeclarativeAgent<KubernetesDecla
         return argMap;
     }
 
-    @Extension @Symbol("kubernetes")
+    @OptionalExtension(requirePlugins = "pipeline-model-extensions") @Symbol("kubernetes")
     public static class DescriptorImpl extends DeclarativeAgentDescriptor<KubernetesDeclarativeAgent> {
     }
 }


### PR DESCRIPTION
There are a number of dependencies declared by the plugin which are actually not required, or that can be made optional.

Here is a recap of the list of changes

Moved to test scope:
* `workflow-cps`
* `workflow-durable-task-step`
* `workflow-support`

Moved to optional
* `pipeline-model-extensions`
-> This requires to add a dependency to `variant` in order to leverage `@OptionalExtension`

Removed
* `pipeline-model-api` as the plugin doesn't depend on it explicitly (only through `pipeline-model-extensions`)