### PR TITLE
Default podTemplate slaveConnectTimeout to 100

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -44,7 +44,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
 
     private static final Logger LOGGER = Logger.getLogger(PodTemplate.class.getName());
 
-    private static final int DEFAULT_SLAVE_JENKINS_CONNECTION_TIMEOUT = 100;
+    public static final int DEFAULT_SLAVE_JENKINS_CONNECTION_TIMEOUT = 100;
 
     private String inheritFrom;
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep.java
@@ -8,6 +8,7 @@ import java.util.Set;
 
 import org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate;
 import org.csanchez.jenkins.plugins.kubernetes.PodAnnotation;
+import org.csanchez.jenkins.plugins.kubernetes.PodTemplate;
 import org.csanchez.jenkins.plugins.kubernetes.model.TemplateEnvVar;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.PodVolume;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.workspace.WorkspaceVolume;
@@ -47,7 +48,7 @@ public class PodTemplateStep extends Step implements Serializable {
 
     private int instanceCap = Integer.MAX_VALUE;
     private int idleMinutes;
-    private int slaveConnectTimeout;
+    private int slaveConnectTimeout = PodTemplate.DEFAULT_SLAVE_JENKINS_CONNECTION_TIMEOUT;
 
     private String serviceAccount;
     private String nodeSelector;


### PR DESCRIPTION
To avoid the log warnings

    Slave -> Jenkins connection timeout cannot be <= 0. Falling back to the default value: 100