### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,11 +321,13 @@ Also see the online help and [examples/containerLog.groovy](examples/containerLo
 
 Multiple containers can be defined in a pod.
 One of them is automatically created with name `jnlp`, and runs the Jenkins JNLP agent service, with args `${computer.jnlpmac} ${computer.name}`,
-and will be the container acting as Jenkins agent. It can be overridden by defining a container with the same name.
+and will be the container acting as Jenkins agent.
 
 Other containers must run a long running process, so the container does not exit. If the default entrypoint or command
 just runs something and exit then it should be overridden with something like `cat` with `ttyEnabled: true`.
 
+**WARNING**
+If you want to provide your own Docker image for the JNLP slave, you **must** name the container `jnlp` so it overrides the default one. Failing to do so will result in two slaves trying to concurrently connect to the master.
 
 # Over provisioning flags
 

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/help-name.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/help-name.html
@@ -1,0 +1,5 @@
+The name for the container to be run.
+
+One container is automatically created with name <code>jnlp</code>, and runs the Jenkins JNLP agent service.
+
+In order to replace the default JNLP agent, the name of the container with the custom JNLP image must be <code>jnlp</code>.


### PR DESCRIPTION
Rewording the `constraints` paragraph to make it more explicit that the custom JNLP container must be named `jnlp`.

I missed this this information in the doc and it cost be several hours of debugging. Two agents concurrently connecting to the master is not easy to investigate.

Ideally this warning should also be in the plugin configuration in Jenkins. Currently the `name` field for the container does not have a help icon.
I'm not sure how to do that though. Happy to do it with guidance though.