### PR TITLE
Wait for complete disconnection during pod slave termination

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
@@ -30,6 +30,8 @@ import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateEncodingException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.concurrent.Future;
+import java.util.concurrent.ExecutionException;
 
 /**
  * @author Carlos Sanchez carlos@apache.org
@@ -166,7 +168,20 @@ public class KubernetesSlave extends AbstractCloudSlave {
         }
 
         OfflineCause offlineCause = OfflineCause.create(new Localizable(HOLDER, "offline"));
-        computer.disconnect(offlineCause);
+        Future disconnected = computer.disconnect(offlineCause);
+        try {
+            disconnected.get();
+        } catch(InterruptedException inte) {
+            String msg = String.format("Failed to disconnect with kubernetes pod %s, interrupted", name);
+            throw inte;
+        } catch(ExecutionException ee) {
+            String msg = String.format("Failed to disconnect with kubernetes pod %s, execution aborted", name);
+            LOGGER.log(Level.WARNING, msg, ee);
+            listener.error(msg);
+            // Assuming pod template has some error itself
+            // Simply return might leave some kuberentes pod of ERROR state 
+            return;
+        }
 
         if (getCloudName() == null) {
             String msg = String.format("Cloud name is not set for agent, can't terminate: %s", name);


### PR DESCRIPTION
# BUG Fix #

Sometimes it can be failed to delete a pod slave with following trace.
```
Nov 13, 2017 5:51:01 AM org.csanchez.jenkins.plugins.kubernetes.KubernetesSlave _terminate
SEVERE: Failed to terminate pod for slave *****
io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: DELETE at: *****
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.requestFailure(OperationSupport.java:315)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.assertResponseCode(OperationSupport.java:268)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleResponse(OperationSupport.java:237)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleResponse(OperationSupport.java:230)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleDelete(OperationSupport.java:202)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.deleteThis(BaseOperation.java:579)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.delete(BaseOperation.java:525)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.delete(BaseOperation.java:62)
	at org.csanchez.jenkins.plugins.kubernetes.KubernetesSlave._terminate(KubernetesSlave.java:139)
	at hudson.slaves.AbstractCloudSlave.terminate(AbstractCloudSlave.java:67)
	at hudson.slaves.CloudRetentionStrategy.check(CloudRetentionStrategy.java:59)
	at hudson.slaves.CloudRetentionStrategy.check(CloudRetentionStrategy.java:43)
	at hudson.slaves.ComputerRetentionWork$1.run(ComputerRetentionWork.java:72)
	at hudson.model.Queue._withLock(Queue.java:1338)
	at hudson.model.Queue.withLock(Queue.java:1215)
	at hudson.slaves.ComputerRetentionWork.doRun(ComputerRetentionWork.java:63)
	at hudson.triggers.SafeTimerTask.run(SafeTimerTask.java:51)
	at jenkins.security.ImpersonatingScheduledExecutorService$1.run(ImpersonatingScheduledExecutorService.java:58)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)

```
This is because pod disconnecting itself is a asynchronous process.

[https://github.com/jenkinsci/kubernetes-plugin/blob/4303ec3c913c80c020eb7a6880853dc1c4838325/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java#L169](https://github.com/jenkinsci/kubernetes-plugin/blob/4303ec3c913c80c020eb7a6880853dc1c4838325/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java#L169)

If we explicitly block on that, and do the pod deletion after safe disconnection. This error will just disappear.

