### PR TITLE
JENKINS-46670: Escape quotes in environment variables

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -57,7 +57,6 @@ import io.fabric8.kubernetes.client.dsl.Execable;
 import io.fabric8.kubernetes.client.dsl.ExecListener;
 import io.fabric8.kubernetes.client.dsl.ExecWatch;
 import okhttp3.Response;
-import org.apache.commons.lang.StringEscapeUtils;
 import org.jenkinsci.plugins.workflow.steps.EnvironmentExpander;
 
 /**
@@ -245,9 +244,14 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
             private void setupEnvironmentVariable(EnvVars vars, ExecWatch watch) throws IOException
             {
                 for (Map.Entry<String, String> entry : vars.entrySet()) {
-                         watch.getInput().write(
-                                 String.format("export %s=\"%s\"%s", entry.getKey(), StringEscapeUtils.escapeJava(entry.getValue()), NEWLINE).getBytes(StandardCharsets.UTF_8));
-                     }
+                    watch.getInput().write(
+                            String.format(
+                                    "export %s='%s'\n",
+                                    entry.getKey(),
+                                    entry.getValue().replace("'", "'\\''")
+                            ).getBytes(StandardCharsets.UTF_8)
+                    );
+                }
             }
 
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -246,9 +246,10 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
                 for (Map.Entry<String, String> entry : vars.entrySet()) {
                     watch.getInput().write(
                             String.format(
-                                    "export %s='%s'\n",
+                                    "export %s='%s'%s",
                                     entry.getKey(),
-                                    entry.getValue().replace("'", "'\\''")
+                                    entry.getValue().replace("'", "'\\''"),
+                                    NEWLINE
                             ).getBytes(StandardCharsets.UTF_8)
                     );
                 }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -57,6 +57,7 @@ import io.fabric8.kubernetes.client.dsl.Execable;
 import io.fabric8.kubernetes.client.dsl.ExecListener;
 import io.fabric8.kubernetes.client.dsl.ExecWatch;
 import okhttp3.Response;
+import org.apache.commons.lang.StringEscapeUtils;
 import org.jenkinsci.plugins.workflow.steps.EnvironmentExpander;
 
 /**
@@ -205,6 +206,7 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
                         // The workspace is not known in advance, so we have to execute a cd command.
                         watch.getInput().write(
                                 String.format("cd \"%s\"%s", pwd, NEWLINE).getBytes(StandardCharsets.UTF_8));
+
                     }
 
                     if (environmentExpander != null) {
@@ -212,7 +214,7 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
                         environmentExpander.expand(envVars);
                         for (Map.Entry<String, String> entry : envVars.entrySet()) {
                             watch.getInput().write(
-                                    String.format("export %s=\"%s\"%s", entry.getKey(), entry.getValue(), NEWLINE).getBytes(StandardCharsets.UTF_8));
+                                    String.format("export %s=\"%s\"%s", entry.getKey(),  StringEscapeUtils.escapeJavaScript(entry.getValue()), NEWLINE).getBytes(StandardCharsets.UTF_8));
                         }
                     }
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -212,10 +212,7 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
                     if (environmentExpander != null) {
                         EnvVars envVars = new EnvVars();
                         environmentExpander.expand(envVars);
-                        for (Map.Entry<String, String> entry : envVars.entrySet()) {
-                            watch.getInput().write(
-                                    String.format("export %s=\"%s\"%s", entry.getKey(),  StringEscapeUtils.escapeJavaScript(entry.getValue()), NEWLINE).getBytes(StandardCharsets.UTF_8));
-                        }
+                        this.setupEnvironmentVariable(envVars, watch);
                     }
 
                     doExec(watch, printStream, commands);
@@ -244,6 +241,15 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
 
                 getListener().getLogger().println("kill finished with exit code " + exitCode);
             }
+
+            private void setupEnvironmentVariable(EnvVars vars, ExecWatch watch) throws IOException
+            {
+                for (Map.Entry<String, String> entry : vars.entrySet()) {
+                         watch.getInput().write(
+                                 String.format("export %s=\"%s\"%s", entry.getKey(), StringEscapeUtils.escapeJava(entry.getValue()), NEWLINE).getBytes(StandardCharsets.UTF_8));
+                     }
+            }
+
 
 
             private boolean isContainerReady(Pod pod, String container) {

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
@@ -131,6 +131,10 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
         r.assertBuildStatusSuccess(r.waitForCompletion(b));
         r.assertLogNotContains("The value of FROM_ENV_DEFINITION is ABC", b);
         r.assertLogContains("The value of FROM_WITHENV_DEFINITION is DEF", b);
+        r.assertLogContains("The value of WITH_QUOTE is \"WITH_QUOTE", b);
+        r.assertLogContains("The value of AFTER_QUOTE is AFTER_QUOTE\"", b);
+        r.assertLogContains("The value of ESCAPED_QUOTE is \\\"ESCAPED_QUOTE", b);
+        r.assertLogContains("The value of AFTER_ESCAPED_QUOTE is AFTER_ESCAPED_QUOTE\\\"", b);
     }
 
     @Test

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
@@ -135,6 +135,8 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
         r.assertLogContains("The value of AFTER_QUOTE is AFTER_QUOTE\"", b);
         r.assertLogContains("The value of ESCAPED_QUOTE is \\\"ESCAPED_QUOTE", b);
         r.assertLogContains("The value of AFTER_ESCAPED_QUOTE is AFTER_ESCAPED_QUOTE\\\"", b);
+        r.assertLogContains("The value of SINGLE_QUOTE is BEFORE'AFTER", b);
+        r.assertLogContains("The value of WITH_NEWLINE is before newline\nafter newline", b);
     }
 
     @Test

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runWithEnvVarsFromContext.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runWithEnvVarsFromContext.groovy
@@ -1,3 +1,4 @@
+//noinspection GrPackage
 podTemplate(label: 'mypod',
     containers: [
         containerTemplate(name: 'busybox', image: 'busybox', ttyEnabled: true, command: '/bin/cat'),
@@ -6,22 +7,27 @@ podTemplate(label: 'mypod',
     env.FROM_ENV_DEFINITION = "ABC"
     node ('mypod') {
         stage('Run busybox') {
-            withEnv(['FROM_WITHENV_DEFINITION=DEF',
-            'WITH_QUOTE="WITH_QUOTE',
-            'AFTER_QUOTE=AFTER_QUOTE"',
-            'ESCAPED_QUOTE=\\"ESCAPED_QUOTE',
-            'AFTER_ESCAPED_QUOTE=AFTER_ESCAPED_QUOTE\\"'
+            withEnv([
+                    'FROM_WITHENV_DEFINITION=DEF',
+                    'WITH_QUOTE="WITH_QUOTE',
+                    'AFTER_QUOTE=AFTER_QUOTE"',
+                    'ESCAPED_QUOTE=\\"ESCAPED_QUOTE',
+                    "SINGLE_QUOTE=BEFORE'AFTER",
+                    'AFTER_ESCAPED_QUOTE=AFTER_ESCAPED_QUOTE\\"',
+                    'WITH_NEWLINE=before newline\nafter newline'
             ]) {
                 container('busybox') {
                     sh 'echo inside container'
-                    sh """
-                    echo The value of FROM_ENV_DEFINITION is \$FROM_ENV_DEFINITION
-                    echo The value of FROM_WITHENV_DEFINITION is \$FROM_WITHENV_DEFINITION
-                    echo The value of WITH_QUOTE is \$WITH_QUOTE
-                    echo The value of AFTER_QUOTE is \$AFTER_QUOTE
-                    echo The value of ESCAPED_QUOTE is \$ESCAPED_QUOTE
-                    echo The value of AFTER_ESCAPED_QUOTE is \$AFTER_ESCAPED_QUOTE
-                    """
+                    sh '''
+                        echo "The value of FROM_ENV_DEFINITION is $FROM_ENV_DEFINITION"
+                        echo "The value of FROM_WITHENV_DEFINITION is $FROM_WITHENV_DEFINITION"
+                        echo "The value of WITH_QUOTE is $WITH_QUOTE"
+                        echo "The value of AFTER_QUOTE is $AFTER_QUOTE"
+                        echo "The value of ESCAPED_QUOTE is $ESCAPED_QUOTE"
+                        echo "The value of AFTER_ESCAPED_QUOTE is $AFTER_ESCAPED_QUOTE"
+                        echo "The value of SINGLE_QUOTE is $SINGLE_QUOTE"
+                        echo "The value of WITH_NEWLINE is $WITH_NEWLINE"
+                    '''
                 }
             }
         }

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runWithEnvVarsFromContext.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runWithEnvVarsFromContext.groovy
@@ -6,13 +6,21 @@ podTemplate(label: 'mypod',
     env.FROM_ENV_DEFINITION = "ABC"
     node ('mypod') {
         stage('Run busybox') {
-            withEnv(['FROM_WITHENV_DEFINITION=DEF']) {
+            withEnv(['FROM_WITHENV_DEFINITION=DEF',
+            'WITH_QUOTE="WITH_QUOTE',
+            'AFTER_QUOTE=AFTER_QUOTE"',
+            'ESCAPED_QUOTE=\\"ESCAPED_QUOTE',
+            'AFTER_ESCAPED_QUOTE=AFTER_ESCAPED_QUOTE\\"'
+            ]) {
                 container('busybox') {
                     sh 'echo inside container'
                     sh """
                     echo The value of FROM_ENV_DEFINITION is \$FROM_ENV_DEFINITION
                     echo The value of FROM_WITHENV_DEFINITION is \$FROM_WITHENV_DEFINITION
-                    echo
+                    echo The value of WITH_QUOTE is \$WITH_QUOTE
+                    echo The value of AFTER_QUOTE is \$AFTER_QUOTE
+                    echo The value of ESCAPED_QUOTE is \$ESCAPED_QUOTE
+                    echo The value of AFTER_ESCAPED_QUOTE is \$AFTER_ESCAPED_QUOTE
                     """
                 }
             }


### PR DESCRIPTION
Simple escape for quotes on environment variables to avoid dangling multi-line variables during 'export' part of container. 