### PR TITLE
Pod annotations cannot contain duplicate keys when combining pod templates

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodAnnotation.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodAnnotation.java
@@ -37,6 +37,22 @@ public class PodAnnotation extends AbstractDescribableImpl<PodAnnotation> implem
         this.value = value;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        PodAnnotation that = (PodAnnotation) o;
+
+        return key != null ? key.equals(that.key) : that.key == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        return key != null ? key.hashCode() : 0;
+    }
+
     @Extension
     @Symbol("podAnnotation")
     public static class DescriptorImpl extends Descriptor<PodAnnotation> {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
@@ -29,7 +29,6 @@ import hudson.model.Node;
 import hudson.tools.ToolLocationNodeProperty;
 
 public class PodTemplateUtils {
-
     /**
      * Combines a {@link ContainerTemplate} with its parent.
      * @param parent        The parent container template (nullable).
@@ -89,11 +88,11 @@ public class PodTemplateUtils {
         String nodeSelector = Strings.isNullOrEmpty(template.getNodeSelector()) ? parent.getNodeSelector() : template.getNodeSelector();
         String serviceAccount = Strings.isNullOrEmpty(template.getServiceAccount()) ? parent.getServiceAccount() : template.getServiceAccount();
         Node.Mode nodeUsageMode = template.getNodeUsageMode() == null ? parent.getNodeUsageMode() : template.getNodeUsageMode();
-        
+
         Set<PodAnnotation> podAnnotations = new LinkedHashSet<>();
-        podAnnotations.addAll(parent.getAnnotations());
         podAnnotations.addAll(template.getAnnotations());
-        
+        podAnnotations.addAll(parent.getAnnotations());
+
         Set<PodImagePullSecret> imagePullSecrets = new LinkedHashSet<>();
         imagePullSecrets.addAll(parent.getImagePullSecrets());
         imagePullSecrets.addAll(template.getImagePullSecrets());

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
@@ -45,12 +45,14 @@ public class PodTemplateUtilsTest {
 
     private static final PodAnnotation ANNOTATION_1 = new PodAnnotation("key1", "value1");
     private static final PodAnnotation ANNOTATION_2 = new PodAnnotation("key2", "value2");
+    private static final PodAnnotation ANNOTATION_3 = new PodAnnotation("key1", "value3");
 
     private static final ContainerTemplate JNLP_1 = new ContainerTemplate("jnlp", "jnlp:1");
     private static final ContainerTemplate JNLP_2 = new ContainerTemplate("jnlp", "jnlp:2");
 
     private static final ContainerTemplate MAVEN_1 = new ContainerTemplate("maven", "maven:1", "sh -c", "cat");
     private static final ContainerTemplate MAVEN_2 = new ContainerTemplate("maven", "maven:2");
+
 
     @Test
     public void shouldReturnContainerTemplateWhenParentIsNull() {
@@ -152,14 +154,15 @@ public class PodTemplateUtilsTest {
         PodTemplate parent = new PodTemplate();
         parent.setName("parent");
         parent.setNodeSelector("key:value");
-        parent.setAnnotations(asList(ANNOTATION_1));
+        parent.setAnnotations(asList(ANNOTATION_1, ANNOTATION_2));
 
         PodTemplate template1 = new PodTemplate();
         template1.setName("template");
-        template1.setAnnotations(asList(ANNOTATION_2));
-        
+        template1.setAnnotations(asList(ANNOTATION_3));
+
         PodTemplate result = combine(parent, template1);
         assertEquals(2, result.getAnnotations().size());
+        assertEquals("value3", result.getAnnotations().get(0).getValue().toString());
     }
 
 


### PR DESCRIPTION
Added equals and hashCode overrides to podAnnotations so that combining doesn't allow duplicate keys  Also, changed precedence so that the template will override the parent in inheritance.