### PR TITLE
Add support for initContainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ Either way it provides access to the following fields:
 * **name** The name of the pod.
 * **namespace** The namespace of the pod.
 * **label** The label of the pod.
-* **container** The container templates that are use to create the containers of the pod *(see below)*.
+* **initContainers** The init container templates that are use to create the init containers of the pod.
+* **containers** The container templates that are use to create the containers of the pod *(see below)*.
 * **serviceAccount** The service account of the pod.
 * **nodeSelector** The node selector of the pod.
 * **nodeUsageMode** Either 'NORMAL' or 'EXCLUSIVE', this controls whether Jenkins only schedules jobs with label expressions matching or use the node as much as possible.
@@ -125,6 +126,8 @@ The `containerTemplate` is a template of container that will be added to the pod
 * **ttyEnabled** Flag to mark that tty should be enabled.
 * **livenessProbe** Parameters to be added to a exec liveness probe in the container (does not suppot httpGet liveness probes)
 * **ports** Expose ports on the container.
+
+The containerTemplate can be used to define templates for both plain and init containers.
 
 #### Liveness Probe Usage
 ```groovy

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <jackson.version>2.5.0</jackson.version>
     <jenkins.version>2.32.1</jenkins.version>
 
-    <kubernetes-client.version>2.6.1</kubernetes-client.version>
+    <kubernetes-client.version>3.1.0</kubernetes-client.version>
 
     <!-- jenkins plugins versions -->
     <jenkins-basic-steps.version>2.3</jenkins-basic-steps.version>

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFactoryAdapter.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFactoryAdapter.java
@@ -99,7 +99,7 @@ public class KubernetesFactoryAdapter {
         // autoconfigure if url is not set
         if (StringUtils.isBlank(serviceAddress)) {
             LOGGER.log(FINE, "Autoconfiguring Kubernetes client");
-            builder = new ConfigBuilder(Config.autoConfigure());
+            builder = new ConfigBuilder(Config.autoConfigure(null));
         } else {
             // although this will still autoconfigure based on Config constructor notes
             // In future releases (2.4.x) the public constructor will be empty.

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
@@ -50,6 +50,7 @@ import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.LogWatch;
 import io.fabric8.kubernetes.client.dsl.PrettyLoggable;
+import io.fabric8.kubernetes.client.utils.Serialization;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
 import org.csanchez.jenkins.plugins.kubernetes.model.TemplateEnvVar;
@@ -81,6 +82,7 @@ import static org.csanchez.jenkins.plugins.kubernetes.PodTemplateUtils.substitut
  * Launches on Kubernetes the specified {@link KubernetesComputer} instance.
  */
 public class KubernetesLauncher extends JNLPLauncher {
+
     private static final Pattern SPLIT_IN_SPACES = Pattern.compile("([^\"]\\S*|\".+?\")\\s*");
 
     private static final String WORKSPACE_VOLUME_NAME = "workspace-volume";
@@ -93,6 +95,9 @@ public class KubernetesLauncher extends JNLPLauncher {
     private static final String JNLPMAC_REF = "\\$\\{computer.jnlpmac\\}";
     private static final String NAME_REF = "\\$\\{computer.name\\}";
     private static final Logger LOGGER = Logger.getLogger(KubernetesLauncher.class.getName());
+
+
+    private static final String INIT_CONTAINER_ANNOTATION = "pod.beta.kubernetes.io/init-containers";
 
     private boolean launched;
 
@@ -272,8 +277,13 @@ public class KubernetesLauncher extends JNLPLauncher {
             volumes.add(new VolumeBuilder().withName(WORKSPACE_VOLUME_NAME).withNewEmptyDir("").build());
         }
 
-        Map<String, Container> containers = new HashMap<>();
 
+        Map<String, Container> initContainers = new HashMap<>();
+        for (ContainerTemplate containerTemplate : template.getInitContainers()) {
+            initContainers.put(containerTemplate.getName(), createContainer(slave, containerTemplate, template.getEnvVars(), volumeMounts.values()));
+        }
+
+        Map<String, Container> containers = new HashMap<>();
         for (ContainerTemplate containerTemplate : template.getContainers()) {
             containers.put(containerTemplate.getName(), createContainer(slave, containerTemplate, template.getEnvVars(), volumeMounts.values()));
         }
@@ -293,6 +303,7 @@ public class KubernetesLauncher extends JNLPLauncher {
                 .withName(substituteEnv(slave.getNodeName()))
                 .withLabels(slave.getKubernetesCloud().getLabelsMap(template.getLabelSet()))
                 .withAnnotations(getAnnotationsMap(template.getAnnotations()))
+                .addToAnnotations(INIT_CONTAINER_ANNOTATION, Serialization.asJson(initContainers.values().toArray(new Container[initContainers.size()])))
                 .endMetadata()
                 .withNewSpec();
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -93,6 +93,8 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
 
     private final List<PodVolume> volumes = new ArrayList<PodVolume>();
 
+    private List<ContainerTemplate> initContainers = new ArrayList<ContainerTemplate>();
+
     private List<ContainerTemplate> containers = new ArrayList<ContainerTemplate>();
 
     private List<TemplateEnvVar> envVars = new ArrayList<>();
@@ -109,6 +111,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
 
     public PodTemplate(PodTemplate from) {
         this.setAnnotations(from.getAnnotations());
+        this.setInitContainers(from.getInitContainers());
         this.setContainers(from.getContainers());
         this.setImagePullSecrets(from.getImagePullSecrets());
         this.setInstanceCap(from.getInstanceCap());
@@ -542,6 +545,14 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
         this.workspaceVolume = workspaceVolume;
     }
 
+    @Nonnull
+    public List<ContainerTemplate> getContainers() {
+        if (containers == null) {
+            return Collections.emptyList();
+        }
+        return containers;
+    }
+
     @DataBoundSetter
     public void setContainers(@Nonnull List<ContainerTemplate> items) {
         synchronized (this.containers) {
@@ -551,11 +562,19 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
     }
 
     @Nonnull
-    public List<ContainerTemplate> getContainers() {
-        if (containers == null) {
+    public List<ContainerTemplate> getInitContainers() {
+        if (initContainers == null) {
             return Collections.emptyList();
         }
-        return containers;
+        return initContainers;
+    }
+
+    @DataBoundSetter
+    public void setInitContainers(@Nonnull List<ContainerTemplate> items) {
+        synchronized (this.initContainers) {
+            this.initContainers.clear();
+            this.initContainers.addAll(items);
+        }
     }
 
     @SuppressWarnings("deprecation")
@@ -579,6 +598,10 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
 
         if (annotations == null) {
             annotations = new ArrayList<>();
+        }
+
+        if (initContainers == null) {
+            initContainers = new ArrayList<>();
         }
 
         return this;

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep.java
@@ -39,6 +39,7 @@ public class PodTemplateStep extends Step implements Serializable {
     private final String name;
 
     private String namespace;
+    private List<ContainerTemplate> initContainers = new ArrayList<>();
     private List<ContainerTemplate> containers = new ArrayList<>();
     private List<TemplateEnvVar> envVars = new ArrayList<>();
     private List<PodVolume> volumes = new ArrayList<PodVolume>();
@@ -95,6 +96,15 @@ public class PodTemplateStep extends Step implements Serializable {
     @DataBoundSetter
     public void setInheritFrom(String inheritFrom) {
         this.inheritFrom = inheritFrom;
+    }
+
+    public List<ContainerTemplate> getInitContainers() {
+        return initContainers;
+    }
+
+    @DataBoundSetter
+    public void setInitContainers(List<ContainerTemplate> initContainers) {
+        this.initContainers = initContainers;
     }
 
     public List<ContainerTemplate> getContainers() {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
@@ -76,6 +76,7 @@ public class PodTemplateStepExecution extends AbstractStepExecutionImpl {
         newTemplate.setVolumes(step.getVolumes());
         newTemplate.setCustomWorkspaceVolumeEnabled(step.getWorkspaceVolume() != null);
         newTemplate.setWorkspaceVolume(step.getWorkspaceVolume());
+        newTemplate.setInitContainers(step.getInitContainers());
         newTemplate.setContainers(step.getContainers());
         newTemplate.setNodeSelector(step.getNodeSelector());
         newTemplate.setNodeUsageMode(step.getNodeUsageMode());

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes/EmptyDirVolume.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes/EmptyDirVolume.java
@@ -66,7 +66,7 @@ public class EmptyDirVolume extends PodVolume {
 
     @Override
     public Volume buildVolume(String volumeName) {
-        return new VolumeBuilder().withName(volumeName).withNewEmptyDir(getMedium()).build();
+        return new VolumeBuilder().withName(volumeName).withNewEmptyDir().withMedium(getMedium()).endEmptyDir().build();
     }
 
     @Extension

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes/workspace/EmptyDirWorkspaceVolume.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes/workspace/EmptyDirWorkspaceVolume.java
@@ -59,7 +59,7 @@ public class EmptyDirWorkspaceVolume extends WorkspaceVolume {
 
     @Override
     public Volume buildVolume(String volumeName) {
-        return new VolumeBuilder().withName(volumeName).withNewEmptyDir(getMedium()).build();
+        return new VolumeBuilder().withName(volumeName).withNewEmptyDir().withMedium(getMedium()).endEmptyDir().build();
     }
 
     @Extension

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
@@ -29,6 +29,11 @@
     <f:textbox/>
   </f:entry>
 
+  <f:entry title="${%Init Containers}" description="${%List of init container in the slave pod}">
+      <f:repeatableHeteroProperty field="initContainers" hasHeader="true" addCaption="Add Init Container"
+                                    deleteCaption="Delete Init Container" />
+  </f:entry>
+
   <f:entry title="${%Containers}" description="${%List of container in the slave pod}">
       <f:repeatableHeteroProperty field="containers" hasHeader="true" addCaption="Add Container"
                                     deleteCaption="Delete Container" />

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesTestUtil.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesTestUtil.java
@@ -75,7 +75,7 @@ public class KubernetesTestUtil {
 
     public static void assumeKubernetes() throws Exception {
         try (DefaultKubernetesClient client = new DefaultKubernetesClient(
-                new ConfigBuilder(Config.autoConfigure()).build())) {
+                new ConfigBuilder(Config.autoConfigure(null)).build())) {
             client.pods().list();
         } catch (Exception e) {
             assumeNoException(e);

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
@@ -113,6 +113,16 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
     }
 
     @Test
+    public void runWithInitContainers() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(loadPipelineScript("runWithInitContainers.groovy"), true));
+        WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+        assertNotNull(b);
+        r.assertBuildStatusSuccess(r.waitForCompletion(b));
+        assertEnvVars(r, b);
+    }
+
+    @Test
     public void runWithEnvVariablesInContext() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(loadPipelineScript("runWithEnvVarsFromContext.groovy"), true));

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runWithInitContainers.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runWithInitContainers.groovy
@@ -1,6 +1,6 @@
 podTemplate(label: 'mypod',
     initContainers: [
-            containerTemplate(name: 'busybox', image: 'alpine', command: 'touch /home/jenkins/key')
+        containerTemplate(name: 'busybox', image: 'alpine', command: 'touch /home/jenkins/key')
     ],
     containers: [
         containerTemplate(name: 'busybox', image: 'busybox', ttyEnabled: true, command: '/bin/cat')

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runWithInitContainers.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runWithInitContainers.groovy
@@ -1,0 +1,16 @@
+podTemplate(label: 'mypod',
+    initContainers: [
+            containerTemplate(name: 'busybox', image: 'alpine', command: 'touch /home/jenkins/key')
+    ],
+    containers: [
+        containerTemplate(name: 'busybox', image: 'busybox', ttyEnabled: true, command: '/bin/cat')
+    ]) {
+
+    node ('mypod') {
+        stage('Run busybox') {
+            container('busybox') {
+                sh 'cat key'
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hello there,

As mentioned in https://github.com/jenkinsci/kubernetes-plugin/pull/229 , the support for initContainers as podAnnotation is no longer an option for k8s >=1.8 so I gave a follow up to this pull request by using the latest version of kubernetes-client so we can use `withInitContainers` on the pod builder.

I'm definitely not a Java developer so I hope I'm not doing too many mistakes in this pull request.