### PR TITLE
Annotate slave pod with job metadata to better identify job resource consumption 

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesComputer.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesComputer.java
@@ -13,12 +13,12 @@ import java.util.logging.Logger;
  * @author Carlos Sanchez carlos@apache.org
  */
 public class KubernetesComputer extends AbstractCloudComputer<KubernetesSlave> {
-	private static final Logger LOGGER = Logger.getLogger(KubernetesComputer.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(KubernetesComputer.class.getName());
 
-	private static final String TASK_NAME_POD_ANNOTATION = "jenkins.task.name";
-	private static final String TASK_STATUS_POD_ANNOTATION = "jenkins.task.status";
+    private static final String TASK_NAME_POD_ANNOTATION = "jenkins.task.name";
+    private static final String TASK_STATUS_POD_ANNOTATION = "jenkins.task.status";
 
-	public KubernetesComputer(KubernetesSlave slave) {
+    public KubernetesComputer(KubernetesSlave slave) {
         super(slave);
     }
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesComputer.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesComputer.java
@@ -13,22 +13,25 @@ import java.util.logging.Logger;
  * @author Carlos Sanchez carlos@apache.org
  */
 public class KubernetesComputer extends AbstractCloudComputer<KubernetesSlave> {
-    private static final Logger LOGGER = Logger.getLogger(KubernetesComputer.class.getName());
+	private static final Logger LOGGER = Logger.getLogger(KubernetesComputer.class.getName());
 
-    public KubernetesComputer(KubernetesSlave slave) {
+	private static final String TASK_NAME_POD_ANNOTATION = "jenkins.task.name";
+	private static final String TASK_STATUS_POD_ANNOTATION = "jenkins.task.status";
+
+	public KubernetesComputer(KubernetesSlave slave) {
         super(slave);
     }
 
     @Override
     public void taskAccepted(Executor executor, Queue.Task task) {
-        annotatePodWithTaskName(task);
+        annotatePodWithTaskInfo(task, "accepted");
         super.taskAccepted(executor, task);
         LOGGER.fine(" Computer " + this + " taskAccepted");
     }
 
     @Override
     public void taskCompleted(Executor executor, Queue.Task task, long durationMS) {
-        cleanupPodAnnotation();
+        annotatePodWithTaskInfo(task, "completed");
         LOGGER.log(Level.FINE, " Computer " + this + " taskCompleted");
 
         // May take the slave offline and remove it, in which case getNode()
@@ -38,7 +41,7 @@ public class KubernetesComputer extends AbstractCloudComputer<KubernetesSlave> {
 
     @Override
     public void taskCompletedWithProblems(Executor executor, Queue.Task task, long durationMS, Throwable problems) {
-        cleanupPodAnnotation();
+        annotatePodWithTaskInfo(task, "completedWithProblems");
         super.taskCompletedWithProblems(executor, task, durationMS, problems);
         LOGGER.log(Level.FINE, " Computer " + this + " taskCompletedWithProblems");
     }
@@ -48,37 +51,21 @@ public class KubernetesComputer extends AbstractCloudComputer<KubernetesSlave> {
         return String.format("KubernetesComputer name: %s slave: %s", getName(), getNode());
     }
 
-    private void annotatePodWithTaskName(Queue.Task task) {
+    private void annotatePodWithTaskInfo(Queue.Task task, String status) {
         KubernetesClient k8sClient = null;
         try {
             KubernetesSlave slave = getNode();
             if (slave != null) {
                 k8sClient = slave.getKubernetesCloud().connect();
-                Pod done = k8sClient.pods().withName(slave.getNodeName()).edit().editMetadata()
-                        .addToAnnotations("jenkins.task.name", task.getName()).endMetadata().done();
+                Pod pod = k8sClient.pods().withName(slave.getNodeName()).edit()
+                        .editMetadata()
+                        .addToAnnotations(TASK_NAME_POD_ANNOTATION, task.getName())
+                        .addToAnnotations(TASK_STATUS_POD_ANNOTATION, status)
+                        .endMetadata().done();
 
-                String nodeName = done.getSpec().getNodeName();
-                LOGGER.info("accepted task [" + task.getName() + "] in pod [" + slave.getNodeName() + "] on node [" + nodeName + "]");
-            }
-        }
-        catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Cannot contact k8s server", e);
-        }
-        finally {
-            if (k8sClient != null) {
-                k8sClient.close();
-            }
-        }
-    }
-
-    private void cleanupPodAnnotation() {
-        KubernetesClient k8sClient = null;
-        try {
-            KubernetesSlave slave = getNode();
-            if (slave != null) {
-                k8sClient = slave.getKubernetesCloud().connect();
-                k8sClient.pods().withName(slave.getNodeName()).edit().editMetadata()
-                        .removeFromAnnotations("jenkins.task.name").endMetadata().done();
+                String nodeName = pod.getSpec().getNodeName();
+                LOGGER.info("task [" + task.getName() + "] updated with status [" + status + "] in pod [" + slave.getNodeName() + "] on node ["
+                        + nodeName + "]");
             }
         }
         catch (Exception e) {


### PR DESCRIPTION
Hi,

We are currently facing regular issues with builds badly hammering cluster resources. Our main problem is to identify which build is actually running inside a slave pod. The end goal is to notify and work with the concerned team in order to fix the situation.
Moreover from time to time we have issues with certain builds that are node specific. Usually it is a node misconfiguration. So we want to identify those cases faster.

Ideally I would like to :
- Annotate the pod with Jenkins variables such as: JOB_NAME, JOB_URL, BUILD_URL, BUILD_NUMBER. 
- Log the k8s node name where the pod is running inside the build log. 
Finally, the solution has to work with any job type (maven, freestyle, pipeline).

I'm currently struggling to link those information as Jenkins architecture decouples slave creation from job creation.  KubernetesComputer seems to be one of the places where we can achieve some results.
I also tried to use a RunListener but the onStarted() method is executed before the job is actually assigned to the slave node.

For now the best result I got is the following:
- Jenkins log  entry with node name, pod name and task name
- A pod annotation using the task name as value

Task name is giving me the information I need, but I would rather prefer to use the previously mentioned Jenkins variables. 

 Do you have any suggestion ?