### PR TITLE
JENKINS-49465: Provide injection of run context

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -41,7 +41,6 @@ import java.util.logging.Logger;
 import org.apache.commons.io.output.TeeOutputStream;
 import org.csanchez.jenkins.plugins.kubernetes.pipeline.proc.CachedProc;
 import org.csanchez.jenkins.plugins.kubernetes.pipeline.proc.DeadProc;
-import org.jenkinsci.plugins.workflow.steps.EnvironmentExpander;
 
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
@@ -181,13 +180,11 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
         this.globalVars = globalVars;
     }
 
-    public void setRunContextEnvVars(EnvVars rcVars)
-    {
+    public void setRunContextEnvVars(EnvVars rcVars) {
         this.rcEnvVars = rcVars;
     }
 
-    public EnvVars getRunContextEnvVars()
-    {
+    public EnvVars getRunContextEnvVars() {
         return this.rcEnvVars;
     }
 
@@ -341,8 +338,7 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
                             this.setupEnvironmentVariable(globalVars, watch);
                     }
 
-                    if(rcEnvVars != null)
-                    {
+                    if(rcEnvVars != null) {
                         this.setupEnvironmentVariable(rcEnvVars, watch);
                     }
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerStepExecution.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerStepExecution.java
@@ -19,6 +19,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.LauncherDecorator;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 import hudson.slaves.EnvironmentVariablesNodeProperty;
 import hudson.slaves.NodeProperty;
 import hudson.slaves.NodePropertyDescriptor;
@@ -68,13 +70,22 @@ public class ContainerStepExecution extends StepExecution {
         EnvironmentExpander env = getContext().get(EnvironmentExpander.class);
         EnvVars globalVars = null;
         Jenkins instance = Jenkins.getInstance();
-        DescribableList<NodeProperty<?>, NodePropertyDescriptor> globalNodeProperties = instance
-                .getGlobalNodeProperties();
+
+        DescribableList<NodeProperty<?>, NodePropertyDescriptor> globalNodeProperties = instance.getGlobalNodeProperties();
         List<EnvironmentVariablesNodeProperty> envVarsNodePropertyList = globalNodeProperties
                 .getAll(EnvironmentVariablesNodeProperty.class);
         if (envVarsNodePropertyList != null && envVarsNodePropertyList.size() != 0) {
             globalVars = envVarsNodePropertyList.get(0).getEnvVars();
         }
+
+        EnvVars rcEnvVars = null;
+        Run run = getContext().get(Run.class);
+        TaskListener taskListener = getContext().get(TaskListener.class);
+        if(run!=null && taskListener != null)
+        {
+            rcEnvVars = run.getEnvironment(taskListener);
+        }
+
         decorator = new ContainerExecDecorator();
         decorator.setClient(client);
         decorator.setPodName(nodeContext.getPodName());
@@ -83,6 +94,7 @@ public class ContainerStepExecution extends StepExecution {
         decorator.setEnvironmentExpander(env);
         decorator.setWs(getContext().get(FilePath.class));
         decorator.setGlobalVars(globalVars);
+        decorator.setRunContextEnvVars(rcEnvVars);
         getContext().newBodyInvoker()
                 .withContext(BodyInvoker
                         .mergeLauncherDecorators(getContext().get(LauncherDecorator.class), decorator))

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerStepExecution.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerStepExecution.java
@@ -81,8 +81,7 @@ public class ContainerStepExecution extends StepExecution {
         EnvVars rcEnvVars = null;
         Run run = getContext().get(Run.class);
         TaskListener taskListener = getContext().get(TaskListener.class);
-        if(run!=null && taskListener != null)
-        {
+        if(run!=null && taskListener != null) {
             rcEnvVars = run.getEnvironment(taskListener);
         }
 

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
@@ -193,6 +193,19 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
     }
 
     @Test
+    public void supportComputerEnvVars() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(loadPipelineScript("buildPropertyVars.groovy"), true));
+        WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+        assertNotNull(b);
+        r.assertBuildStatusSuccess(r.waitForCompletion(b));
+        r.assertLogContains("OPENJDK_BUILD_NUMBER: 1\n", b);
+        r.assertLogContains("JNLP_BUILD_NUMBER: 1\n", b);
+        r.assertLogContains("DEFAULT_BUILD_NUMBER: 1\n", b);
+
+    }
+
+    @Test
     public void runJobWithSpaces() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p with spaces");
         p.setDefinition(new CpsFlowDefinition(loadPipelineScript("runJobWithSpaces.groovy"), true));

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/buildPropertyVars.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/buildPropertyVars.groovy
@@ -1,0 +1,33 @@
+pipeline {
+	agent {
+
+        kubernetes{
+                label 'openjdk'
+                containerTemplate{
+                        name 'openjdk'
+                        image 'openjdk'
+                        workingDir '/home/jenkins'
+                        ttyEnabled true
+                        command 'cat'
+                        args ''
+                }
+        }
+}
+
+
+    stages{
+        stage('Build') {
+            steps {
+
+                sh 'echo DEFAULT_BUILD_NUMBER: ${BUILD_NUMBER}'
+                container('jnlp')
+                {
+                    sh 'echo JNLP_BUILD_NUMBER: ${BUILD_NUMBER}'
+                }
+                container('openjdk'){
+                    sh 'echo OPENJDK_BUILD_NUMBER: ${BUILD_NUMBER}'
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
[JENKINS-49465](https://issues.jenkins-ci.org/browse/JENKINS-49465)
This solves a small but critical issue where, within declarative pipeline container step, build environment variables are not available. 

This also removes the odd "JAVA_HOME" #245 work of obtaining builtins as we only need to that to determine if the executor is being called from either Jenkins proper or through another plugin. 

This work was based off reading https://github.com/jglick/pipeline-plugin/blob/e19ac3608789e841eed2bdd90aff35bc9bd74dc9/support/src/main/java/org/jenkinsci/plugins/workflow/support/DefaultStepContext.java#L68