### PR TITLE
Fix overriding HOME env var and remove duplicated env vars

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
@@ -312,20 +312,21 @@ public class KubernetesLauncher extends JNLPLauncher {
 
         Map<String, EnvVar> envVarsMap = new HashMap<>();
 
-        if (containerTemplate.getEnvVars() != null) {
-            containerTemplate.getEnvVars().forEach(item ->
-                    envVarsMap.computeIfAbsent(item.getKey(), k -> item.buildEnvVar())
-            );
-        }
+        env.entrySet().forEach(item ->
+                envVarsMap.put(item.getKey(), new EnvVar(item.getKey(), item.getValue(), null))
+        );
+
         if (globalEnvVars != null) {
             globalEnvVars.forEach(item ->
-                    envVarsMap.computeIfAbsent(item.getKey(), k -> item.buildEnvVar())
+                    envVarsMap.put(item.getKey(), item.buildEnvVar())
             );
         }
 
-        env.entrySet().forEach(item ->
-                envVarsMap.computeIfAbsent(item.getKey(), k -> new EnvVar(item.getKey(), item.getValue(), null))
-        );
+        if (containerTemplate.getEnvVars() != null) {
+            containerTemplate.getEnvVars().forEach(item ->
+                    envVarsMap.put(item.getKey(), item.buildEnvVar())
+            );
+        }
 
         EnvVar[] envVars = envVarsMap.values().stream().toArray(EnvVar[]::new);
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
@@ -318,15 +318,14 @@ public class KubernetesLauncher extends JNLPLauncher {
             );
         }
         if (globalEnvVars != null) {
-            globalEnvVars.forEach( item ->
+            globalEnvVars.forEach(item ->
                     envVarsMap.computeIfAbsent(item.getKey(), k -> item.buildEnvVar())
             );
         }
 
-        List<EnvVar> defaultEnvVars = env.entrySet().stream()
-                .map(entry -> new EnvVar(entry.getKey(), entry.getValue(), null))
-                .collect(Collectors.toList());
-        defaultEnvVars.forEach( item -> envVarsMap.putIfAbsent(item.getName(), item));
+        env.entrySet().forEach(item ->
+                envVarsMap.computeIfAbsent(item.getKey(), k -> new EnvVar(item.getKey(), item.getValue(), null))
+        );
 
         EnvVar[] envVars = envVarsMap.values().stream().toArray(EnvVar[]::new);
 

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
@@ -157,6 +157,19 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
     }
 
     @Test
+    public void runWithOverriddenEnvVariables() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(loadPipelineScript("runWithOverriddenEnvVars.groovy"), true));
+        WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+        assertNotNull(b);
+        r.assertBuildStatusSuccess(r.waitForCompletion(b));
+        r.assertLogContains("OUTSIDE_CONTAINER_HOME_ENV_VAR = /home/jenkins\n", b);
+        r.assertLogContains("INSIDE_CONTAINER_HOME_ENV_VAR = /root\n",b);
+        r.assertLogContains("OUTSIDE_CONTAINER_POD_ENV_VAR = " + POD_ENV_VAR_VALUE + "\n", b);
+        r.assertLogContains("INSIDE_CONTAINER_POD_ENV_VAR = " + CONTAINER_ENV_VAR_VALUE + "\n",b);
+    }
+
+    @Test
     public void runJobWithSpaces() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p with spaces");
         p.setDefinition(new CpsFlowDefinition(loadPipelineScript("runJobWithSpaces.groovy"), true));

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runWithOverriddenEnvVars.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runWithOverriddenEnvVars.groovy
@@ -12,17 +12,17 @@ podTemplate(label: 'mypod',
         ]) {
 
     node ('mypod') {
-        sh """
-        echo OUTSIDE_CONTAINER_HOME_ENV_VAR = \$HOME
-        echo OUTSIDE_CONTAINER_POD_ENV_VAR = \$POD_ENV_VAR
-        """
+        sh '''
+        echo OUTSIDE_CONTAINER_HOME_ENV_VAR = $HOME
+        echo OUTSIDE_CONTAINER_POD_ENV_VAR = $POD_ENV_VAR
+        '''
         stage('Run busybox') {
             container('busybox') {
-                sh 'echo inside container'
-                sh """
-                echo INSIDE_CONTAINER_HOME_ENV_VAR = \$HOME
-                echo INSIDE_CONTAINER_POD_ENV_VAR = \$POD_ENV_VAR
-                """
+                sh '''
+                echo inside container
+                echo INSIDE_CONTAINER_HOME_ENV_VAR = $HOME
+                echo INSIDE_CONTAINER_POD_ENV_VAR = $POD_ENV_VAR
+                '''
             }
         }
     }

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runWithOverriddenEnvVars.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runWithOverriddenEnvVars.groovy
@@ -1,0 +1,29 @@
+podTemplate(label: 'mypod',
+        envVars: [
+                envVar(key: 'POD_ENV_VAR', value: 'pod-env-var-value')
+        ],
+        containers: [
+                containerTemplate(name: 'busybox', image: 'busybox', ttyEnabled: true, command: '/bin/cat',
+                        envVars: [
+                                envVar(key: 'HOME', value: '/root'),
+                                envVar(key: 'POD_ENV_VAR', value: 'container-env-var-value')
+                        ],
+                ),
+        ]) {
+
+    node ('mypod') {
+        sh """
+        echo OUTSIDE_CONTAINER_HOME_ENV_VAR = \$HOME
+        echo OUTSIDE_CONTAINER_POD_ENV_VAR = \$POD_ENV_VAR
+        """
+        stage('Run busybox') {
+            container('busybox') {
+                sh 'echo inside container'
+                sh """
+                echo INSIDE_CONTAINER_HOME_ENV_VAR = \$HOME
+                echo INSIDE_CONTAINER_POD_ENV_VAR = \$POD_ENV_VAR
+                """
+            }
+        }
+    }
+}

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runWithOverriddenEnvVars.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runWithOverriddenEnvVars.groovy
@@ -1,11 +1,13 @@
 podTemplate(label: 'mypod',
         envVars: [
+                envVar(key: 'POD_ENV_VAR', value: 'pod-env-var-value-first'),
                 envVar(key: 'POD_ENV_VAR', value: 'pod-env-var-value')
         ],
         containers: [
                 containerTemplate(name: 'busybox', image: 'busybox', ttyEnabled: true, command: '/bin/cat',
                         envVars: [
                                 envVar(key: 'HOME', value: '/root'),
+                                envVar(key: 'POD_ENV_VAR', value: 'container-env-var-value-first'),
                                 envVar(key: 'POD_ENV_VAR', value: 'container-env-var-value')
                         ],
                 ),


### PR DESCRIPTION
This PR enables redefining default env variables like HOME and removes duplicated env vars for created containers.
It fixes regression introduced in https://github.com/jenkinsci/kubernetes-plugin/pull/162/files#diff-14316beac1f1489a56a52e21cf8e0ee6R371

After bumping kubernetes-plugin to version 1.0 redefining HOME env variable doesn't work.
One of our pipeline where we need to redefine HOME variable for a container in a podTemplate stopped working.
```
podTemplate(label: 'mypod',
    containers: [
        containerTemplate(
            name: 'mongodb', 
            image: 'bitnami/mongodb:3.4.5-r0',
            envVars: [
                envVar(key: 'HOME', value: '/root'),
            ]
        )
    ]
)
{
    node ('mypod') {
        stage('Check mongo') {
            container('mongodb') {
                sh """
                mongo version
                """
            }
        }
    }
}
```
On kubernetes-plugin version 1.0 mongodb container starts with following setup:
```
Environment variables:
HOME: /root
JENKINS_SECRET: <secret>
JENKINS_NAME: jenkins-slave-tg7rl-mcknd
JENKINS_URL: http://192.168.99.1:8080/jenkins/
HOME: /home/jenkins
```
And the pod terminates with an error from mongodb container:
```
INFO  ==> Starting mongod...
error: failed switching to "mongo": unable to find user mongo: no matching entries in passwd file
```
Environment variables should look like here for mongodb container from the example:
```
HOME: /root
JENKINS_SECRET: <secret>
JENKINS_NAME: jenkins-slave-tg7rl-mcknd
JENKINS_URL: http://192.168.99.1:8080/jenkins/
```