### PR TITLE
Test branches in separate namespaces if they exist

### DIFF
--- a/Jenkinsfile-kubernetes
+++ b/Jenkinsfile-kubernetes
@@ -19,7 +19,8 @@ timestamps {
         resourceRequestCpu: '100m',
         resourceLimitMemory: '1200Mi')
     ], envVars: [
-        envVar(key: '_JAVA_OPTIONS', value: jvmOptions)
+        envVar(key: '_JAVA_OPTIONS', value: jvmOptions),
+        envVar(key: 'BRANCH_NAME', value: env.BRANCH_NAME)
     ], volumes: [
       persistentVolumeClaim(mountPath: '/root/.m2/repository-read-only', claimName: 'maven-repo', readOnly: true)
     ]) {

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesTestUtil.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesTestUtil.java
@@ -40,6 +40,8 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import org.apache.commons.lang.StringUtils;
+
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodList;
@@ -55,7 +57,8 @@ public class KubernetesTestUtil {
 
     private static final Logger LOGGER = Logger.getLogger(KubernetesTestUtil.class.getName());
 
-    public static final String TESTING_NAMESPACE = "kubernetes-plugin-test";
+    private static final String DEFAULT_TESTING_NAMESPACE = "kubernetes-plugin-test";
+    public static String testingNamespace;
 
     public static KubernetesCloud setupCloud() throws UnrecoverableKeyException, CertificateEncodingException,
             NoSuchAlgorithmException, KeyStoreException, IOException {
@@ -63,11 +66,26 @@ public class KubernetesTestUtil {
         KubernetesClient client = cloud.connect();
 
         // Run in our own testing namespace
-        if (client.namespaces().withName(TESTING_NAMESPACE).get() == null) {
-            client.namespaces()
-                    .create(new NamespaceBuilder().withNewMetadata().withName(TESTING_NAMESPACE).endMetadata().build());
+
+        // if there is a namespace specific for this branch (ie. kubernetes-plugin-test-master), use it
+        String branch = System.getenv("BRANCH_NAME");
+        if (StringUtils.isNotBlank(branch)) {
+            String namespaceWithBranch = String.format("%s-%s", DEFAULT_TESTING_NAMESPACE, branch);
+            LOGGER.log(FINE, "Trying to use namespace: {0}", testingNamespace);
+            if (client.namespaces().withName(namespaceWithBranch).get() != null) {
+                testingNamespace = namespaceWithBranch;
+            }
         }
-        cloud.setNamespace(TESTING_NAMESPACE);
+        if (testingNamespace == null) {
+            testingNamespace = DEFAULT_TESTING_NAMESPACE;
+            if (client.namespaces().withName(testingNamespace).get() == null) {
+                LOGGER.log(INFO, "Creating namespace: {0}", testingNamespace);
+                client.namespaces().create(
+                        new NamespaceBuilder().withNewMetadata().withName(testingNamespace).endMetadata().build());
+            }
+        }
+        LOGGER.log(INFO, "Using namespace {0} for branch {1}", new String[] { testingNamespace, branch });
+        cloud.setNamespace(testingNamespace);
         client = cloud.connect();
 
         return cloud;

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
@@ -227,7 +227,8 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
         }
 
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "stepOverriddenNamespace");
-        p.setDefinition(new CpsFlowDefinition(loadPipelineScript("runWithStepOverriddenNamespace.groovy"), true));
+        p.setDefinition(new CpsFlowDefinition(loadPipelineScript("runWithStepOverriddenNamespace.groovy")
+                .replace("OVERRIDDEN_NAMESPACE", stepNamespace), true));
 
         WorkflowRun b = p.scheduleBuild2(0).waitForStart();
         assertNotNull(b);

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
@@ -193,7 +193,7 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
 
     @Test
     public void runWithOverriddenNamespace() throws Exception {
-        String overriddenNamespace = TESTING_NAMESPACE + "-overridden-namespace";
+        String overriddenNamespace = testingNamespace + "-overridden-namespace";
         KubernetesClient client = cloud.connect();
         // Run in our own testing namespace
         if (client.namespaces().withName(overriddenNamespace).get() == null) {
@@ -217,8 +217,8 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
      * Step namespace should have priority over anything else.
      */
     public void runWithStepOverriddenNamespace() throws Exception {
-        String overriddenNamespace = TESTING_NAMESPACE + "-overridden-namespace";
-        String stepNamespace = TESTING_NAMESPACE + "-overridden-namespace2";
+        String overriddenNamespace = testingNamespace + "-overridden-namespace";
+        String stepNamespace = testingNamespace + "-overridden-namespace2";
         KubernetesClient client = cloud.connect();
         // Run in our own testing namespace
         if (client.namespaces().withName(stepNamespace).get() == null) {

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runWithStepOverriddenNamespace.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runWithStepOverriddenNamespace.groovy
@@ -1,6 +1,6 @@
 // Step namespace should have priority over anything else.
 podTemplate(
-    namespace: 'kubernetes-plugin-test-overridden-namespace2', label: 'mypod',
+    namespace: 'OVERRIDDEN_NAMESPACE', label: 'mypod',
     volumes: [emptyDirVolume(mountPath: '/my-mount')], 
     containers: [
       containerTemplate(name: 'jnlp', image: 'jenkins/jnlp-slave:3.10-1-alpine', args: '${computer.jnlpmac} ${computer.name}')


### PR DESCRIPTION
To prevent multiple tests running simultaneously to collide with each other.

Only separating master from the rest for now