### PR TITLE
[JENKINS-50282] Allow creating Pod templates from yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Either way it provides access to the following fields:
 * **name** The name of the pod.
 * **namespace** The namespace of the pod.
 * **label** The label of the pod. Set a unique value to avoid conflicts across builds
-* **yaml** yaml representation of the Pod, to allow setting any values not supported as fields
+* **yaml** [yaml representation of the Pod](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#pod-v1-core), to allow setting any values not supported as fields
 * **containers** The container templates that are use to create the containers of the pod *(see below)*.
 * **serviceAccount** The service account of the pod.
 * **nodeSelector** The node selector of the pod.
@@ -151,7 +151,8 @@ In order to support any possible value in Kubernetes `Pod` object, we can pass a
 for the template. If any other properties are set outside of the yaml they will take precedence.
 
 ```groovy
-podTemplate(label: 'mypod', yaml: """
+def label = "mypod-${UUID.randomUUID().toString()}"
+podTemplate(label: label, yaml: """
 apiVersion: v1
 kind: Pod
 metadata:
@@ -166,13 +167,15 @@ spec:
     tty: true
 """
 ) {
-    node ('mypod') {
+    node (label) {
       container('busybox') {
         sh "hostname"
       }
     }
 }
 ```
+
+You can use [`readFile` step](https://jenkins.io/doc/pipeline/steps/workflow-basic-steps/#code-readfile-code-read-file-from-workspace) to load the yaml from a file.
 
 #### Liveness Probe Usage
 ```groovy

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Either way it provides access to the following fields:
 * **name** The name of the pod.
 * **namespace** The namespace of the pod.
 * **label** The label of the pod.
+* **yaml** yaml representation of the Pod, to allow setting any values not supported as fields
 * **containers** The container templates that are use to create the containers of the pod *(see below)*.
 * **serviceAccount** The service account of the pod.
 * **nodeSelector** The node selector of the pod.
@@ -139,6 +140,35 @@ The `containerTemplate` is a template of container that will be added to the pod
 * **ttyEnabled** Flag to mark that tty should be enabled.
 * **livenessProbe** Parameters to be added to a exec liveness probe in the container (does not suppot httpGet liveness probes)
 * **ports** Expose ports on the container.
+
+#### Using yaml to Define Pod Templates
+
+In order to support any possible value in Kubernetes `Pod` object, we can pass a yaml snippet that will be used as a base
+for the template. If any other properties are set outside of the yaml they will take precedence.
+
+```groovy
+podTemplate(label: 'mypod', yaml: """
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    some-label: some-label-value
+spec:
+  containers:
+  - name: busybox
+    image: busybox
+    command:
+    - cat
+    tty: true
+"""
+) {
+    node ('mypod') {
+      container('busybox') {
+        sh "hostname"
+      }
+    }
+}
+```
 
 #### Liveness Probe Usage
 ```groovy

--- a/examples/maven-yaml.groovy
+++ b/examples/maven-yaml.groovy
@@ -1,0 +1,32 @@
+/**
+ * This pipeline will execute a simple Maven build using a pod template in yaml
+ */
+
+podTemplate(label: 'maven', yaml: """
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    some-label: some-label-value
+spec:
+  containers:
+  - name: maven
+    image: maven:3.3.9-jdk-8-alpine
+    command:
+    - cat
+    tty: true
+    env:
+    - name: CONTAINER_ENV_VAR
+      value: container-env-var-value
+"""
+  ) {
+
+  node('maven') {
+    stage('Build a Maven project') {
+      git 'https://github.com/jenkinsci/kubernetes-plugin.git'
+      container('maven') {
+          sh 'mvn -B clean package'
+      }
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,12 @@
       <version>${jenkins-workflow-cps.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.9.0</version>
+      <scope>test</scope>
+    </dependency>
 
     <!-- for ContainerExecDecoratorPipelineTest -->
     <dependency>

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -16,6 +16,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -25,6 +26,7 @@ import javax.servlet.ServletException;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
+import org.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateMap;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -44,8 +46,6 @@ import com.google.common.collect.ImmutableMap;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import org.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateMap;
-
 import hudson.Extension;
 import hudson.Util;
 import hudson.init.InitMilestone;
@@ -53,7 +53,6 @@ import hudson.init.Initializer;
 import hudson.model.Computer;
 import hudson.model.Descriptor;
 import hudson.model.Label;
-import hudson.model.Node;
 import hudson.security.ACL;
 import hudson.slaves.Cloud;
 import hudson.slaves.NodeProvisioner;

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
@@ -96,7 +96,7 @@ public class KubernetesLauncher extends JNLPLauncher {
         final PodTemplate unwrappedTemplate = slave.getTemplate();
         try {
             KubernetesClient client = cloud.connect();
-            Pod pod = getPodTemplate(slave, unwrappedTemplate);
+            Pod pod = getPodTemplate(client, slave, unwrappedTemplate);
 
             String podId = pod.getMetadata().getName();
             String namespace = StringUtils.defaultIfBlank(slave.getNamespace(), client.getNamespace());
@@ -209,8 +209,8 @@ public class KubernetesLauncher extends JNLPLauncher {
         }
     }
 
-    private Pod getPodTemplate(KubernetesSlave slave, PodTemplate template) {
-        return template == null ? null : template.build(slave);
+    private Pod getPodTemplate(KubernetesClient client, KubernetesSlave slave, PodTemplate template) {
+        return template == null ? null : template.build(client, slave);
     }
 
     /**

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -274,7 +274,7 @@ public class PodTemplateBuilder {
         EnvVar[] envVars = envVarsMap.values().stream().toArray(EnvVar[]::new);
 
         String cmd = containerTemplate.getArgs();
-        if (slave != null) {
+        if (slave != null && cmd != null) {
             cmd = cmd.replaceAll(JNLPMAC_REF, slave.getComputer().getJnlpMac()) //
                     .replaceAll(NAME_REF, slave.getComputer().getName());
         }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -24,9 +24,11 @@
 
 package org.csanchez.jenkins.plugins.kubernetes;
 
+import static java.nio.charset.StandardCharsets.*;
 import static org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud.*;
 import static org.csanchez.jenkins.plugins.kubernetes.PodTemplateUtils.*;
 
+import java.io.ByteArrayInputStream;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -50,6 +52,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.ContainerPort;
@@ -58,13 +61,16 @@ import io.fabric8.kubernetes.api.model.ExecAction;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
-import io.fabric8.kubernetes.api.model.PodFluent;
+import io.fabric8.kubernetes.api.model.PodFluent.MetadataNested;
+import io.fabric8.kubernetes.api.model.PodFluent.SpecNested;
 import io.fabric8.kubernetes.api.model.Probe;
 import io.fabric8.kubernetes.api.model.ProbeBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeBuilder;
 import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
 
 /**
  * Helper class to build Pods from PodTemplates
@@ -91,20 +97,26 @@ public class PodTemplateBuilder {
 
     private PodTemplate template;
 
+    @CheckForNull
+    private KubernetesSlave slave;
+
     public PodTemplateBuilder(PodTemplate template) {
         this.template = template;
     }
 
+    public PodTemplateBuilder withSlave(KubernetesSlave slave) {
+        this.slave = slave;
+        return this;
+    }
+
     /**
      * Create a Pod object from a PodTemplate
-     * @param slave
-     * @return
      */
-    public Pod build(KubernetesSlave slave) {
+    public Pod build() {
 
         // Build volumes and volume mounts.
-        List<Volume> volumes = new ArrayList<>();
-        Map<String, VolumeMount> volumeMounts = new HashMap();
+        Map<String, Volume> volumes = new HashMap<>();
+        Map<String, VolumeMount> volumeMounts = new HashMap<>();
 
         int i = 0;
         for (final PodVolume volume : template.getVolumes()) {
@@ -113,75 +125,124 @@ public class PodTemplateBuilder {
             final String mountPath = substituteEnv(Paths.get(volume.getMountPath()).normalize().toString());
             if (!volumeMounts.containsKey(mountPath)) {
                 volumeMounts.put(mountPath, new VolumeMount(mountPath, volumeName, false, null));
-                volumes.add(volume.buildVolume(volumeName));
+                volumes.put(volumeName, volume.buildVolume(volumeName));
                 i++;
             }
         }
 
         if (template.getWorkspaceVolume() != null) {
-            volumes.add(template.getWorkspaceVolume().buildVolume(WORKSPACE_VOLUME_NAME));
-        } else {
-            // add an empty volume to share the workspace across the pod
-            volumes.add(new VolumeBuilder().withName(WORKSPACE_VOLUME_NAME).withNewEmptyDir("").build());
+            volumes.put(WORKSPACE_VOLUME_NAME, template.getWorkspaceVolume().buildVolume(WORKSPACE_VOLUME_NAME));
         }
 
         Map<String, Container> containers = new HashMap<>();
-
+        // containers from pod template
         for (ContainerTemplate containerTemplate : template.getContainers()) {
-            containers.put(containerTemplate.getName(), createContainer(slave, containerTemplate, template.getEnvVars(), volumeMounts.values()));
+            containers.put(containerTemplate.getName(),
+                    createContainer(containerTemplate, template.getEnvVars(), volumeMounts.values()));
         }
 
-        if (!containers.containsKey(JNLP_NAME)) {
-            ContainerTemplate containerTemplate = new ContainerTemplate(DEFAULT_JNLP_IMAGE);
-            containerTemplate.setName(JNLP_NAME);
-            containerTemplate.setArgs(DEFAULT_JNLP_ARGUMENTS);
-            containers.put(JNLP_NAME, createContainer(slave, containerTemplate, template.getEnvVars(), volumeMounts.values()));
+        MetadataNested<PodBuilder> metadataBuilder = new PodBuilder().withNewMetadata();
+        if (slave != null) {
+            metadataBuilder.withName(substituteEnv(slave.getNodeName()));
+        }
+
+        Map<String, String> labels = new HashMap<>();
+        if (slave != null) {
+            labels.putAll(slave.getKubernetesCloud().getLabels());
+        }
+        labels.putAll(template.getLabelsMap());
+        if (!labels.isEmpty()) {
+            metadataBuilder.withLabels(labels);
+        }
+
+        Map<String, String> annotations = getAnnotationsMap(template.getAnnotations());
+        if (!annotations.isEmpty()) {
+            metadataBuilder.withAnnotations(annotations);
+        }
+
+        SpecNested<PodBuilder> builder = metadataBuilder.endMetadata().withNewSpec();
+
+        if (template.getActiveDeadlineSeconds() > 0) {
+            builder = builder.withActiveDeadlineSeconds(Long.valueOf(template.getActiveDeadlineSeconds()));
+        }
+
+        if (!volumes.isEmpty()) {
+            builder.withVolumes(volumes.values().toArray(new Volume[volumes.size()]));
+        }
+        if (template.getServiceAccount() != null) {
+            builder.withServiceAccount(substituteEnv(template.getServiceAccount()));
         }
 
         List<LocalObjectReference> imagePullSecrets = template.getImagePullSecrets().stream()
                 .map((x) -> x.toLocalObjectReference()).collect(Collectors.toList());
-
-        PodFluent.SpecNested<PodBuilder> builder = new PodBuilder()
-                .withNewMetadata()
-                .withName(substituteEnv(slave.getNodeName()))
-                .withLabels(slave.getKubernetesCloud().getLabelsMap(template.getLabelSet()))
-                .withAnnotations(getAnnotationsMap(template.getAnnotations()))
-                .endMetadata()
-                .withNewSpec();
-
-        if(template.getActiveDeadlineSeconds() > 0) {
-            builder = builder.withActiveDeadlineSeconds(Long.valueOf(template.getActiveDeadlineSeconds()));
+        if (!imagePullSecrets.isEmpty()) {
+            builder.withImagePullSecrets(imagePullSecrets);
         }
 
-        Pod pod = builder.withVolumes(volumes)
-                .withServiceAccount(substituteEnv(template.getServiceAccount()))
-                .withImagePullSecrets(imagePullSecrets)
-                .withContainers(containers.values().toArray(new Container[containers.size()]))
-                .withNodeSelector(getNodeSelectorMap(template.getNodeSelector()))
-                .withRestartPolicy("Never")
-                .endSpec()
-                .build();
+        Map<String, String> nodeSelector = getNodeSelectorMap(template.getNodeSelector());
+        if (!nodeSelector.isEmpty()) {
+            builder.withNodeSelector(nodeSelector);
+        }
+
+        builder.withContainers(containers.values().toArray(new Container[containers.size()]));
+        Pod pod = builder.endSpec().build();
+
+        // merge with the yaml
+        String yaml = template.getYaml();
+        if (!StringUtils.isBlank(yaml)) {
+            try (KubernetesClient client = new DefaultKubernetesClient()) {
+                Pod podFromYaml = client.pods()
+                        .load(new ByteArrayInputStream((yaml == null ? "" : yaml).getBytes(UTF_8))).get();
+                LOGGER.log(Level.FINEST, "Parsed pod template from yaml: {0}", podFromYaml);
+                pod = combine(podFromYaml, pod);
+            }
+        }
+
+        // Apply defaults
+
+        // default restart policy
+        if (StringUtils.isBlank(pod.getSpec().getRestartPolicy())) {
+            pod.getSpec().setRestartPolicy("Never");
+        }
+
+        // default jnlp container
+        if (pod.getSpec().getContainers().stream().noneMatch(c -> JNLP_NAME.equals(c.getName()))) {
+            ContainerTemplate containerTemplate = new ContainerTemplate(DEFAULT_JNLP_IMAGE);
+            containerTemplate.setName(JNLP_NAME);
+            containerTemplate.setArgs(DEFAULT_JNLP_ARGUMENTS);
+            pod.getSpec().getContainers().add(createContainer(containerTemplate, template.getEnvVars(), volumeMounts.values()));
+        }
+
+        // default workspace volume, add an empty volume to share the workspace across the pod
+        if (pod.getSpec().getVolumes().stream().noneMatch(v -> WORKSPACE_VOLUME_NAME.equals(v.getName()))) {
+            pod.getSpec().getVolumes()
+                    .add(new VolumeBuilder().withName(WORKSPACE_VOLUME_NAME).withNewEmptyDir("").build());
+        }
+        pod.getSpec().getContainers().stream()
+                .filter(c -> c.getVolumeMounts().stream().noneMatch(vm -> WORKSPACE_VOLUME_NAME.equals(vm.getName())))
+                .forEach(c -> c.getVolumeMounts().add(getDefaultVolumeMount(c.getWorkingDir())));
 
         return pod;
-
     }
 
 
-    private Container createContainer(KubernetesSlave slave, ContainerTemplate containerTemplate, Collection<TemplateEnvVar> globalEnvVars, Collection<VolumeMount> volumeMounts) {
+    private Container createContainer(ContainerTemplate containerTemplate, Collection<TemplateEnvVar> globalEnvVars, Collection<VolumeMount> volumeMounts) {
         // Last-write wins map of environment variable names to values
         HashMap<String, String> env = new HashMap<>();
 
-        // Add some default env vars for Jenkins
-        env.put("JENKINS_SECRET", slave.getComputer().getJnlpMac());
-        env.put("JENKINS_NAME", slave.getComputer().getName());
+        if (slave != null) {
+            // Add some default env vars for Jenkins
+            env.put("JENKINS_SECRET", slave.getComputer().getJnlpMac());
+            env.put("JENKINS_NAME", slave.getComputer().getName());
 
-        KubernetesCloud cloud = slave.getKubernetesCloud();
+            KubernetesCloud cloud = slave.getKubernetesCloud();
 
-        String url = cloud.getJenkinsUrlOrDie();
+            String url = cloud.getJenkinsUrlOrDie();
 
-        env.put("JENKINS_URL", url);
-        if (!StringUtils.isBlank(cloud.getJenkinsTunnel())) {
-            env.put("JENKINS_TUNNEL", cloud.getJenkinsTunnel());
+            env.put("JENKINS_URL", url);
+            if (!StringUtils.isBlank(cloud.getJenkinsTunnel())) {
+                env.put("JENKINS_TUNNEL", cloud.getJenkinsTunnel());
+            }
         }
 
         // Running on OpenShift Enterprise, security concerns force use of arbitrary user ID
@@ -209,20 +270,18 @@ public class PodTemplateBuilder {
 
         EnvVar[] envVars = envVarsMap.values().stream().toArray(EnvVar[]::new);
 
+        String cmd = containerTemplate.getArgs();
+        if (slave != null) {
+            cmd = cmd.replaceAll(JNLPMAC_REF, slave.getComputer().getJnlpMac()) //
+                    .replaceAll(NAME_REF, slave.getComputer().getName());
+        }
         List<String> arguments = Strings.isNullOrEmpty(containerTemplate.getArgs()) ? Collections.emptyList()
-                : parseDockerCommand(containerTemplate.getArgs() //
-                .replaceAll(JNLPMAC_REF, slave.getComputer().getJnlpMac()) //
-                .replaceAll(NAME_REF, slave.getComputer().getName()));
-
-
-        List<VolumeMount> containerMounts = new ArrayList<>(volumeMounts);
+                : parseDockerCommand(cmd);
 
         ContainerPort[] ports = containerTemplate.getPorts().stream().map(entry -> entry.toPort()).toArray(size -> new ContainerPort[size]);
 
-        if (!Strings.isNullOrEmpty(containerTemplate.getWorkingDir())
-                && !PodVolume.volumeMountExists(containerTemplate.getWorkingDir(), volumeMounts)) {
-            containerMounts.add(new VolumeMount(containerTemplate.getWorkingDir(), WORKSPACE_VOLUME_NAME, false, null));
-        }
+        String workingDir = substituteEnv(containerTemplate.getWorkingDir());
+        List<VolumeMount> containerMounts = getContainerVolumeMounts(volumeMounts, workingDir);
 
         ContainerLivenessProbe clp = containerTemplate.getLivenessProbe();
         Probe livenessProbe = null;
@@ -244,7 +303,7 @@ public class PodTemplateBuilder {
                 .withNewSecurityContext()
                 .withPrivileged(containerTemplate.isPrivileged())
                 .endSecurityContext()
-                .withWorkingDir(substituteEnv(containerTemplate.getWorkingDir()))
+                .withWorkingDir(workingDir)
                 .withVolumeMounts(containerMounts.toArray(new VolumeMount[containerMounts.size()]))
                 .addToEnv(envVars)
                 .addToPorts(ports)
@@ -257,6 +316,18 @@ public class PodTemplateBuilder {
                 .withLimits(getResourcesMap(containerTemplate.getResourceLimitMemory(), containerTemplate.getResourceLimitCpu()))
                 .endResources()
                 .build();
+    }
+
+    private VolumeMount getDefaultVolumeMount(String workingDir) {
+        return new VolumeMount(workingDir, WORKSPACE_VOLUME_NAME, false, null);
+    }
+
+    private List<VolumeMount> getContainerVolumeMounts(Collection<VolumeMount> volumeMounts, String workingDir) {
+        List<VolumeMount> containerMounts = new ArrayList<>(volumeMounts);
+        if (!Strings.isNullOrEmpty(workingDir) && !PodVolume.volumeMountExists(workingDir, volumeMounts)) {
+            containerMounts.add(getDefaultVolumeMount(workingDir));
+        }
+        return containerMounts;
     }
 
     /**

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -109,6 +109,12 @@ public class PodTemplateBuilder {
         return this;
     }
 
+    @Deprecated
+    public Pod build(KubernetesSlave slave) {
+        LOGGER.log(Level.WARNING, "This method is deprecated and does nothing");
+        return this.build();
+    }
+
     /**
      * Create a Pod object from a PodTemplate
      */
@@ -225,6 +231,7 @@ public class PodTemplateBuilder {
                 .filter(c -> c.getVolumeMounts().stream().noneMatch(vm -> WORKSPACE_VOLUME_NAME.equals(vm.getName())))
                 .forEach(c -> c.getVolumeMounts().add(getDefaultVolumeMount(c.getWorkingDir())));
 
+        LOGGER.log(Level.FINE, "Pod built: {0}", pod);
         return pod;
     }
 
@@ -321,8 +328,13 @@ public class PodTemplateBuilder {
                 .build();
     }
 
-    private VolumeMount getDefaultVolumeMount(String workingDir) {
-        return new VolumeMount(workingDir, WORKSPACE_VOLUME_NAME, false, null);
+    private VolumeMount getDefaultVolumeMount(@CheckForNull String workingDir) {
+        String wd = workingDir;
+        if (wd == null) {
+            wd = ContainerTemplate.DEFAULT_WORKING_DIR;
+            LOGGER.log(Level.FINE, "Container workingDir is null, defaulting to {0}", wd);
+        }
+        return new VolumeMount(wd, WORKSPACE_VOLUME_NAME, false, null);
     }
 
     private List<VolumeMount> getContainerVolumeMounts(Collection<VolumeMount> volumeMounts, String workingDir) {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
@@ -12,6 +12,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -42,6 +44,9 @@ import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
 
 public class PodTemplateUtils {
+
+    private static final Logger LOGGER = Logger.getLogger(PodTemplateUtils.class.getName());
+
     /**
      * Combines a {@link ContainerTemplate} with its parent.
      * @param parent        The parent container template (nullable).
@@ -161,6 +166,9 @@ public class PodTemplateUtils {
             return template;
         }
 
+        LOGGER.log(Level.FINE, "Combining pods, parent: {0}", parent);
+        LOGGER.log(Level.FINE, "Combining pods, template: {0}", template);
+
         Map<String, String> nodeSelector = mergeMaps(parent.getSpec().getNodeSelector(),
                 template.getSpec().getNodeSelector());
         String serviceAccount = Strings.isNullOrEmpty(template.getSpec().getServiceAccount())
@@ -218,7 +226,9 @@ public class PodTemplateUtils {
 //        podTemplate.setNodeUsageMode(nodeUsageMode);
 //        podTemplate.setYaml(template.getYaml() == null ? parent.getYaml() : template.getYaml());
 
-        return specBuilder.endSpec().build();
+        Pod pod = specBuilder.endSpec().build();
+        LOGGER.log(Level.FINE, "Pods combined: {0}", pod);
+        return pod;
     }
 
     /**

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep.java
@@ -56,6 +56,8 @@ public class PodTemplateStep extends Step implements Serializable {
     private Node.Mode nodeUsageMode;
     private String workingDir = ContainerTemplate.DEFAULT_WORKING_DIR;
 
+    private String yaml;
+
     @DataBoundConstructor
     public PodTemplateStep(String label, String name) {
         this.label = label;
@@ -235,6 +237,16 @@ public class PodTemplateStep extends Step implements Serializable {
             this.imagePullSecrets.clear();
             this.imagePullSecrets.addAll(imagePullSecrets);
         }
+    }
+
+    
+    public String getYaml() {
+        return yaml;
+    }
+
+    @DataBoundSetter
+    public void setYaml(String yaml) {
+        this.yaml = yaml;
     }
 
     @Extension

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
@@ -86,6 +86,7 @@ public class PodTemplateStepExecution extends AbstractStepExecutionImpl {
         newTemplate.setAnnotations(step.getAnnotations());
         newTemplate.setImagePullSecrets(
                 step.getImagePullSecrets().stream().map(x -> new PodImagePullSecret(x)).collect(toList()));
+        newTemplate.setYaml(step.getYaml());
 
         if(step.getActiveDeadlineSeconds() != 0) {
             newTemplate.setActiveDeadlineSeconds(step.getActiveDeadlineSeconds());

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
@@ -2,12 +2,41 @@ package org.csanchez.jenkins.plugins.kubernetes;
 
 import static org.csanchez.jenkins.plugins.kubernetes.PodTemplateBuilder.*;
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.compress.utils.IOUtils;
+import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeMount;
 
 public class PodTemplateBuilderTest {
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    private KubernetesCloud cloud;
+
+    @Mock
+    private KubernetesSlave slave;
+
+    @Mock
+    private KubernetesComputer computer;
+
     @Test
     public void testParseDockerCommand() {
         assertNull(parseDockerCommand(""));
@@ -29,4 +58,55 @@ public class PodTemplateBuilderTest {
                 parseLivenessProbe("curl -k --silent --output=/dev/null \"https://localhost:8080\""));
     }
 
+    @Test
+    public void testBuildWithoutSlave() throws Exception {
+        PodTemplate template = new PodTemplate();
+        template.setYaml(new String(IOUtils.toByteArray(getClass().getResourceAsStream("pod-busybox.yaml"))));
+        Pod pod = new PodTemplateBuilder(template).build();
+        validatePod(pod);
+    }
+
+    @Test
+    public void testBuildFromYaml() throws Exception {
+        PodTemplate template = new PodTemplate();
+        template.setYaml(new String(IOUtils.toByteArray(getClass().getResourceAsStream("pod-busybox.yaml"))));
+
+        when(cloud.getJenkinsUrlOrDie()).thenReturn("http://jenkins.example.com");
+        when(computer.getName()).thenReturn("jenkins-agent");
+        when(computer.getJnlpMac()).thenReturn("xxx");
+        when(slave.getComputer()).thenReturn(computer);
+        when(slave.getKubernetesCloud()).thenReturn(cloud);
+
+        Pod pod = new PodTemplateBuilder(template).withSlave(slave).build();
+        validatePod(pod);
+    }
+
+    private void validatePod(Pod pod) {
+        assertEquals(ImmutableMap.of("some-label", "some-label-value"), pod.getMetadata().getLabels());
+
+        // check containers
+        Map<String, Container> containers = new HashMap<>();
+        for (Container c : pod.getSpec().getContainers()) {
+            containers.put(c.getName(), c);
+        }
+        assertEquals(2, containers.size());
+
+        assertEquals("busybox", containers.get("busybox").getImage());
+        assertEquals("jenkins/jnlp-slave:alpine", containers.get("jnlp").getImage());
+
+        // check volumes and volume mounts
+        Map<String, Volume> volumes = new HashMap<>();
+        for (Volume v : pod.getSpec().getVolumes()) {
+            volumes.put(v.getName(), v);
+        }
+        assertEquals(2, volumes.size());
+        assertNotNull(volumes.get("workspace-volume"));
+        assertNotNull(volumes.get("empty-volume"));
+
+        List<VolumeMount> mounts = containers.get("busybox").getVolumeMounts();
+        assertEquals(1, mounts.size());
+
+        mounts = containers.get("jnlp").getVolumeMounts();
+        assertEquals(1, mounts.size());
+    }
 }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
@@ -84,6 +84,29 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
     }
 
     @Test
+    public void runInPodFromYaml() throws Exception {
+        deletePods(cloud.connect(), getLabels(this), false);
+
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(loadPipelineScript("runInPodFromYaml.groovy"), true));
+        WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+        assertNotNull(b);
+        List<PodTemplate> templates = cloud.getTemplates();
+        while (templates.isEmpty()) {
+            LOGGER.log(Level.INFO, "Waiting for template to be created");
+            templates = cloud.getTemplates();
+            Thread.sleep(1000);
+        }
+        assertFalse(templates.isEmpty());
+        PodTemplate template = templates.get(0);
+        assertEquals(Integer.MAX_VALUE, template.getInstanceCap());
+        r.assertBuildStatusSuccess(r.waitForCompletion(b));
+        r.assertLogContains("script file contents: ", b);
+        assertFalse("There are pods leftover after test execution, see previous logs",
+                deletePods(cloud.connect(), getLabels(this), true));
+    }
+
+    @Test
     public void runInPodWithMultipleContainers() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(loadPipelineScript("runInPodWithMultipleContainers.groovy"), true));

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runInPodFromYaml.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runInPodFromYaml.groovy
@@ -1,0 +1,33 @@
+podTemplate(label: 'mypod', yaml: """
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    some-label: some-label-value
+spec:
+  containers:
+  - name: busybox
+    image: busybox
+    command:
+    - cat
+    tty: true
+    env:
+    - name: CONTAINER_ENV_VAR
+      value: container-env-var-value
+"""
+) {
+
+    node ('mypod') {
+      stage('Run') {
+        container('busybox') {
+          sh """
+            ## durable-task plugin generates a script.sh file.
+            ##
+            echo "script file: \$(find ../../.. -iname script.sh))"
+            echo "script file contents: \$(find ../../.. -iname script.sh -exec cat {} \\;)"
+            test -n "\$(cat \$(find ../../.. -iname script.sh))"
+          """
+        }
+      }
+    }
+}

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pod-busybox.yaml
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pod-busybox.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    some-label: some-label-value
+spec:
+  affinity:
+    podAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: security
+            operator: In
+            values:
+            - S1
+        topologyKey: failure-domain.beta.kubernetes.io/zone
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: security
+              operator: In
+              values:
+              - S2
+          topologyKey: kubernetes.io/hostname
+  containers:
+  - name: busybox
+    image: busybox
+    command:
+    - cat
+    tty: true
+    env:
+    - name: CONTAINER_ENV_VAR
+      value: container-env-var-value
+  volumes:
+  - name: empty-volume
+    emptyDir: {}


### PR DESCRIPTION
To avoid having to manually add fields for all possible options current and future, just pass the yaml to be used as base.

Yaml is merged with other fields (if set) as it if were a parent Podtemplate