### PR TITLE
[JENKINS-45892] IllegalStateException at hudson.XmlFile.replaceIfNotA…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <!-- dependency versions -->
     <httpclient.version>4.5.1</httpclient.version>
     <jackson.version>2.5.0</jackson.version>
-    <jenkins.version>2.32.1</jenkins.version>
+    <jenkins.version>2.89</jenkins.version>
 
     <kubernetes-client.version>2.6.1</kubernetes-client.version>
 
@@ -207,6 +207,11 @@
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>ssh-credentials</artifactId>
         <version>1.12</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.sshd</groupId>
+        <artifactId>sshd-core</artifactId>
+        <version>1.6.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/AbstractInvisibleRunAction2.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/AbstractInvisibleRunAction2.java
@@ -46,19 +46,7 @@ public abstract class AbstractInvisibleRunAction2 extends InvisibleAction implem
 
     protected final Stack<String> stack = new Stack<>();
 
-    private transient Run<?, ?> run;
-
-    public AbstractInvisibleRunAction2() {
-        super();
-    }
-
-    @Deprecated
-    public AbstractInvisibleRunAction2(Run<?, ?> run) {
-        setRun(run);
-    }
-
-    @Deprecated
-    protected abstract AbstractInvisibleRunAction2 createAction(Run<?, ?> run);
+    protected transient Run<?, ?> run;
 
     public Run<?, ?> getRun() {
         return run;
@@ -84,55 +72,6 @@ public abstract class AbstractInvisibleRunAction2 extends InvisibleAction implem
                 bc.commit();
             } catch (InstantiationException | IllegalAccessException e) {
                 throw new RuntimeException("Can not instantiate class " + clazz, e);
-            } finally {
-                bc.abort();
-            }
-        }
-    }
-
-    @Deprecated
-    public void push(String item) throws IOException {
-        if (run == null) {
-            LOGGER.warning("run is null, cannot push");
-            return;
-        }
-        synchronized (run) {
-            BulkChange bc = new BulkChange(run);
-            try {
-                AbstractInvisibleRunAction2 action = run.getAction(this.getClass());
-                if (action == null) {
-                    action = createAction(run);
-                    run.addAction(action);
-                }
-                LOGGER.log(Level.FINEST, "Pushing item {0} to action {1} in run {2}",
-                        new Object[] { item, action, run });
-                action.stack.push(item);
-                bc.commit();
-            } finally {
-                bc.abort();
-            }
-        }
-    }
-
-    @Deprecated
-    public String pop() throws IOException {
-        if (run == null) {
-            LOGGER.warning("run is null, cannot pop");
-            return null;
-        }
-        synchronized (run) {
-            BulkChange bc = new BulkChange(run);
-            try {
-                AbstractInvisibleRunAction2 action = run.getAction(this.getClass());
-                if (action == null) {
-                    action = createAction(run);
-                    run.addAction(action);
-                }
-                String item = action.stack.pop();
-                LOGGER.log(Level.FINEST, "Popped item {0} from action {1} in run {2}",
-                        new Object[] { item, action, run });
-                bc.commit();
-                return item;
             } finally {
                 bc.abort();
             }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/AbstractInvisibleRunAction2.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/AbstractInvisibleRunAction2.java
@@ -97,7 +97,6 @@ public class AbstractInvisibleRunAction2 extends InvisibleAction implements RunA
                 return template;
             } finally {
                 bc.abort();
-                return null;
             }
         }
     }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/AbstractInvisibleRunAction2.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/AbstractInvisibleRunAction2.java
@@ -1,0 +1,58 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.csanchez.jenkins.plugins.kubernetes.pipeline;
+
+import hudson.model.InvisibleAction;
+import hudson.model.Run;
+import jenkins.model.RunAction2;
+
+/**
+ * @author Carlos Sanchez
+ * @since 1.1.1
+ *
+ */
+public class AbstractInvisibleRunAction2 extends InvisibleAction implements RunAction2 {
+
+    private transient Run<?, ?> run;
+
+    public Run<?, ?> getRun() {
+        return run;
+    }
+
+    protected void setRun(Run<?, ?> run) {
+        this.run = run;
+    }
+
+    @Override
+    public void onAttached(Run<?, ?> r) {
+        setRun(r);
+    }
+
+    @Override
+    public void onLoad(Run<?, ?> r) {
+        setRun(r);
+    }
+
+}

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/AbstractInvisibleRunAction2.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/AbstractInvisibleRunAction2.java
@@ -74,7 +74,8 @@ public abstract class AbstractInvisibleRunAction2 extends InvisibleAction implem
                     action = createAction(run);
                     run.addAction(action);
                 }
-                LOGGER.log(Level.INFO, "Pushing item {0} to action {1} in run {2}", new Object[] { item, action, run });
+                LOGGER.log(Level.FINEST, "Pushing item {0} to action {1} in run {2}",
+                        new Object[] { item, action, run });
                 action.stack.push(item);
                 bc.commit();
             } finally {
@@ -97,7 +98,7 @@ public abstract class AbstractInvisibleRunAction2 extends InvisibleAction implem
                     getRun().addAction(action);
                 }
                 String item = action.stack.pop();
-                LOGGER.log(Level.INFO, "Popped item {0} from action {1} in run {2}",
+                LOGGER.log(Level.FINEST, "Popped item {0} from action {1} in run {2}",
                         new Object[] { item, action, run });
                 bc.commit();
                 return item;

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/NamespaceAction.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/NamespaceAction.java
@@ -2,30 +2,74 @@ package org.csanchez.jenkins.plugins.kubernetes.pipeline;
 
 import java.io.IOException;
 import java.util.EmptyStackException;
+import java.util.logging.Logger;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.BulkChange;
 import hudson.model.Run;
 import jenkins.model.RunAction2;
 
 public class NamespaceAction extends AbstractInvisibleRunAction2 implements RunAction2 {
+
+    private static final Logger LOGGER = Logger.getLogger(NamespaceAction.class.getName());
 
     NamespaceAction() {
         super();
     }
 
     @Deprecated
-    public NamespaceAction(Run<?, ?> run) {
-        super(run);
-    }
-
-    @Override
-    @Deprecated
-    protected AbstractInvisibleRunAction2 createAction(Run<?, ?> run) {
-        return new NamespaceAction(run);
+    public NamespaceAction(Run run) {
+        setRun(run);
     }
 
     protected static void push(@NonNull Run<?, ?> run, @NonNull String item) throws IOException {
         AbstractInvisibleRunAction2.push(run, NamespaceAction.class, item);
+    }
+
+    @Deprecated
+    public void push(String namespace) throws IOException {
+        if (run == null) {
+            LOGGER.warning("run is null, cannot push");
+            return;
+        }
+        synchronized (run) {
+            BulkChange bc = new BulkChange(run);
+            try {
+                NamespaceAction action = run.getAction(NamespaceAction.class);
+                if (action == null) {
+                    action = new NamespaceAction(run);
+                    run.addAction(action);
+                }
+                action.stack.push(namespace);
+                bc.commit();
+            } finally {
+                bc.abort();
+            }
+        }
+    }
+
+    @Deprecated
+    public String pop() throws IOException {
+        if (run == null) {
+            LOGGER.warning("run is null, cannot pop");
+            return null;
+        }
+        synchronized (run) {
+            BulkChange bc = new BulkChange(run);
+            try {
+                NamespaceAction action = run.getAction(NamespaceAction.class);
+                if (action == null) {
+                    action = new NamespaceAction(run);
+                    run.addAction(action);
+                }
+                String namespace = action.stack.pop();
+                bc.commit();
+                return namespace;
+            } finally {
+                bc.abort();
+                return null;
+            }
+        }
     }
 
     public String getNamespace() {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/NamespaceAction.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/NamespaceAction.java
@@ -1,33 +1,38 @@
 package org.csanchez.jenkins.plugins.kubernetes.pipeline;
 
+import java.io.IOException;
 import java.util.EmptyStackException;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.Run;
 import jenkins.model.RunAction2;
 
 public class NamespaceAction extends AbstractInvisibleRunAction2 implements RunAction2 {
 
+    NamespaceAction() {
+        super();
+    }
+
+    @Deprecated
     public NamespaceAction(Run<?, ?> run) {
         super(run);
     }
 
     @Override
+    @Deprecated
     protected AbstractInvisibleRunAction2 createAction(Run<?, ?> run) {
         return new NamespaceAction(run);
     }
 
+    protected static void push(@NonNull Run<?, ?> run, @NonNull String item) throws IOException {
+        AbstractInvisibleRunAction2.push(run, NamespaceAction.class, item);
+    }
+
     public String getNamespace() {
-        synchronized (getRun()) {
-            NamespaceAction action = getRun().getAction(NamespaceAction.class);
-            if (action == null) {
-                action = new NamespaceAction(getRun());
-                getRun().addAction(action);
-            }
-            try {
-                return action.stack.peek();
-            } catch (EmptyStackException e) {
-                return null;
-            }
+        try {
+            return stack.peek();
+        } catch (EmptyStackException e) {
+            return null;
         }
     }
 }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/NamespaceAction.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/NamespaceAction.java
@@ -11,6 +11,11 @@ public class NamespaceAction extends AbstractInvisibleRunAction2 implements RunA
         super(run);
     }
 
+    @Override
+    protected AbstractInvisibleRunAction2 createAction(Run<?, ?> run) {
+        return new NamespaceAction(run);
+    }
+
     public String getNamespace() {
         synchronized (getRun()) {
             NamespaceAction action = getRun().getAction(NamespaceAction.class);

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/NamespaceAction.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/NamespaceAction.java
@@ -1,66 +1,14 @@
 package org.csanchez.jenkins.plugins.kubernetes.pipeline;
 
-import java.io.IOException;
 import java.util.EmptyStackException;
-import java.util.Stack;
-import java.util.logging.Logger;
 
-import hudson.BulkChange;
 import hudson.model.Run;
 import jenkins.model.RunAction2;
 
 public class NamespaceAction extends AbstractInvisibleRunAction2 implements RunAction2 {
 
-    private static final Logger LOGGER = Logger.getLogger(NamespaceAction.class.getName());
-
-    private final Stack<String> namespaces = new Stack<>();
-
     public NamespaceAction(Run<?, ?> run) {
-        setRun(run);
-    }
-
-    public void push(String namespace) throws IOException {
-        if (getRun() == null) {
-            LOGGER.warning("run is null, cannot push");
-            return;
-        }
-        synchronized (getRun()) {
-            BulkChange bc = new BulkChange(getRun());
-            try {
-                NamespaceAction action = getRun().getAction(NamespaceAction.class);
-                if (action == null) {
-                    action = new NamespaceAction(getRun());
-                    getRun().addAction(action);
-                }
-                action.namespaces.push(namespace);
-                bc.commit();
-            } finally {
-                bc.abort();
-            }
-        }
-    }
-
-    public String pop() throws IOException {
-        if (getRun() == null) {
-            LOGGER.warning("run is null, cannot pop");
-            return null;
-        }
-        synchronized (getRun()) {
-            BulkChange bc = new BulkChange(getRun());
-            try {
-                NamespaceAction action = getRun().getAction(NamespaceAction.class);
-                if (action == null) {
-                    action = new NamespaceAction(getRun());
-                    getRun().addAction(action);
-                }
-                String namespace = action.namespaces.pop();
-                bc.commit();
-                return namespace;
-            } finally {
-                bc.abort();
-                return null;
-            }
-        }
+        super(run);
     }
 
     public String getNamespace() {
@@ -71,7 +19,7 @@ public class NamespaceAction extends AbstractInvisibleRunAction2 implements RunA
                 getRun().addAction(action);
             }
             try {
-                return action.namespaces.peek();
+                return action.stack.peek();
             } catch (EmptyStackException e) {
                 return null;
             }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/NamespaceAction.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/NamespaceAction.java
@@ -1,40 +1,36 @@
 package org.csanchez.jenkins.plugins.kubernetes.pipeline;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.EmptyStackException;
-import java.util.List;
 import java.util.Stack;
 import java.util.logging.Logger;
 
 import hudson.BulkChange;
-import hudson.model.InvisibleAction;
 import hudson.model.Run;
+import jenkins.model.RunAction2;
 
-public class NamespaceAction extends InvisibleAction {
+public class NamespaceAction extends AbstractInvisibleRunAction2 implements RunAction2 {
 
     private static final Logger LOGGER = Logger.getLogger(NamespaceAction.class.getName());
 
     private final Stack<String> namespaces = new Stack<>();
-    private final Run run;
 
-
-    public NamespaceAction(Run run) {
-        this.run = run;
+    public NamespaceAction(Run<?, ?> run) {
+        setRun(run);
     }
 
     public void push(String namespace) throws IOException {
-        if (run == null) {
+        if (getRun() == null) {
             LOGGER.warning("run is null, cannot push");
             return;
         }
-        synchronized (run) {
-            BulkChange bc = new BulkChange(run);
+        synchronized (getRun()) {
+            BulkChange bc = new BulkChange(getRun());
             try {
-                NamespaceAction action = run.getAction(NamespaceAction.class);
+                NamespaceAction action = getRun().getAction(NamespaceAction.class);
                 if (action == null) {
-                    action = new NamespaceAction(run);
-                    run.addAction(action);
+                    action = new NamespaceAction(getRun());
+                    getRun().addAction(action);
                 }
                 action.namespaces.push(namespace);
                 bc.commit();
@@ -45,17 +41,17 @@ public class NamespaceAction extends InvisibleAction {
     }
 
     public String pop() throws IOException {
-        if (run == null) {
+        if (getRun() == null) {
             LOGGER.warning("run is null, cannot pop");
             return null;
         }
-        synchronized (run) {
-            BulkChange bc = new BulkChange(run);
+        synchronized (getRun()) {
+            BulkChange bc = new BulkChange(getRun());
             try {
-                NamespaceAction action = run.getAction(NamespaceAction.class);
+                NamespaceAction action = getRun().getAction(NamespaceAction.class);
                 if (action == null) {
-                    action = new NamespaceAction(run);
-                    run.addAction(action);
+                    action = new NamespaceAction(getRun());
+                    getRun().addAction(action);
                 }
                 String namespace = action.namespaces.pop();
                 bc.commit();
@@ -68,11 +64,11 @@ public class NamespaceAction extends InvisibleAction {
     }
 
     public String getNamespace() {
-        synchronized (run) {
-            NamespaceAction action = run.getAction(NamespaceAction.class);
+        synchronized (getRun()) {
+            NamespaceAction action = getRun().getAction(NamespaceAction.class);
             if (action == null) {
-                action = new NamespaceAction(run);
-                run.addAction(action);
+                action = new NamespaceAction(getRun());
+                getRun().addAction(action);
             }
             try {
                 return action.namespaces.peek();

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateAction.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateAction.java
@@ -12,6 +12,11 @@ public class PodTemplateAction extends AbstractInvisibleRunAction2 implements Ru
         super(run);
     }
 
+    @Override
+    protected AbstractInvisibleRunAction2 createAction(Run<?, ?> run) {
+        return new PodTemplateAction(run);
+    }
+
     public List<String> getParentTemplateList() {
         synchronized (getRun()) {
             PodTemplateAction action = getRun().getAction(PodTemplateAction.class);

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateAction.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateAction.java
@@ -1,31 +1,36 @@
 package org.csanchez.jenkins.plugins.kubernetes.pipeline;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.Run;
 import jenkins.model.RunAction2;
 
 public class PodTemplateAction extends AbstractInvisibleRunAction2 implements RunAction2 {
 
+    PodTemplateAction() {
+        super();
+    }
+
+    @Deprecated
     PodTemplateAction(Run<?, ?> run) {
         super(run);
     }
 
     @Override
+    @Deprecated
     protected AbstractInvisibleRunAction2 createAction(Run<?, ?> run) {
         return new PodTemplateAction(run);
     }
 
+    protected static void push(@NonNull Run<?, ?> run, @NonNull String item) throws IOException {
+        AbstractInvisibleRunAction2.push(run, PodTemplateAction.class, item);
+    }
+
     public List<String> getParentTemplateList() {
-        synchronized (getRun()) {
-            PodTemplateAction action = getRun().getAction(PodTemplateAction.class);
-            if (action == null) {
-                action = new PodTemplateAction(getRun());
-                getRun().addAction(action);
-            }
-            return new ArrayList<>(action.stack);
-        }
+        return new ArrayList<>(stack);
     }
 
     public String getParentTemplates() {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateAction.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateAction.java
@@ -1,67 +1,15 @@
 package org.csanchez.jenkins.plugins.kubernetes.pipeline;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Stack;
-import java.util.logging.Logger;
 
-import hudson.BulkChange;
 import hudson.model.Run;
 import jenkins.model.RunAction2;
 
 public class PodTemplateAction extends AbstractInvisibleRunAction2 implements RunAction2 {
 
-    private static final Logger LOGGER = Logger.getLogger(PodTemplateAction.class.getName());
-
-    private final Stack<String> names = new Stack<>();
-
     PodTemplateAction(Run<?, ?> run) {
-        setRun(run);
-    }
-
-    public void push(String template) throws IOException {
-        if (getRun() == null) {
-            LOGGER.warning("run is null, cannot push");
-            return;
-        }
-        synchronized (getRun()) {
-            BulkChange bc = new BulkChange(getRun());
-            try {
-                PodTemplateAction action = getRun().getAction(PodTemplateAction.class);
-                if (action == null) {
-                    action = new PodTemplateAction(getRun());
-                    getRun().addAction(action);
-                }
-                action.names.push(template);
-                bc.commit();
-            } finally {
-                bc.abort();
-            }
-        }
-    }
-
-    public String pop() throws IOException {
-        if (getRun() == null) {
-            LOGGER.warning("run is null, cannot pop");
-            return null;
-        }
-        synchronized (getRun()) {
-            BulkChange bc = new BulkChange(getRun());
-            try {
-                PodTemplateAction action = getRun().getAction(PodTemplateAction.class);
-                if (action == null) {
-                    action = new PodTemplateAction(getRun());
-                    getRun().addAction(action);
-                }
-                String template = action.names.pop();
-                bc.commit();
-                return template;
-            } finally {
-                bc.abort();
-                return null;
-            }
-        }
+        super(run);
     }
 
     public List<String> getParentTemplateList() {
@@ -71,7 +19,7 @@ public class PodTemplateAction extends AbstractInvisibleRunAction2 implements Ru
                 action = new PodTemplateAction(getRun());
                 getRun().addAction(action);
             }
-            return new ArrayList<>(action.names);
+            return new ArrayList<>(action.stack);
         }
     }
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateAction.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateAction.java
@@ -3,30 +3,74 @@ package org.csanchez.jenkins.plugins.kubernetes.pipeline;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Logger;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.BulkChange;
 import hudson.model.Run;
 import jenkins.model.RunAction2;
 
 public class PodTemplateAction extends AbstractInvisibleRunAction2 implements RunAction2 {
+
+    private static final Logger LOGGER = Logger.getLogger(PodTemplateAction.class.getName());
 
     PodTemplateAction() {
         super();
     }
 
     @Deprecated
-    PodTemplateAction(Run<?, ?> run) {
-        super(run);
-    }
-
-    @Override
-    @Deprecated
-    protected AbstractInvisibleRunAction2 createAction(Run<?, ?> run) {
-        return new PodTemplateAction(run);
+    PodTemplateAction(Run run) {
+        setRun(run);
     }
 
     protected static void push(@NonNull Run<?, ?> run, @NonNull String item) throws IOException {
         AbstractInvisibleRunAction2.push(run, PodTemplateAction.class, item);
+    }
+
+    @Deprecated
+    public void push(String template) throws IOException {
+        if (run == null) {
+            LOGGER.warning("run is null, cannot push");
+            return;
+        }
+        synchronized (run) {
+            BulkChange bc = new BulkChange(run);
+            try {
+                PodTemplateAction action = run.getAction(PodTemplateAction.class);
+                if (action == null) {
+                    action = new PodTemplateAction(run);
+                    run.addAction(action);
+                }
+                action.stack.push(template);
+                bc.commit();
+            } finally {
+                bc.abort();
+            }
+        }
+    }
+
+    @Deprecated
+    public String pop() throws IOException {
+        if (run == null) {
+            LOGGER.warning("run is null, cannot pop");
+            return null;
+        }
+        synchronized (run) {
+            BulkChange bc = new BulkChange(run);
+            try {
+                PodTemplateAction action = run.getAction(PodTemplateAction.class);
+                if (action == null) {
+                    action = new PodTemplateAction(run);
+                    run.addAction(action);
+                }
+                String template = action.stack.pop();
+                bc.commit();
+                return template;
+            } finally {
+                bc.abort();
+                return null;
+            }
+        }
     }
 
     public List<String> getParentTemplateList() {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateAction.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateAction.java
@@ -7,33 +7,31 @@ import java.util.Stack;
 import java.util.logging.Logger;
 
 import hudson.BulkChange;
-import hudson.model.InvisibleAction;
 import hudson.model.Run;
+import jenkins.model.RunAction2;
 
-public class PodTemplateAction extends InvisibleAction {
+public class PodTemplateAction extends AbstractInvisibleRunAction2 implements RunAction2 {
 
     private static final Logger LOGGER = Logger.getLogger(PodTemplateAction.class.getName());
 
     private final Stack<String> names = new Stack<>();
-    private final Run run;
 
-
-    PodTemplateAction(Run run) {
-        this.run = run;
+    PodTemplateAction(Run<?, ?> run) {
+        setRun(run);
     }
 
     public void push(String template) throws IOException {
-        if (run == null) {
+        if (getRun() == null) {
             LOGGER.warning("run is null, cannot push");
             return;
         }
-        synchronized (run) {
-            BulkChange bc = new BulkChange(run);
+        synchronized (getRun()) {
+            BulkChange bc = new BulkChange(getRun());
             try {
-                PodTemplateAction action = run.getAction(PodTemplateAction.class);
+                PodTemplateAction action = getRun().getAction(PodTemplateAction.class);
                 if (action == null) {
-                    action = new PodTemplateAction(run);
-                    run.addAction(action);
+                    action = new PodTemplateAction(getRun());
+                    getRun().addAction(action);
                 }
                 action.names.push(template);
                 bc.commit();
@@ -44,17 +42,17 @@ public class PodTemplateAction extends InvisibleAction {
     }
 
     public String pop() throws IOException {
-        if (run == null) {
+        if (getRun() == null) {
             LOGGER.warning("run is null, cannot pop");
             return null;
         }
-        synchronized (run) {
-            BulkChange bc = new BulkChange(run);
+        synchronized (getRun()) {
+            BulkChange bc = new BulkChange(getRun());
             try {
-                PodTemplateAction action = run.getAction(PodTemplateAction.class);
+                PodTemplateAction action = getRun().getAction(PodTemplateAction.class);
                 if (action == null) {
-                    action = new PodTemplateAction(run);
-                    run.addAction(action);
+                    action = new PodTemplateAction(getRun());
+                    getRun().addAction(action);
                 }
                 String template = action.names.pop();
                 bc.commit();
@@ -67,11 +65,11 @@ public class PodTemplateAction extends InvisibleAction {
     }
 
     public List<String> getParentTemplateList() {
-        synchronized (run) {
-            PodTemplateAction action = run.getAction(PodTemplateAction.class);
+        synchronized (getRun()) {
+            PodTemplateAction action = getRun().getAction(PodTemplateAction.class);
             if (action == null) {
-                action = new PodTemplateAction(run);
-                run.addAction(action);
+                action = new PodTemplateAction(getRun());
+                getRun().addAction(action);
             }
             return new ArrayList<>(action.names);
         }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
@@ -206,8 +206,7 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
 
         WorkflowRun b = p.scheduleBuild2(0).waitForStart();
         assertNotNull(b);
-        NamespaceAction namespaceAction = new NamespaceAction(b);
-        namespaceAction.push(overriddenNamespace);
+        NamespaceAction.push(b, overriddenNamespace);
 
         r.assertBuildStatusSuccess(r.waitForCompletion(b));
         r.assertLogContains(overriddenNamespace, b);
@@ -232,8 +231,7 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
 
         WorkflowRun b = p.scheduleBuild2(0).waitForStart();
         assertNotNull(b);
-        NamespaceAction namespaceAction = new NamespaceAction(b);
-        namespaceAction.push(overriddenNamespace);
+        NamespaceAction.push(b, overriddenNamespace);
 
         r.assertBuildStatusSuccess(r.waitForCompletion(b));
         r.assertLogContains(stepNamespace, b);


### PR DESCRIPTION
…tTopLevel

[JENKINS-45892](https://issues.jenkins-ci.org/browse/JENKINS-45892) introduced a change that is causing

```
Nov 29, 2017 6:58:52 PM hudson.XmlFile replaceIfNotAtTopLevel
WARNING: JENKINS-45892: reference to org.jenkinsci.plugins.workflow.job.WorkflowJob@488f6bf6[cloudbees/test/branch] being saved from unexpected /var/jenkins_home/jobs/test/branches/branch.njvm0k/builds/7/build.xml
java.lang.IllegalStateException
        at hudson.XmlFile.replaceIfNotAtTopLevel(XmlFile.java:210)
```
