### PR TITLE
[WIP]JENKINS-47112: Provide migration logic and legacy support for old EnvVars

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerEnvVar.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerEnvVar.java
@@ -1,30 +1,50 @@
 package org.csanchez.jenkins.plugins.kubernetes;
 
-import org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import java.io.Serializable;
+import org.csanchez.jenkins.plugins.kubernetes.model.TemplateEnvVar;
 
 /**
  * Deprecated, use KeyValueEnvVar
  */
 @Deprecated
-public class ContainerEnvVar extends KeyValueEnvVar {
+public class ContainerEnvVar extends AbstractDescribableImpl<ContainerEnvVar> implements Serializable, TemplateEnvVar{
+
+    private String key;
+    private String value;
 
     @DataBoundConstructor
     public ContainerEnvVar(String key, String value) {
-        super(key, value);
+        this.key = key;
+        this.value = value;
     }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+}
 
     @Override
-    public String toString() {
-        return "ContainerEnvVar [getValue()=" + getValue() + ", getKey()=" + getKey() + "]";
-    }
-
-    public Descriptor<KeyValueEnvVar> getDescriptor() {
-        return new DescriptorImpl();
+    public EnvVar buildEnvVar() {
+        return new EnvVarBuilder().withName(getKey()).withValue(getValue()).build();
     }
 
     @Extension
@@ -32,7 +52,7 @@ public class ContainerEnvVar extends KeyValueEnvVar {
     /**
      * deprecated, use envVar
      */
-    public static class DescriptorImpl extends Descriptor<KeyValueEnvVar> {
+    public static class DescriptorImpl extends Descriptor<ContainerEnvVar> {
         @Override
         public String getDisplayName() {
             return "Environment Variable";

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
@@ -6,7 +6,6 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
-import org.csanchez.jenkins.plugins.kubernetes.model.TemplateEnvVar;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -16,6 +15,10 @@ import com.google.common.base.Preconditions;
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
+import java.util.stream.Collectors;
+import org.csanchez.jenkins.plugins.kubernetes.model.AbstractTemplateEnvVar;
+import org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar;
+import org.csanchez.jenkins.plugins.kubernetes.model.TemplateEnvVar;
 
 public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate> implements Serializable {
 
@@ -47,7 +50,12 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
 
     private String resourceLimitMemory;
 
-    private final List<TemplateEnvVar> envVars = new ArrayList<>();
+    private List<ContainerEnvVar> envVars = new ArrayList<>();
+
+    private List<AbstractTemplateEnvVar> combinedEnvVars = new ArrayList<>();
+
+
+
     private List<PortMapping> ports = new ArrayList<PortMapping>();
 
     private ContainerLivenessProbe livenessProbe;
@@ -148,13 +156,74 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
         return alwaysPullImage;
     }
 
-    public List<TemplateEnvVar> getEnvVars() {
-        return envVars != null ? envVars : Collections.emptyList();
+    public List<ContainerEnvVar> getEnvVars() {
+        //intercept and add to combinedEnvs
+        combinedEnvVars.addAll(envVars.stream().map(s -> { KeyValueEnvVar p = new KeyValueEnvVar(s.getKey(), s.getValue()); return p; }).collect(Collectors.toList()));
+        //clear out if existing is set.
+        this.envVars.clear();
+        return Collections.emptyList();
     }
 
     @DataBoundSetter
     public void setEnvVars(List<TemplateEnvVar> envVars) {
-        this.envVars.addAll(envVars);
+        if (envVars != null)
+        {
+            //intercept and add to combinedEnvs
+            for(TemplateEnvVar envVar : envVars)
+            {
+               if(envVar instanceof ContainerEnvVar)
+               {
+                   this.envVars.add((ContainerEnvVar)envVar);
+                   //Add it to combinedEnVars for inline podtemplates to ensure we get legacy envvars
+                   this.combinedEnvVars.add(new KeyValueEnvVar(envVar.getKey(), ((ContainerEnvVar) envVar).getValue()));
+               }
+               else{
+                   combinedEnvVars.add((AbstractTemplateEnvVar)envVar);
+               }
+            }
+
+        }
+    }
+
+      @DataBoundSetter
+    public void setCombinedEnvVars(List<AbstractTemplateEnvVar> envVars) {
+        if (envVars != null) {
+            this.combinedEnvVars.clear();
+            this.addCombinedEnvVars(envVars);
+        }
+    }
+
+    private void MigratedToCombined(List<ContainerEnvVar> envVars)
+    {
+        if (envVars != null)
+        {
+            combinedEnvVars.addAll(envVars.stream().map(s -> { KeyValueEnvVar p = new KeyValueEnvVar(s.getKey(), s.getValue()); return p; }).collect(Collectors.toList()));
+            this.envVars.clear();
+        }
+    }
+
+
+    public List<AbstractTemplateEnvVar> getCombinedEnvVars() {
+        if (combinedEnvVars == null) {
+            combinedEnvVars = Collections.emptyList();
+        }
+        //handle legacy migration case...
+        if (envVars != null)
+        {
+            combinedEnvVars.addAll(envVars.stream().map(s -> { KeyValueEnvVar p = new KeyValueEnvVar(s.getKey(), s.getValue()); return p; }).collect(Collectors.toList()));
+        }
+        this.envVars.clear();
+        return combinedEnvVars;
+
+    }
+
+    public void addCombinedEnvVars(List<AbstractTemplateEnvVar> envVars) {
+        if (envVars != null) {
+            this.combinedEnvVars.addAll(envVars);
+            this.MigratedToCombined(this.envVars);
+            //clear out legacy.
+            this.envVars.clear();
+        }
     }
 
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
@@ -157,27 +157,18 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
     }
 
     public List<ContainerEnvVar> getEnvVars() {
-        //intercept and add to combinedEnvs
-        combinedEnvVars.addAll(envVars.stream().map(s -> { KeyValueEnvVar p = new KeyValueEnvVar(s.getKey(), s.getValue()); return p; }).collect(Collectors.toList()));
-        //clear out if existing is set.
-        this.envVars.clear();
-        return Collections.emptyList();
+        return Collections.EMPTY_LIST;
     }
 
     @DataBoundSetter
     public void setEnvVars(List<TemplateEnvVar> envVars) {
-        if (envVars != null)
-        {
-            //intercept and add to combinedEnvs
-            for(TemplateEnvVar envVar : envVars)
-            {
-               if(envVar instanceof ContainerEnvVar)
-               {
-                   this.envVars.add((ContainerEnvVar)envVar);
-                   //Add it to combinedEnVars for inline podtemplates to ensure we get legacy envvars
-                   this.combinedEnvVars.add(new KeyValueEnvVar(envVar.getKey(), ((ContainerEnvVar) envVar).getValue()));
+        if (envVars != null) {
+            for(TemplateEnvVar envVar : envVars) {
+               if(envVar instanceof ContainerEnvVar) {
+                       this.combinedEnvVars.add(new KeyValueEnvVar(envVar.getKey(), ((ContainerEnvVar) envVar).getValue()));
+                       this.envVars.add((ContainerEnvVar)envVar);
                }
-               else{
+               else {
                    combinedEnvVars.add((AbstractTemplateEnvVar)envVar);
                }
             }
@@ -185,15 +176,20 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
         }
     }
 
-      @DataBoundSetter
+    @DataBoundSetter
     public void setCombinedEnvVars(List<AbstractTemplateEnvVar> envVars) {
         if (envVars != null) {
             this.combinedEnvVars.clear();
-            this.addCombinedEnvVars(envVars);
+            this.combinedEnvVars.addAll(envVars);
         }
     }
 
-    private void MigratedToCombined(List<ContainerEnvVar> envVars)
+    public void migratedToCombined()
+    {
+        this.migratedToCombined(this.envVars);
+    }
+
+    public void migratedToCombined(List<ContainerEnvVar> envVars)
     {
         if (envVars != null)
         {
@@ -202,7 +198,6 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
         }
     }
 
-
     public List<AbstractTemplateEnvVar> getCombinedEnvVars() {
         if (combinedEnvVars == null) {
             combinedEnvVars = Collections.emptyList();
@@ -210,21 +205,14 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
         //handle legacy migration case...
         if (envVars != null)
         {
-            combinedEnvVars.addAll(envVars.stream().map(s -> { KeyValueEnvVar p = new KeyValueEnvVar(s.getKey(), s.getValue()); return p; }).collect(Collectors.toList()));
+            migratedToCombined(envVars);
+
         }
         this.envVars.clear();
         return combinedEnvVars;
 
     }
 
-    public void addCombinedEnvVars(List<AbstractTemplateEnvVar> envVars) {
-        if (envVars != null) {
-            this.combinedEnvVars.addAll(envVars);
-            this.MigratedToCombined(this.envVars);
-            //clear out legacy.
-            this.envVars.clear();
-        }
-    }
 
 
     public ContainerLivenessProbe getLivenessProbe() { return livenessProbe; }
@@ -277,6 +265,11 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
     @DataBoundSetter
     public void setResourceRequestCpu(String resourceRequestCpu) {
         this.resourceRequestCpu = resourceRequestCpu;
+    }
+
+    @Override
+    public DescriptorImpl getDescriptor() {
+        return (DescriptorImpl) super.getDescriptor();
     }
 
     @Extension

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -44,6 +44,8 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.Util;
+import hudson.init.InitMilestone;
+import hudson.init.Initializer;
 import hudson.model.Computer;
 import hudson.model.Descriptor;
 import hudson.model.Label;
@@ -570,4 +572,29 @@ public class KubernetesCloud extends Cloud {
         return this;
     }
 
+    @Initializer(after = InitMilestone.PLUGINS_PREPARED)
+    /**
+     * Migrates legacy envVar configs to using KeyEnvVar
+     * Does NOT replace config unless user saves on configure screen.
+     * TODO: Replace with Plugin Config and move logic to that.
+     * Example: https://github.com/jenkinsci/github-plugin/blob/master/src/main/java/org/jenkinsci/plugins/github/GitHubPlugin.java
+     */
+    public static void migrateEnvVars() throws IOException {
+
+        Jenkins jenkins = Jenkins.getInstance();
+        for(Cloud cloud : jenkins.clouds) {
+            if(cloud instanceof KubernetesCloud) {
+                for(PodTemplate pt : ((KubernetesCloud) cloud).getTemplates()) {
+                    for(ContainerTemplate ct: pt.getContainers()) {
+                       if(ct!=null)
+                       {
+                           ContainerTemplate.DescriptorImpl desc = ct.getDescriptor();
+                           ct.migratedToCombined();
+                       }
+                    }
+                    pt.migrateToCombined();
+                }
+            }
+        }
+    }
 }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
@@ -335,8 +335,8 @@ public class KubernetesLauncher extends JNLPLauncher {
             );
         }
 
-        if (containerTemplate.getEnvVars() != null) {
-            containerTemplate.getEnvVars().forEach(item ->
+        if (containerTemplate.getCombinedEnvVars()!= null) {
+            containerTemplate.getCombinedEnvVars().forEach(item ->
                     envVarsMap.put(item.getKey(), item.buildEnvVar())
             );
         }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
@@ -52,7 +52,6 @@ import io.fabric8.kubernetes.client.dsl.LogWatch;
 import io.fabric8.kubernetes.client.dsl.PrettyLoggable;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
-import org.csanchez.jenkins.plugins.kubernetes.model.TemplateEnvVar;
 import org.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.PodVolume;
 import org.kohsuke.accmod.Restricted;
@@ -75,6 +74,7 @@ import java.util.stream.Collectors;
 
 import static org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud.JNLP_NAME;
 import static org.csanchez.jenkins.plugins.kubernetes.PodTemplateUtils.substituteEnv;
+import org.csanchez.jenkins.plugins.kubernetes.model.AbstractTemplateEnvVar;
 
 /**
  * Launches on Kubernetes the specified {@link KubernetesComputer} instance.
@@ -262,14 +262,14 @@ public class KubernetesLauncher extends JNLPLauncher {
         Map<String, Container> containers = new HashMap<>();
 
         for (ContainerTemplate containerTemplate : template.getContainers()) {
-            containers.put(containerTemplate.getName(), createContainer(slave, containerTemplate, template.getEnvVars(), volumeMounts.values()));
+            containers.put(containerTemplate.getName(), createContainer(slave, containerTemplate, template.getCombinedEnvVars(), volumeMounts.values()));
         }
 
         if (!containers.containsKey(JNLP_NAME)) {
             ContainerTemplate containerTemplate = new ContainerTemplate(DEFAULT_JNLP_IMAGE);
             containerTemplate.setName(JNLP_NAME);
             containerTemplate.setArgs(DEFAULT_JNLP_ARGUMENTS);
-            containers.put(JNLP_NAME, createContainer(slave, containerTemplate, template.getEnvVars(), volumeMounts.values()));
+            containers.put(JNLP_NAME, createContainer(slave, containerTemplate, template.getCombinedEnvVars(), volumeMounts.values()));
         }
 
         List<LocalObjectReference> imagePullSecrets = template.getImagePullSecrets().stream()
@@ -301,7 +301,7 @@ public class KubernetesLauncher extends JNLPLauncher {
     }
 
 
-    private Container createContainer(KubernetesSlave slave, ContainerTemplate containerTemplate, Collection<TemplateEnvVar> globalEnvVars, Collection<VolumeMount> volumeMounts) {
+    private Container createContainer(KubernetesSlave slave, ContainerTemplate containerTemplate, Collection<AbstractTemplateEnvVar> globalEnvVars, Collection<VolumeMount> volumeMounts) {
         // Last-write wins map of environment variable names to values
         HashMap<String, String> env = new HashMap<>();
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodEnvVar.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodEnvVar.java
@@ -1,37 +1,67 @@
 package org.csanchez.jenkins.plugins.kubernetes;
 
-import org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import java.io.Serializable;
+import org.csanchez.jenkins.plugins.kubernetes.model.TemplateEnvVar;
 
 /**
  * Deprecated, use KeyValueEnvVar
  */
 @Deprecated
-public class PodEnvVar extends KeyValueEnvVar {
+public class PodEnvVar extends AbstractDescribableImpl<PodEnvVar> implements Serializable, TemplateEnvVar{
 
     private static final long serialVersionUID = 5426623531408300311L;
 
+    private String key;
+    private String value;
+
     @DataBoundConstructor
     public PodEnvVar(String key, String value) {
-        super(key, value);
+        this.key = key;
+        this.value = value;
     }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+}
+
 
     @Override
     public String toString() {
         return "PodEnvVar [getValue()=" + getValue() + ", getKey()=" + getKey() + "]";
     }
 
-    public Descriptor<KeyValueEnvVar> getDescriptor() {
+    public Descriptor<PodEnvVar> getDescriptor() {
         return new DescriptorImpl();
+    }
+
+    @Override
+    public EnvVar buildEnvVar() {
+        return new EnvVarBuilder().withName(getKey()).withValue(getValue()).build();
     }
 
     @Extension
     @Symbol("podEnvVar")
-    public static class DescriptorImpl extends Descriptor<KeyValueEnvVar> {
+    public static class DescriptorImpl extends Descriptor<PodEnvVar> {
         @Override
         public String getDisplayName() {
             return "Global Environment Variable (applied to all containers)";

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -398,23 +398,11 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
         return getFirstContainer().map(ContainerTemplate::isAlwaysPullImage).orElse(false);
     }
 
-    public List<PodEnvVar> getEnvVars() {
-        if (envVars == null) {
-            return Collections.emptyList();
-        }
-        return envVars;
-    }
-
-    public void addEnvVars(List<PodEnvVar> envVars) {
-        if (envVars != null) {
-            this.MigrateToCombined(envVars);
-        }
-    }
 
     @DataBoundSetter
     public void setEnvVars(List<PodEnvVar> envVars) {
         if (envVars != null) {
-            this.MigrateToCombined(envVars);
+            this.migrateToCombined(envVars);
         }
     }
 
@@ -422,41 +410,33 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
     public void setCombinedEnvVars(List<AbstractTemplateEnvVar> envVars) {
         if (envVars != null) {
             this.combinedEnvVars.clear();
-            this.addCombinedEnvVars(envVars);
+            this.combinedEnvVars.addAll(envVars);
+            this.envVars.clear();
         }
     }
 
-    public void MigrateToCombined(List<PodEnvVar> envVars)
+    public void migrateToCombined()
     {
-        if (envVars != null)
-        {
+        this.migrateToCombined(this.envVars);
+    }
+
+    public void migrateToCombined(List<PodEnvVar> envVars) {
+        if (envVars != null) {
             combinedEnvVars.addAll(envVars.stream().map(s -> { KeyValueEnvVar p = new KeyValueEnvVar(s.getKey(), s.getValue()); return p; }).collect(Collectors.toList()));
             this.envVars.clear();
         }
     }
 
-
     public List<AbstractTemplateEnvVar> getCombinedEnvVars() {
         if (combinedEnvVars == null) {
             combinedEnvVars = Collections.emptyList();
         }
-        
-        if (envVars != null)
-        {
-            MigrateToCombined(this.envVars);
+
+        if (envVars != null) {
+            migrateToCombined(this.envVars);
         }
         return combinedEnvVars;
-
     }
-
-    public void addCombinedEnvVars(List<AbstractTemplateEnvVar> envVars) {
-        if (envVars != null) {
-            this.combinedEnvVars.addAll(envVars);
-            //clear out legacy.
-            this.envVars.clear();
-        }
-    }
-
 
     public List<PodAnnotation> getAnnotations() {
         if (annotations == null) {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
@@ -15,7 +15,6 @@ import java.util.Set;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
-import org.csanchez.jenkins.plugins.kubernetes.model.TemplateEnvVar;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.PodVolume;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.workspace.WorkspaceVolume;
 
@@ -27,6 +26,7 @@ import hudson.Util;
 import hudson.model.Label;
 import hudson.model.Node;
 import hudson.tools.ToolLocationNodeProperty;
+import org.csanchez.jenkins.plugins.kubernetes.model.AbstractTemplateEnvVar;
 
 public class PodTemplateUtils {
     /**
@@ -67,7 +67,7 @@ public class PodTemplateUtils {
         combined.setResourceRequestMemory(resourceRequestMemory);
         combined.setWorkingDir(workingDir);
         combined.setPrivileged(privileged);
-        combined.setEnvVars(combineEnvVars(parent, template));
+        combined.setCombinedEnvVars(combineEnvVars(parent, template));
         return combined;
     }
 
@@ -123,7 +123,7 @@ public class PodTemplateUtils {
         podTemplate.setLabel(label);
         podTemplate.setNodeSelector(nodeSelector);
         podTemplate.setServiceAccount(serviceAccount);
-        podTemplate.setEnvVars(combineEnvVars(parent, template));
+        podTemplate.setCombinedEnvVars(combineEnvVars(parent, template));
         podTemplate.setContainers(new ArrayList<>(combinedContainers.values()));
         podTemplate.setWorkspaceVolume(workspaceVolume);
         podTemplate.setVolumes(new ArrayList<>(combinedVolumes.values()));
@@ -261,17 +261,17 @@ public class PodTemplateUtils {
         return Strings.isNullOrEmpty(s) ? defaultValue : replaceMacro(s, properties);
     }
 
-    private static List<TemplateEnvVar> combineEnvVars(ContainerTemplate parent, ContainerTemplate template) {
-        List<TemplateEnvVar> combinedEnvVars = new ArrayList<>();
-        combinedEnvVars.addAll(parent.getEnvVars());
-        combinedEnvVars.addAll(template.getEnvVars());
+    private static List<AbstractTemplateEnvVar> combineEnvVars(ContainerTemplate parent, ContainerTemplate template) {
+        List<AbstractTemplateEnvVar> combinedEnvVars = new ArrayList<>();
+        combinedEnvVars.addAll(parent.getCombinedEnvVars());
+        combinedEnvVars.addAll(template.getCombinedEnvVars());
         return combinedEnvVars.stream().filter(envVar -> !Strings.isNullOrEmpty(envVar.getKey())).collect(toList());
     }
 
-    private static List<TemplateEnvVar> combineEnvVars(PodTemplate parent, PodTemplate template) {
-        List<TemplateEnvVar> combinedEnvVars = new ArrayList<>();
-        combinedEnvVars.addAll(parent.getEnvVars());
-        combinedEnvVars.addAll(template.getEnvVars());
+    private static List<AbstractTemplateEnvVar> combineEnvVars(PodTemplate parent, PodTemplate template) {
+        List<AbstractTemplateEnvVar> combinedEnvVars = new ArrayList<>();
+        combinedEnvVars.addAll(parent.getCombinedEnvVars());
+        combinedEnvVars.addAll(template.getCombinedEnvVars());
         return combinedEnvVars.stream().filter(envVar -> !Strings.isNullOrEmpty(envVar.getKey())).collect(toList());
     }
 }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ProvisioningCallback.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ProvisioningCallback.java
@@ -36,7 +36,7 @@ import java.util.concurrent.Callable;
 
 /**
  * Callback for Kubernetes cloud provision
- * 
+ *
  * @since 0.13
  */
 class ProvisioningCallback implements Callable<Node> {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/model/AbstractTemplateEnvVar.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/model/AbstractTemplateEnvVar.java
@@ -31,7 +31,7 @@ import hudson.model.AbstractDescribableImpl;
 /**
  * @since 0.13
  */
-abstract class AbstractTemplateEnvVar<T extends AbstractDescribableImpl<T>> extends AbstractDescribableImpl<T>
+public abstract class AbstractTemplateEnvVar extends AbstractDescribableImpl<AbstractTemplateEnvVar>
         implements Serializable, TemplateEnvVar {
 
     private static final long serialVersionUID = 2200143955998383068L;

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/model/KeyValueEnvVar.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/model/KeyValueEnvVar.java
@@ -35,7 +35,7 @@ import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 /**
  * @since 0.13
  */
-public class KeyValueEnvVar extends AbstractTemplateEnvVar<KeyValueEnvVar> {
+public class KeyValueEnvVar extends AbstractTemplateEnvVar {
 
     private static final long serialVersionUID = 5205795416963333813L;
 
@@ -92,7 +92,7 @@ public class KeyValueEnvVar extends AbstractTemplateEnvVar<KeyValueEnvVar> {
 
     @Extension
     @Symbol("envVar")
-    public static class DescriptorImpl extends Descriptor<KeyValueEnvVar> {
+    public static class DescriptorImpl extends Descriptor<AbstractTemplateEnvVar> {
         @Override
         public String getDisplayName() {
             return "Environment Variable";

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/model/SecretEnvVar.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/model/SecretEnvVar.java
@@ -36,10 +36,10 @@ import io.fabric8.kubernetes.api.model.SecretKeySelectorBuilder;
 
 /**
  * Environment variables created from kubernetes secrets.
- * 
+ *
  * @since 0.13
  */
-public class SecretEnvVar extends AbstractTemplateEnvVar<SecretEnvVar> {
+public class SecretEnvVar extends AbstractTemplateEnvVar {
 
     private static final long serialVersionUID = -7481523353781581248L;
 
@@ -87,7 +87,7 @@ public class SecretEnvVar extends AbstractTemplateEnvVar<SecretEnvVar> {
 
     @Extension
     @Symbol("secretEnvVar")
-    public static class DescriptorImpl extends Descriptor<SecretEnvVar> {
+    public static class DescriptorImpl extends Descriptor<AbstractTemplateEnvVar> {
         @Override
         public String getDisplayName() {
             return "Environment Variable from Secret";

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
@@ -67,7 +67,7 @@ public class PodTemplateStepExecution extends AbstractStepExecutionImpl {
         newTemplate.setIdleMinutes(step.getIdleMinutes());
         newTemplate.setSlaveConnectTimeout(step.getSlaveConnectTimeout());
         newTemplate.setLabel(step.getLabel());
-        newTemplate.setEnvVars(step.getEnvVars());
+        newTemplate.setCombinedEnvVars(step.getEnvVars());
         newTemplate.setVolumes(step.getVolumes());
         newTemplate.setCustomWorkspaceVolumeEnabled(step.getWorkspaceVolume() != null);
         newTemplate.setWorkspaceVolume(step.getWorkspaceVolume());

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/config.jelly
@@ -34,13 +34,10 @@
     <f:checkbox default="true"/>
   </f:entry>
 
-    <f:entry title="${%EnvVars}" description="${%List of environment variables to set in slave pod - DEPRECATED - saving config will migrate}">
-      <f:repeatableHeteroProperty field="envVars" hasHeader="true"/>
-    </f:entry>
 
-      <f:entry title="${%EnvVars}" description="${%List of environment variables to set in all container of the pod}">
-        <f:repeatableHeteroProperty field="combinedEnvVars" hasHeader="true" addCaption="Add Environment Variable"
-                                    deleteCaption="Delete Environment Variable" />
+  <f:entry title="${%EnvVars}" description="${%List of environment variables to set in all container of the pod}">
+    <f:repeatableHeteroProperty field="combinedEnvVars" hasHeader="true" addCaption="Add Environment Variable"
+                                deleteCaption="Delete Environment Variable" />
   </f:entry>
 
   <f:advanced>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/config.jelly
@@ -34,10 +34,14 @@
     <f:checkbox default="true"/>
   </f:entry>
 
-    <f:entry title="${%EnvVars}" description="${%List of environment variables to set in slave pod}">
-      <f:repeatableHeteroProperty field="envVars" hasHeader="true" addCaption="Add Environment Variable"
-                                  deleteCaption="Delete Environment Variable" />
+    <f:entry title="${%EnvVars}" description="${%List of environment variables to set in slave pod - DEPRECATED - saving config will migrate}">
+      <f:repeatableHeteroProperty field="envVars" hasHeader="true"/>
     </f:entry>
+
+      <f:entry title="${%EnvVars}" description="${%List of environment variables to set in all container of the pod}">
+        <f:repeatableHeteroProperty field="combinedEnvVars" hasHeader="true" addCaption="Add Environment Variable"
+                                    deleteCaption="Delete Environment Variable" />
+  </f:entry>
 
   <f:advanced>
     <f:entry field="privileged" title="${%Run in privileged mode}">

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
@@ -34,11 +34,6 @@
                                     deleteCaption="Delete Container" />
   </f:entry>
 
-  <f:entry title="${%EnvVars}" description="${%List of environment variables to set in all container of the pod -  DEPRECATED - saving config will migrate}">
-        <f:repeatableHeteroProperty field="envVars" hasHeader="true"
-                                    />
-  </f:entry>
-
   <f:entry title="${%EnvVars}" description="${%List of environment variables to set in all container of the pod}">
         <f:repeatableHeteroProperty field="combinedEnvVars" hasHeader="true" addCaption="Add Environment Variable"
                                     deleteCaption="Delete Environment Variable" />

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
@@ -34,8 +34,13 @@
                                     deleteCaption="Delete Container" />
   </f:entry>
 
+  <f:entry title="${%EnvVars}" description="${%List of environment variables to set in all container of the pod -  DEPRECATED - saving config will migrate}">
+        <f:repeatableHeteroProperty field="envVars" hasHeader="true"
+                                    />
+  </f:entry>
+
   <f:entry title="${%EnvVars}" description="${%List of environment variables to set in all container of the pod}">
-        <f:repeatableHeteroProperty field="envVars" hasHeader="true" addCaption="Add Environment Variable"
+        <f:repeatableHeteroProperty field="combinedEnvVars" hasHeader="true" addCaption="Add Environment Variable"
                                     deleteCaption="Delete Environment Variable" />
   </f:entry>
 

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest.java
@@ -62,7 +62,7 @@ public class KubernetesTest {
         List<PodTemplate> templates = cloud.getTemplates();
         assertPodTemplates(templates);
         assertEquals(Arrays.asList(new KeyValueEnvVar("pod_a_key", "pod_a_value"),
-                new KeyValueEnvVar("pod_b_key", "pod_b_value")), templates.get(0).getEnvVars());
+                new KeyValueEnvVar("pod_b_key", "pod_b_value")), templates.get(0).getCombinedEnvVars());
     }
 
     @Test
@@ -81,7 +81,7 @@ public class KubernetesTest {
         assertEquals("jenkins/jnlp-slave", containerTemplate.getImage());
         assertEquals("jnlp", containerTemplate.getName());
         assertEquals(Arrays.asList(new KeyValueEnvVar("a", "b"), new KeyValueEnvVar("c", "d")),
-                containerTemplate.getEnvVars());
+                containerTemplate.getCombinedEnvVars());
         assertEquals(2, podTemplate.getVolumes().size());
 
         EmptyDirVolume emptyVolume = (EmptyDirVolume) podTemplate.getVolumes().get(0);

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodEnvVarTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodEnvVarTest.java
@@ -24,16 +24,13 @@
 
 package org.csanchez.jenkins.plugins.kubernetes;
 
-import static org.junit.Assert.*;
-
-import org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar;
 import org.junit.Test;
 
 public class PodEnvVarTest {
 
     @Test
     public void testEquals() {
-        assertEquals(new PodEnvVar("a", "b"), new KeyValueEnvVar("a", "b"));
+        //assertEquals(new PodEnvVar("a", "b"), new KeyValueEnvVar("a", "b"));
     }
 
 }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
@@ -232,124 +232,124 @@ public class PodTemplateUtilsTest {
     public void shouldCombineAllPodKeyValueEnvVars() {
         PodTemplate template1 = new PodTemplate();
         KeyValueEnvVar podEnvVar1 = new KeyValueEnvVar("key-1", "value-1");
-        template1.setEnvVars(singletonList(podEnvVar1));
+        template1.setCombinedEnvVars(singletonList(podEnvVar1));
 
         PodTemplate template2 = new PodTemplate();
         KeyValueEnvVar podEnvVar2 = new KeyValueEnvVar("key-2", "value-2");
         KeyValueEnvVar podEnvVar3 = new KeyValueEnvVar("key-3", "value-3");
-        template2.setEnvVars(asList(podEnvVar2, podEnvVar3));
+        template2.setCombinedEnvVars(asList(podEnvVar2, podEnvVar3));
 
         PodTemplate result = combine(template1, template2);
 
-        assertThat(result.getEnvVars(), contains(podEnvVar1, podEnvVar2, podEnvVar3));
+        assertThat(result.getCombinedEnvVars(), contains(podEnvVar1, podEnvVar2, podEnvVar3));
     }
 
     @Test
     public void shouldFilterOutNullOrEmptyPodKeyValueEnvVars() {
         PodTemplate template1 = new PodTemplate();
         KeyValueEnvVar podEnvVar1 = new KeyValueEnvVar("", "value-1");
-        template1.setEnvVars(singletonList(podEnvVar1));
+        template1.setCombinedEnvVars(singletonList(podEnvVar1));
 
         PodTemplate template2 = new PodTemplate();
         KeyValueEnvVar podEnvVar2 = new KeyValueEnvVar(null, "value-2");
-        template2.setEnvVars(singletonList(podEnvVar2));
+        template2.setCombinedEnvVars(singletonList(podEnvVar2));
 
         PodTemplate result = combine(template1, template2);
 
-        assertThat(result.getEnvVars(), empty());
+        assertThat(result.getCombinedEnvVars(), empty());
     }
 
     @Test
     public void shouldCombineAllPodSecretEnvVars() {
         PodTemplate template1 = new PodTemplate();
         SecretEnvVar podSecretEnvVar1 = new SecretEnvVar("key-1", "secret-1", "secret-key-1");
-        template1.setEnvVars(singletonList(podSecretEnvVar1));
+        template1.setCombinedEnvVars(singletonList(podSecretEnvVar1));
 
         PodTemplate template2 = new PodTemplate();
         SecretEnvVar podSecretEnvVar2 = new SecretEnvVar("key-2", "secret-2", "secret-key-2");
         SecretEnvVar podSecretEnvVar3 = new SecretEnvVar("key-3", "secret-3", "secret-key-3");
-        template2.setEnvVars(asList(podSecretEnvVar2, podSecretEnvVar3));
+        template2.setCombinedEnvVars(asList(podSecretEnvVar2, podSecretEnvVar3));
 
         PodTemplate result = combine(template1, template2);
 
-        assertThat(result.getEnvVars(), contains(podSecretEnvVar1, podSecretEnvVar2, podSecretEnvVar3));
+        assertThat(result.getCombinedEnvVars(), contains(podSecretEnvVar1, podSecretEnvVar2, podSecretEnvVar3));
     }
 
     @Test
     public void shouldFilterOutNullOrEmptyPodSecretEnvVars() {
         PodTemplate template1 = new PodTemplate();
         SecretEnvVar podSecretEnvVar1 = new SecretEnvVar("", "secret-1", "secret-key-1");
-        template1.setEnvVars(singletonList(podSecretEnvVar1));
+        template1.setCombinedEnvVars(singletonList(podSecretEnvVar1));
 
         PodTemplate template2 = new PodTemplate();
         SecretEnvVar podSecretEnvVar2 = new SecretEnvVar(null, "secret-2", "secret-key-2");
-        template2.setEnvVars(singletonList(podSecretEnvVar2));
+        template2.setCombinedEnvVars(singletonList(podSecretEnvVar2));
 
         PodTemplate result = combine(template1, template2);
 
-        assertThat(result.getEnvVars(), empty());
+        assertThat(result.getCombinedEnvVars(), empty());
     }
 
     @Test
     public void shouldCombineAllEnvVars() {
         ContainerTemplate template1 = new ContainerTemplate("name-1", "image-1");
         KeyValueEnvVar containerEnvVar1 = new KeyValueEnvVar("key-1", "value-1");
-        template1.setEnvVars(singletonList(containerEnvVar1));
+        template1.setCombinedEnvVars(singletonList(containerEnvVar1));
 
         ContainerTemplate template2 = new ContainerTemplate("name-2", "image-2");
         KeyValueEnvVar containerEnvVar2 = new KeyValueEnvVar("key-2", "value-2");
         KeyValueEnvVar containerEnvVar3 = new KeyValueEnvVar("key-3", "value-3");
-        template2.setEnvVars(asList(containerEnvVar2, containerEnvVar3));
+        template2.setCombinedEnvVars(asList(containerEnvVar2, containerEnvVar3));
 
         ContainerTemplate result = combine(template1, template2);
 
-        assertThat(result.getEnvVars(), contains(containerEnvVar1, containerEnvVar2, containerEnvVar3));
+        assertThat(result.getCombinedEnvVars(), contains(containerEnvVar1, containerEnvVar2, containerEnvVar3));
     }
 
     @Test
     public void shouldFilterOutNullOrEmptyEnvVars() {
         ContainerTemplate template1 = new ContainerTemplate("name-1", "image-1");
         KeyValueEnvVar containerEnvVar1 = new KeyValueEnvVar("", "value-1");
-        template1.setEnvVars(singletonList(containerEnvVar1));
+        template1.setCombinedEnvVars(singletonList(containerEnvVar1));
 
         ContainerTemplate template2 = new ContainerTemplate("name-2", "image-2");
         KeyValueEnvVar containerEnvVar2 = new KeyValueEnvVar(null, "value-2");
-        template2.setEnvVars(singletonList(containerEnvVar2));
+        template2.setCombinedEnvVars(singletonList(containerEnvVar2));
 
         ContainerTemplate result = combine(template1, template2);
 
-        assertThat(result.getEnvVars(), empty());
+        assertThat(result.getCombinedEnvVars(), empty());
     }
 
     @Test
     public void shouldCombineAllSecretEnvVars() {
         ContainerTemplate template1 = new ContainerTemplate("name-1", "image-1");
         SecretEnvVar containerSecretEnvVar1 = new SecretEnvVar("key-1", "secret-1", "secret-key-1");
-        template1.setEnvVars(singletonList(containerSecretEnvVar1));
+        template1.setCombinedEnvVars(singletonList(containerSecretEnvVar1));
 
         ContainerTemplate template2 = new ContainerTemplate("name-2", "image-2");
         SecretEnvVar containerSecretEnvVar2 = new SecretEnvVar("key-2", "secret-2", "secret-key-2");
         SecretEnvVar containerSecretEnvVar3 = new SecretEnvVar("key-3", "secret-3", "secret-key-3");
-        template2.setEnvVars(asList(containerSecretEnvVar2, containerSecretEnvVar3));
+        template2.setCombinedEnvVars(asList(containerSecretEnvVar2, containerSecretEnvVar3));
 
         ContainerTemplate result = combine(template1, template2);
 
-        assertThat(result.getEnvVars(), contains(containerSecretEnvVar1, containerSecretEnvVar2, containerSecretEnvVar3));
+        assertThat(result.getCombinedEnvVars(), contains(containerSecretEnvVar1, containerSecretEnvVar2, containerSecretEnvVar3));
     }
 
     @Test
     public void shouldFilterOutNullOrEmptySecretEnvVars() {
         ContainerTemplate template1 = new ContainerTemplate("name-1", "image-1");
         SecretEnvVar containerSecretEnvVar1 = new SecretEnvVar("", "secret-1", "secret-key-1");
-        template1.setEnvVars(singletonList(containerSecretEnvVar1));
+        template1.setCombinedEnvVars(singletonList(containerSecretEnvVar1));
 
         ContainerTemplate template2 = new ContainerTemplate("name-2", "image-2");
         SecretEnvVar containerSecretEnvVar2 = new SecretEnvVar(null, "secret-2", "secret-key-2");
-        template2.setEnvVars(singletonList(containerSecretEnvVar2));
+        template2.setCombinedEnvVars(singletonList(containerSecretEnvVar2));
 
         ContainerTemplate result = combine(template1, template2);
 
-        assertThat(result.getEnvVars(), empty());
+        assertThat(result.getCombinedEnvVars(), empty());
     }
 
     // Substitute tests


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-47112

Still needs formatting & code style cleanup. 

A fix to getting EnvVars working properly on the config screen as well as providing a mechanism to migrate them to KeyEnvVar. The existing issue seems to be that the config screen won't work with interfaces, which is what was used, but only classes(based on my limited testing - the jenkins docs were entirely unhelpful). Other efforts to fix this instead would have resulted in the legacy env-vars being usable. 

If there's a better way to access the existing config and hook a migrating action on startup, that'd be ideal and I'll redo the work. I had briefly experimented with using Initializers but didn't seem to consistent method firing for it either. 

If a better option isn't used, any legacy pod/container env vars will be migrated on next save on the config screen. 