### PR TITLE
Ensure that scm env variables are set for declarative pipeline.

### DIFF
--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgentTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgentTest.java
@@ -47,4 +47,14 @@ public class KubernetesDeclarativeAgentTest extends AbstractKubernetesPipelineTe
         r.assertLogContains("OUTSIDE_CONTAINER_ENV_VAR = " + CONTAINER_ENV_VAR_VALUE + "\n", b);
     }
 
+    @Test
+    public void declarativeWithSCMEnvVars() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "job with dir");
+        p.setDefinition(new CpsFlowDefinition(loadPipelineScript("declarativeWithSCMEnvVars.groovy"), true));
+        WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+        assertNotNull(b);
+        r.assertBuildStatusSuccess((r.waitForCompletion(b)));
+        r.assertLogNotContains("GIT_COMMIT is null", b);
+    }
+
 }

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/declarativeWithSCMEnvVars.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/declarativeWithSCMEnvVars.groovy
@@ -1,0 +1,10 @@
+pipeline {
+    agent any
+    stages {
+        stage("foo") {
+            steps {
+                echo "GIT_COMMIT is ${env.GIT_COMMIT}"
+            }
+        }
+    }
+}


### PR DESCRIPTION
I had an issue in my Jenkins setup that I did not have access to `GIT_COMMIT` etc variables in my declarative pipeline. And it was a mystery to me as I have the latest versions of all plugins and that should be working. Turns out that the kubernetes declarative agant is not support it.

I just copied some of the relevant bits of code from: https://github.com/jenkinsci/pipeline-model-definition-plugin/blob/fd56764049461eca7c27a976446f5e053ea3aefe/pipeline-model-extensions/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/CheckoutScript.groovy as well as the corresponding test. There might be a better way of doing this but this is the first time for me writing any groovy and contributing to anything related to jenkins. Also for some reason I could not run the test locally. But I have compiled the plugin and tested it in our jenkins deployment. Finally the SCM env variables work again as expected.

Just let me know if I should improve anything anywhere, but would be great to get this fix in.