### PR TITLE
Add support for Restart Policy

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
@@ -304,12 +304,13 @@ public class KubernetesLauncher extends JNLPLauncher {
             builder = builder.withActiveDeadlineSeconds(Long.valueOf(template.getActiveDeadlineSeconds()));
         }
 
+        String restartPolicy = template.getRestartPolicy();
         Pod pod = builder.withVolumes(volumes)
                 .withServiceAccount(substituteEnv(template.getServiceAccount()))
                 .withImagePullSecrets(imagePullSecrets)
                 .withContainers(containers.values().toArray(new Container[containers.size()]))
                 .withNodeSelector(getNodeSelectorMap(template.getNodeSelector()))
-                .withRestartPolicy("Never")
+                .withRestartPolicy(restartPolicy)
                 .endSpec()
                 .build();
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -91,6 +91,8 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
 
     private String resourceLimitMemory;
 
+    private String restartPolicy = "Never";
+
     private boolean customWorkspaceVolumeEnabled;
     private WorkspaceVolume workspaceVolume;
 
@@ -126,6 +128,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
         this.setActiveDeadlineSeconds(from.getActiveDeadlineSeconds());
         this.setVolumes(from.getVolumes());
         this.setWorkspaceVolume(from.getWorkspaceVolume());
+        this.setRestartPolicy(from.getRestartPolicy());
     }
 
     @Deprecated
@@ -503,6 +506,15 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
     @Deprecated
     public String getResourceRequestCpu() {
         return getFirstContainer().map(ContainerTemplate::getResourceRequestCpu).orElse(null);
+    }
+
+    public String getRestartPolicy() {
+        return restartPolicy;
+    }
+
+    @DataBoundSetter
+    public void setRestartPolicy(String restartPolicy) {
+        this.restartPolicy = restartPolicy;
     }
 
     @Deprecated

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
@@ -87,6 +87,7 @@ public class PodTemplateUtils {
         String label = template.getLabel();
         String nodeSelector = Strings.isNullOrEmpty(template.getNodeSelector()) ? parent.getNodeSelector() : template.getNodeSelector();
         String serviceAccount = Strings.isNullOrEmpty(template.getServiceAccount()) ? parent.getServiceAccount() : template.getServiceAccount();
+        String restartPolicy = Strings.isNullOrEmpty(template.getRestartPolicy()) ? parent.getRestartPolicy() : template.getRestartPolicy();
         Node.Mode nodeUsageMode = template.getNodeUsageMode() == null ? parent.getNodeUsageMode() : template.getNodeUsageMode();
 
         Set<PodAnnotation> podAnnotations = new LinkedHashSet<>();
@@ -123,6 +124,7 @@ public class PodTemplateUtils {
         podTemplate.setLabel(label);
         podTemplate.setNodeSelector(nodeSelector);
         podTemplate.setServiceAccount(serviceAccount);
+        podTemplate.setRestartPolicy(restartPolicy);
         podTemplate.setEnvVars(combineEnvVars(parent, template));
         podTemplate.setContainers(new ArrayList<>(combinedContainers.values()));
         podTemplate.setWorkspaceVolume(workspaceVolume);

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
@@ -81,6 +81,14 @@
       <f:textbox/>
     </f:entry>
 
+    <f:entry name="restartPolicy" title="Restart Policy" field="restartPolicy">
+        <select name="restartPolicy">
+            <option value="Never" selected="${instance.restartPolicy.equals('Never')? 'true':null}">Never</option>
+            <option value="OnFailure" selected="${instance.restartPolicy.equals('OnFailure')? 'true':null}">OnFailure</option>
+            <option value="Always" selected="${instance.restartPolicy.equals('Always')? 'true':null}">Always</option>
+        </select>
+    </f:entry>
+
     <f:descriptorList title="${%Node Properties}" descriptors="${h.getNodePropertyDescriptors(descriptor.clazz)}" field="nodeProperties" />
     <f:block>
       <table>
@@ -92,6 +100,7 @@
         </f:optionalBlock>
       </table>
     </f:block>
+
   </f:advanced>
 
 </j:jelly>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/help-restartPolicy.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/help-restartPolicy.html
@@ -1,0 +1,3 @@
+Restart Policy of Pod
+This value determines how a pod is restarted in the event the pod crashes or is terminated. <code>Always</code> is useful when a 
+node is rebooted and you want the pod to come back up when the node is back online.

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
@@ -148,6 +148,12 @@ public class PodTemplateUtilsTest {
         assertEquals(1, result.getImagePullSecrets().size());
     }
 
+    @Test
+    public void shouldDefaultRestartPolicyToNever() {
+        PodTemplate template = new PodTemplate();
+    
+        assertEquals("Never", template.getRestartPolicy());
+    }
 
     @Test
     public void shouldCombineAllAnnotations() {


### PR DESCRIPTION
When Kubernetes nodes are rebooted for patching or slaves crash, we need the slave to restart. Add an option to the container template that allows a user to specify the restart policy of Always or Never (default).