### PR TITLE
Missing call to slave.terminate()

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
@@ -222,6 +222,7 @@ public class KubernetesLauncher extends JNLPLauncher {
                 if (containerStatuses != null) {
                     logLastLines(containerStatuses, podId, namespace, slave, null, client);
                 }
+                slave.terminate();
                 throw new IllegalStateException("Slave is not connected after " + j + " attempts, status: " + status);
             }
             computer.setAcceptingTasks(true);
@@ -229,8 +230,8 @@ public class KubernetesLauncher extends JNLPLauncher {
             LOGGER.log(Level.WARNING, String.format("Error in provisioning; slave=%s, template=%s", slave, unwrappedTemplate), ex);
             LOGGER.log(Level.FINER, "Removing Jenkins node: {0}", slave.getNodeName());
             try {
-                Jenkins.getInstance().removeNode(slave);
-            } catch (IOException e) {
+                slave.terminate();
+            } catch (IOException | InterruptedException e) {
                 LOGGER.log(Level.WARNING, "Unable to remove Jenkins node", e);
             }
             throw Throwables.propagate(ex);

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
@@ -222,7 +222,6 @@ public class KubernetesLauncher extends JNLPLauncher {
                 if (containerStatuses != null) {
                     logLastLines(containerStatuses, podId, namespace, slave, null, client);
                 }
-                slave.terminate();
                 throw new IllegalStateException("Slave is not connected after " + j + " attempts, status: " + status);
             }
             computer.setAcceptingTasks(true);


### PR DESCRIPTION
Apparently it is needed or jenkins will think failed nodes are still available in some cases,
not calling the plugin again to provision nodes,
thus leaving jobs stuck waiting for executor that will never be created

Based on yet-another-docker-plugin which was mentioned by @stephenc as a good example of cloud api implementation https://github.com/KostyaSha/yet-another-docker-plugin/blob/db0026ea46b1ca24a03c4212d09acefff0b1f2e4/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/launcher/DockerComputerJNLPLauncher.java#L281 


