### PR TITLE
[WIP] Add convenience variable "current_pod_label" in the body of podTemplate

### DIFF
--- a/examples/currentPodLabel.groovy
+++ b/examples/currentPodLabel.groovy
@@ -1,0 +1,12 @@
+podTemplate(
+        containers: [
+                containerTemplate(name: 'mvn', image: 'maven', ttyEnabled: true, command: 'cat'),
+        ],
+) {
+    node(current_pod_label) {
+        container('mvn') {
+            sh 'mvn --version'
+        }
+    }
+}
+


### PR DESCRIPTION
So you can't use the wrong label when requesting a node inside.
Also makes 'label' optional, see example.

@carlossg @iocanel:
This is not ready for merging yet, just wanted to get feedback if you like the approach.

Will add tests/docs if I get the okay to continue.

I am not sure about the name of the "environment" variable - should it be different/camelCased? I actually just wanted an ordinary "groovy" variable for this, but only found the hack to add it to the environment, hence being also directly available as `current_pod_label`.

If you like the approach, I maybe could also add a step like

```
podTemplate(
        containers: [
                containerTemplate(name: 'mvn', image: 'maven', ttyEnabled: true, command: 'cat'),
        ],
) {
  podNode {
    ...      
  }
}
```

Or even a shortcut:

```
nodeFromPodTemplate(
        containers: [
                containerTemplate(name: 'mvn', image: 'maven', ttyEnabled: true, command: 'cat'),
        ],
) {
  
}
```