### PR TITLE
allow a PodTemplate to be configured by name in declarative pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,29 @@ Declarative Pipeline support requires Jenkins 2.66+
 
 Example at [examples/declarative.groovy](examples/declarative.groovy)
 
+### Referring to PodTemplates
+
+You can refer to a named PodTemplate in the Jenkins configuration via the **inheritFrom** property as follows:
+
+```groovy
+pipeline {
+  agent {
+    kubernetes {
+      label "my-build-pod"
+      inheritFrom "maven"
+    }
+  }
+  ...
+}
+``` 
+
+The meaning of the values is as follows:
+
+* **label** is used to add a kubernetes label to the build pods created by the pipeline jobs
+* **inheritFrom**  is used to lookup a named PodTemplate in the Jenkins configuration for the Kubernetes Cloud and uses that as the basis for the PodTemplate for this pipeline
+
+So the above example will reuse the **maven** podTemplate from the Jenkins Kubernetes Cloud configuration and then label the build pod with **my-build-pod**.
+
 ## Accessing container logs from the pipeline
 
 If you use the `containerTemplate` to run some service in the background

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
@@ -56,6 +56,23 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
     public ContainerTemplate(String image) {
         this(null, image);
     }
+    public ContainerTemplate(ContainerTemplate that) {
+        setAlwaysPullImage(that.isAlwaysPullImage());
+        setArgs(that.getArgs());
+        setCommand(that.getCommand());
+        setEnvVars(that.getEnvVars());
+        setImage(that.getImage());
+        setLivenessProbe(that.getLivenessProbe());
+        setName(that.getName());
+        setPorts(that.getPorts());
+        setPrivileged(that.isPrivileged());
+        setResourceLimitCpu(that.getResourceLimitCpu());
+        setResourceLimitMemory(that.getResourceLimitMemory());
+        setResourceRequestCpu(that.getResourceRequestCpu());
+        setResourceRequestMemory(that.getResourceRequestMemory());
+        setTtyEnabled(that.isTtyEnabled());
+        setWorkingDir(that.getWorkingDir());
+    }
 
     @DataBoundConstructor
     public ContainerTemplate(String name, String image) {
@@ -70,6 +87,14 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
         this.image = image;
         this.command = command;
         this.args = args;
+    }
+
+    @Override
+    public String toString() {
+        return "ContainerTemplate{" +
+                "name='" + name + '\'' +
+                ", image='" + image + '\'' +
+                '}';
     }
 
     @DataBoundSetter

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -71,6 +71,8 @@ import jenkins.model.JenkinsLocationConfiguration;
 public class KubernetesCloud extends Cloud {
     public static final int DEFAULT_MAX_REQUESTS_PER_HOST = 32;
 
+    public static final String DEFAULT_CLOUD_NAME = "kubernetes";
+
     private static final Logger LOGGER = Logger.getLogger(KubernetesCloud.class.getName());
 
     private static final String DEFAULT_ID = "jenkins/slave-default";

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -218,6 +218,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
         return getFirstContainer().map(ContainerTemplate::getWorkingDir).orElse(null);
     }
 
+
     public void setInstanceCap(int instanceCap) {
         if (instanceCap < 0) {
             this.instanceCap = Integer.MAX_VALUE;
@@ -547,6 +548,19 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
         synchronized (this.containers) {
             this.containers.clear();
             this.containers.addAll(items);
+        }
+    }
+
+    /**
+     * Helper method to let you specify a single containerTemplate inside the podTemplate
+     *
+     * though note this does not yet you configure more than one containerTemplate!
+     * See <a href="https://issues.jenkins-ci.org/browse/JENKINS-48135">JENKINS-48135</a>
+     */
+    @DataBoundSetter
+    public void setContainerTemplate(ContainerTemplate item) {
+        synchronized (this.containers) {
+            this.containers.add(item);
         }
     }
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgent.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgent.java
@@ -1,7 +1,19 @@
 package org.csanchez.jenkins.plugins.kubernetes.pipeline;
 
+import com.google.common.base.Strings;
+import hudson.Util;
+import hudson.model.labels.LabelAtom;
+import hudson.slaves.Cloud;
+import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
 import org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate;
+import org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud;
+import org.csanchez.jenkins.plugins.kubernetes.PodAnnotation;
+import org.csanchez.jenkins.plugins.kubernetes.PodImagePullSecret;
+import org.csanchez.jenkins.plugins.kubernetes.PodTemplate;
+import org.csanchez.jenkins.plugins.kubernetes.PodTemplateUtils;
+import org.csanchez.jenkins.plugins.kubernetes.model.TemplateEnvVar;
+import org.csanchez.jenkins.plugins.kubernetes.volumes.PodVolume;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgent;
 import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentDescriptor;
@@ -10,10 +22,15 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
+import java.util.logging.Logger;
 
 public class KubernetesDeclarativeAgent extends DeclarativeAgent<KubernetesDeclarativeAgent> {
+    private static final Logger LOGGER = Logger.getLogger(KubernetesCloud.class.getName());
+
     private final String label;
 
     private String cloud;
@@ -26,11 +43,17 @@ public class KubernetesDeclarativeAgent extends DeclarativeAgent<KubernetesDecla
     private int activeDeadlineSeconds;
 
     private ContainerTemplate containerTemplate;
+    private PodTemplate podTemplate;
 
-    @DataBoundConstructor
+    @Deprecated
     public KubernetesDeclarativeAgent(String label, ContainerTemplate containerTemplate) {
         this.label = label;
         this.containerTemplate = containerTemplate;
+    }
+
+    @DataBoundConstructor
+    public KubernetesDeclarativeAgent(String label) {
+        this.label = label;
     }
 
     public String getLabel() {
@@ -52,7 +75,7 @@ public class KubernetesDeclarativeAgent extends DeclarativeAgent<KubernetesDecla
 
     @DataBoundSetter
     public void setInheritFrom(String inheritFrom) {
-        this.inheritFrom = inheritFrom;
+        this.inheritFrom = Util.fixEmpty(inheritFrom);
     }
 
     public int getInstanceCap() {
@@ -91,8 +114,53 @@ public class KubernetesDeclarativeAgent extends DeclarativeAgent<KubernetesDecla
         this.workingDir = workingDir;
     }
 
+    /**
+     * Returns the effective first {@link ContainerTemplate} either configured directly or from the effective PodTemplate
+     * @return
+     */
     public ContainerTemplate getContainerTemplate() {
+        PodTemplate pod = getPodTemplate();
+        if (pod != null) {
+            List<ContainerTemplate> containers = pod.getContainers();
+            if (containers != null && containers.size() > 0) {
+                return containers.get(0);
+            }
+        }
         return containerTemplate;
+    }
+
+    @DataBoundSetter
+    public void setContainerTemplate(ContainerTemplate containerTemplate) {
+        this.containerTemplate = containerTemplate;
+    }
+
+    /**
+     * Returns the effective {@link PodTemplate} after taking into account the use of the {@link #setInheritFrom(String)} property
+     */
+    public PodTemplate getPodTemplate() {
+        String inheritFromValue = this.inheritFrom;
+        // if we have a podTemplate and it has an inheritFrom then use that instead
+        if (podTemplate != null && podTemplate.getInheritFrom() != null) {
+            inheritFromValue = podTemplate.getInheritFrom();
+        }
+        if (inheritFromValue != null) {
+            PodTemplate parent = findPodTemplate(inheritFromValue);
+            if (parent == null) {
+                LOGGER.warning("Could not find a PodTemplate called " + inheritFromValue + " in the cloud " + getCloud() + " so cannot default the PodTemplate");
+            } else {
+                if (podTemplate == null) {
+                    return parent;
+                } else {
+                    return PodTemplateUtils.combine(parent, podTemplate);
+                }
+            }
+        }
+        return podTemplate;
+    }
+
+    @DataBoundSetter
+    public void setPodTemplate(PodTemplate podTemplate) {
+        this.podTemplate = podTemplate;
     }
 
     public int getActiveDeadlineSeconds() {
@@ -101,14 +169,68 @@ public class KubernetesDeclarativeAgent extends DeclarativeAgent<KubernetesDecla
 
     @DataBoundSetter
     public void setActiveDeadlineSeconds(int activeDeadlineSeconds) { this.activeDeadlineSeconds = activeDeadlineSeconds; }
-
+    
     public Map<String,Object> getAsArgs() {
         Map<String,Object> argMap = new TreeMap<>();
 
+        int instanceCap = this.instanceCap;
+        int activeDeadlineSeconds = this.activeDeadlineSeconds;
+        String inheritFrom = this.inheritFrom;
+        String nodeSelector = this.nodeSelector;
+        String serviceAccount = this.serviceAccount;
+        String label = this.label;
+
+        PodTemplate podTemplate = getPodTemplate();
+        if (podTemplate != null) {
+            if (StringUtils.isEmpty(label)) {
+                label = podTemplate.getLabel();
+                if (StringUtils.isEmpty(label)) {
+                    label = podTemplate.getName();
+                }
+            }
+            // override properties if specified on the podTemplate
+            if (podTemplate.getInstanceCap() > 0) {
+                instanceCap = podTemplate.getInstanceCap();
+            }
+            if (podTemplate.getActiveDeadlineSeconds() > 0) {
+                activeDeadlineSeconds = podTemplate.getActiveDeadlineSeconds();
+            }
+            if (!StringUtils.isEmpty(podTemplate.getNodeSelector())) {
+                nodeSelector = podTemplate.getNodeSelector();
+            }
+            if (!StringUtils.isEmpty(podTemplate.getServiceAccount())) {
+                serviceAccount = podTemplate.getServiceAccount();
+            }
+
+
+            argMap.put("containers", podTemplate.getContainers());
+
+            List<PodAnnotation> annotations = podTemplate.getAnnotations();
+            if (annotations != null && annotations.size() > 0) {
+                argMap.put("annotations", annotations);
+            }
+            Set<LabelAtom> labelSet = podTemplate.getLabelSet();
+            if (labelSet != null && labelSet.size() > 0) {
+                argMap.put("labelSet", labelSet);
+            }
+            List<TemplateEnvVar> envVars = podTemplate.getEnvVars();
+            if (envVars != null && envVars.size() > 0) {
+                argMap.put("envVars", envVars);
+            }
+            List<PodImagePullSecret> imagePullSecrets = podTemplate.getImagePullSecrets();
+            if (imagePullSecrets != null && imagePullSecrets.size() > 0) {
+                argMap.put("imagePullSecrets", imagePullSecrets);
+            }
+            List<PodVolume> volumes = podTemplate.getVolumes();
+            if (volumes != null && volumes.size() > 0) {
+                argMap.put("volumes", volumes);
+            }
+            argMap.put("podTemplate", Collections.singletonList(podTemplate));
+        } else if (containerTemplate != null) {
+            argMap.put("containers", Collections.singletonList(containerTemplate));
+        }
         argMap.put("label", label);
         argMap.put("name", label);
-        argMap.put("containers", Collections.singletonList(containerTemplate));
-
         if (!StringUtils.isEmpty(cloud)) {
             argMap.put("cloud", cloud);
         }
@@ -127,12 +249,42 @@ public class KubernetesDeclarativeAgent extends DeclarativeAgent<KubernetesDecla
         if (activeDeadlineSeconds != 0) {
             argMap.put("activeDeadlineSeconds", activeDeadlineSeconds);
         }
-
         if (instanceCap > 0) {
             argMap.put("instanceCap", instanceCap);
         }
-
         return argMap;
+    }
+
+    protected PodTemplate findPodTemplate(String inheritFrom) {
+        PodTemplate template = null;
+        if (!Strings.isNullOrEmpty(inheritFrom)) {
+            String cloudName = getCloud();
+            if (StringUtils.isEmpty(cloudName)) {
+                cloudName = KubernetesCloud.DEFAULT_CLOUD_NAME;
+            }
+            Cloud cloud = Jenkins.getInstance().getCloud(cloudName);
+            if (cloud instanceof KubernetesCloud) {
+                KubernetesCloud kubernetesCloud = (KubernetesCloud) cloud;
+                List<PodTemplate> templates = kubernetesCloud.getTemplates();
+                for (PodTemplate t : templates) {
+                    String name = t.getName();
+                    if (inheritFrom.equals(name)) {
+                        template = t;
+                        break;
+                    }
+                }
+                if (template == null) {
+                    for (PodTemplate t : templates) {
+                        String label = t.getLabel();
+                        if (inheritFrom.equals(label)) {
+                            template = t;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        return template;
     }
 
     @OptionalExtension(requirePlugins = "pipeline-model-extensions") @Symbol("kubernetes")

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate;
+import org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud;
 import org.csanchez.jenkins.plugins.kubernetes.PodAnnotation;
 import org.csanchez.jenkins.plugins.kubernetes.PodTemplate;
 import org.csanchez.jenkins.plugins.kubernetes.model.TemplateEnvVar;
@@ -30,9 +31,7 @@ public class PodTemplateStep extends Step implements Serializable {
 
     private static final long serialVersionUID = 5588861066775717487L;
 
-    private static final String DEFAULT_CLOUD = "kubernetes";
-
-    private String cloud = DEFAULT_CLOUD;
+    private String cloud = KubernetesCloud.DEFAULT_CLOUD_NAME;
     private String inheritFrom;
 
     private final String label;

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/AbstractKubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/AbstractKubernetesPipelineTest.java
@@ -83,6 +83,7 @@ public class AbstractKubernetesPipelineTest {
         createSecret(cloud.connect());
         cloud.getTemplates().clear();
         cloud.addTemplate(buildBusyboxTemplate("busybox"));
+        cloud.addTemplate(mavenTemplate("maven"));
 
         // Slaves running in Kubernetes (minikube) need to connect to this server, so localhost does not work
         URL url = r.getURL();
@@ -101,9 +102,22 @@ public class AbstractKubernetesPipelineTest {
     private PodTemplate buildBusyboxTemplate(String label) {
         // Create a busybox template
         PodTemplate podTemplate = new PodTemplate();
+        podTemplate.setName(label);
         podTemplate.setLabel(label);
 
         ContainerTemplate containerTemplate = new ContainerTemplate("busybox", "busybox", "cat", "");
+        containerTemplate.setTtyEnabled(true);
+        podTemplate.getContainers().add(containerTemplate);
+        setEnvVariables(podTemplate);
+        return podTemplate;
+    }
+
+    private PodTemplate mavenTemplate(String label) {
+        PodTemplate podTemplate = new PodTemplate();
+        podTemplate.setName(label);
+        podTemplate.setLabel(label);
+
+        ContainerTemplate containerTemplate = new ContainerTemplate("maven", "maven:3.3.9-jdk-8-alpine", "cat", "");
         containerTemplate.setTtyEnabled(true);
         podTemplate.getContainers().add(containerTemplate);
         setEnvVariables(podTemplate);

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesInheritPodTemplateDeclarativeAgentTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesInheritPodTemplateDeclarativeAgentTest.java
@@ -24,21 +24,21 @@
 
 package org.csanchez.jenkins.plugins.kubernetes.pipeline;
 
-import static org.junit.Assert.*;
-
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
-public class KubernetesDeclarativeAgentTest extends AbstractKubernetesPipelineTest {
+import static org.junit.Assert.assertNotNull;
 
-    @Issue("JENKINS-41758")
+public class KubernetesInheritPodTemplateDeclarativeAgentTest extends AbstractKubernetesPipelineTest {
+
+    @Issue("JENKINS-48140")
     @Test
     public void declarative() throws Exception {
-        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "declarative pipeline with containerTemplate");
-        p.setDefinition(new CpsFlowDefinition(loadPipelineScript("declarative.groovy"), true));
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "declarative pipeline inherit podTemplate");
+        p.setDefinition(new CpsFlowDefinition(loadPipelineScript("declarativeInheritPod.groovy"), true));
         WorkflowRun b = p.scheduleBuild2(0).waitForStart();
         assertNotNull(b);
         r.assertBuildStatusSuccess(r.waitForCompletion(b));

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPodTemplateDeclarativeAgentTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPodTemplateDeclarativeAgentTest.java
@@ -24,21 +24,21 @@
 
 package org.csanchez.jenkins.plugins.kubernetes.pipeline;
 
-import static org.junit.Assert.*;
-
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
-public class KubernetesDeclarativeAgentTest extends AbstractKubernetesPipelineTest {
+import static org.junit.Assert.assertNotNull;
+
+public class KubernetesPodTemplateDeclarativeAgentTest extends AbstractKubernetesPipelineTest {
 
     @Issue("JENKINS-41758")
     @Test
     public void declarative() throws Exception {
-        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "declarative pipeline with containerTemplate");
-        p.setDefinition(new CpsFlowDefinition(loadPipelineScript("declarative.groovy"), true));
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "declarative pipeline with podTemplate");
+        p.setDefinition(new CpsFlowDefinition(loadPipelineScript("declarativePod.groovy"), true));
         WorkflowRun b = p.scheduleBuild2(0).waitForStart();
         assertNotNull(b);
         r.assertBuildStatusSuccess(r.waitForCompletion(b));

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPodTemplateWithInheritFromDeclarativeAgentTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPodTemplateWithInheritFromDeclarativeAgentTest.java
@@ -24,21 +24,21 @@
 
 package org.csanchez.jenkins.plugins.kubernetes.pipeline;
 
-import static org.junit.Assert.*;
-
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
-public class KubernetesDeclarativeAgentTest extends AbstractKubernetesPipelineTest {
+import static org.junit.Assert.assertNotNull;
 
-    @Issue("JENKINS-41758")
+public class KubernetesPodTemplateWithInheritFromDeclarativeAgentTest extends AbstractKubernetesPipelineTest {
+
+    @Issue("JENKINS-48140")
     @Test
     public void declarative() throws Exception {
-        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "declarative pipeline with containerTemplate");
-        p.setDefinition(new CpsFlowDefinition(loadPipelineScript("declarative.groovy"), true));
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "declarative pipeline with podTemplate and inheritFrom");
+        p.setDefinition(new CpsFlowDefinition(loadPipelineScript("declarativePodWithInheritFrom.groovy"), true));
         WorkflowRun b = p.scheduleBuild2(0).waitForStart();
         assertNotNull(b);
         r.assertBuildStatusSuccess(r.waitForCompletion(b));

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/declarativeInheritPod.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/declarativeInheritPod.groovy
@@ -1,0 +1,21 @@
+pipeline {
+  agent {
+    kubernetes {
+      label 'mypod'
+      inheritFrom 'maven'
+    }
+  }
+  environment {
+    CONTAINER_ENV_VAR = 'container-env-var-value'
+  }
+  stages {
+    stage('Run maven') {
+      steps {
+        container('maven') {
+          sh 'echo INSIDE_CONTAINER_ENV_VAR = ${CONTAINER_ENV_VAR}'
+          sh 'mvn -version'
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/declarativePod.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/declarativePod.groovy
@@ -1,0 +1,29 @@
+pipeline {
+  agent {
+    kubernetes {
+      label 'mypod'
+      podTemplate {
+        name 'mypodtemplate'
+        containerTemplate {
+          name 'maven'
+          image 'maven:3.3.9-jdk-8-alpine'
+          ttyEnabled true
+          command 'cat'
+        }
+      }
+    }
+  }
+  environment {
+    CONTAINER_ENV_VAR = 'container-env-var-value'
+  }
+  stages {
+    stage('Run maven') {
+      steps {
+        container('maven') {
+          sh 'echo INSIDE_CONTAINER_ENV_VAR = ${CONTAINER_ENV_VAR}'
+          sh 'mvn -version'
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/declarativePodWithInheritFrom.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/declarativePodWithInheritFrom.groovy
@@ -1,0 +1,23 @@
+pipeline {
+  agent {
+    kubernetes {
+      label 'mypod'
+      podTemplate {
+        inheritFrom 'maven'
+      }
+    }
+  }
+  environment {
+    CONTAINER_ENV_VAR = 'container-env-var-value'
+  }
+  stages {
+    stage('Run maven') {
+      steps {
+        container('maven') {
+          sh 'echo INSIDE_CONTAINER_ENV_VAR = ${CONTAINER_ENV_VAR}'
+          sh 'mvn -version'
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
allows either a nested `podTemplate` or the use of `inheritFrom` in declarative pipelines to specify a `PodTemplate`
includes lots of great feedback from @carlossg
fixes JENKINS-48140

cc @carlossg @shaiazulay 