### PR TITLE
Allow specifying a different shell command other than /bin/sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,22 @@ There might be cases, where you need to have the agent pod run inside a differen
 For example you may need the agent to run inside an `ephemeral` namespace for the sake of testing.
 For those cases you can explicitly configure a namespace either using the ui or the pipeline.
 
+#### Specifying a different shell command other than /bin/sh
+
+By default, the shell command is /bin/sh. In some case, you would like to use another shell command like /bin/bash.
+
+```groovy
+podTemplate(label: my-label) {
+  node(my-label) {
+    stage('Run specific shell') {
+      container(name:'mycontainer', shell:'/bin/bash') {
+        sh 'echo hello world'
+      }
+    }
+  }
+}
+```
+
 ## Container Configuration
 When configuring a container in a pipeline podTemplate the following options are available:
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
@@ -4,6 +4,8 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 import org.apache.commons.lang.StringUtils;
 import org.csanchez.jenkins.plugins.kubernetes.model.TemplateEnvVar;
@@ -50,6 +52,7 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
     private String resourceLimitCpu;
 
     private String resourceLimitMemory;
+    private String shell;
 
     private final List<TemplateEnvVar> envVars = new ArrayList<>();
     private List<PortMapping> ports = new ArrayList<PortMapping>();
@@ -214,6 +217,18 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
         this.resourceRequestCpu = resourceRequestCpu;
     }
 
+    public Map<String,Object> getAsArgs() {
+        Map<String,Object> argMap = new TreeMap<>();
+
+        argMap.put("name", name);
+
+        if (!StringUtils.isEmpty(shell)) {
+            argMap.put("shell", shell);
+        }
+
+        return argMap;
+    }
+
     @Extension
     @Symbol("containerTemplate")
     public static class DescriptorImpl extends Descriptor<ContainerTemplate> {
@@ -249,5 +264,14 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
                 (ports == null || ports.isEmpty() ? "" : ", ports=" + ports) +
                 (livenessProbe == null ? "" : ", livenessProbe=" + livenessProbe) +
                 '}';
+    }
+
+    public String getShell() {
+        return shell;
+    }
+
+    @DataBoundSetter
+    public void setShell(String shell) {
+        this.shell = shell;
     }
 }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -42,7 +42,6 @@ import org.apache.commons.io.output.TeeOutputStream;
 import org.csanchez.jenkins.plugins.kubernetes.pipeline.proc.CachedProc;
 import org.csanchez.jenkins.plugins.kubernetes.pipeline.proc.DeadProc;
 
-
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.EnvVars;
@@ -200,7 +199,7 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
     }
 
     public String getShell() {
-        return shell;
+        return shell == null? DEFAULT_SHELL:shell;
     }
 
     public void setShell(String shell) {
@@ -320,7 +319,7 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
 
                 ExecWatch watch;
                 try {
-                    watch = execable.exec(shell);
+                    watch = execable.exec(getShell());
                 } catch (KubernetesClientException e) {
                     if (e.getCause() instanceof InterruptedException) {
                         throw new IOException("JENKINS-40825: interrupted while starting websocket connection", e);

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -77,6 +77,7 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
     private static final String COOKIE_VAR = "JENKINS_SERVER_COOKIE";
 
     private static final Logger LOGGER = Logger.getLogger(ContainerExecDecorator.class.getName());
+    private static final String DEFAULT_SHELL="/bin/sh";
 
     private transient KubernetesClient client;
 
@@ -93,6 +94,7 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
     private EnvVars globalVars;
     private FilePath ws;
     private EnvVars rcEnvVars;
+    private String shell;
 
     public ContainerExecDecorator() {
     }
@@ -105,6 +107,7 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
         this.containerName = containerName;
         this.environmentExpander = environmentExpander;
         this.ws = ws;
+        this.shell = DEFAULT_SHELL;
     }
 
     @Deprecated
@@ -194,6 +197,14 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
 
     public void setWs(FilePath ws) {
         this.ws = ws;
+    }
+
+    public String getShell() {
+        return shell;
+    }
+
+    public void setShell(String shell) {
+        this.shell = shell;
     }
 
     @Override
@@ -309,7 +320,7 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
 
                 ExecWatch watch;
                 try {
-                    watch = execable.exec("/bin/sh");
+                    watch = execable.exec(shell);
                 } catch (KubernetesClientException e) {
                     if (e.getCause() instanceof InterruptedException) {
                         throw new IOException("JENKINS-40825: interrupted while starting websocket connection", e);

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerStep.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerStep.java
@@ -8,6 +8,7 @@ import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 import com.google.common.collect.ImmutableSet;
 
@@ -21,6 +22,7 @@ public class ContainerStep extends Step implements Serializable {
     private static final long serialVersionUID = 5588861066775717487L;
 
     private final String name;
+    private String shell;
 
     @DataBoundConstructor
     public ContainerStep(String name) {
@@ -29,6 +31,15 @@ public class ContainerStep extends Step implements Serializable {
 
     public String getName() {
         return name;
+    }
+
+    @DataBoundSetter
+    public void setShell(String shell){
+        this.shell = shell;
+    }
+
+    public String getShell() {
+        return shell;
     }
 
     @Override

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerStepExecution.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerStepExecution.java
@@ -63,6 +63,7 @@ public class ContainerStepExecution extends StepExecution {
     public boolean start() throws Exception {
         LOGGER.log(Level.FINE, "Starting container step.");
         String containerName = step.getName();
+        String shell = step.getShell();
 
         KubernetesNodeContext nodeContext = new KubernetesNodeContext(getContext());
         client = nodeContext.connectToCloud();
@@ -94,6 +95,7 @@ public class ContainerStepExecution extends StepExecution {
         decorator.setWs(getContext().get(FilePath.class));
         decorator.setGlobalVars(globalVars);
         decorator.setRunContextEnvVars(rcEnvVars);
+        decorator.setShell(shell);
         getContext().newBodyInvoker()
                 .withContext(BodyInvoker
                         .mergeLauncherDecorators(getContext().get(LauncherDecorator.class), decorator))

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgentScript.groovy
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgentScript.groovy
@@ -50,7 +50,7 @@ public class KubernetesDeclarativeAgentScript extends DeclarativeAgentScript<Kub
                                 script.checkout script.scm
                             }
                         }
-                        script.container(describable.containerTemplate.name) {
+                        script.container(describable.containerTemplate.asArgs) {
                             body.call()
                         }
                     }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
@@ -40,6 +40,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.JenkinsRuleNonLocalhost;
 
+import hudson.model.Result;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 
@@ -81,6 +82,16 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
                 && templates.stream()
                 .map(PodTemplate::getLabel)
                 .anyMatch(label::equals);
+    }
+
+    @Test
+    public void runInPodWithDifferentShell() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(loadPipelineScript("runInPodWithDifferentShell.groovy"), true));
+        WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+        assertNotNull(b);
+        r.assertBuildStatus(Result.FAILURE,r.waitForCompletion(b));
+        r.assertLogContains("/bin/bash: no such file or directory", b);
     }
 
     @Test

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/declarative.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/declarative.groovy
@@ -18,7 +18,7 @@ pipeline {
       steps {
         sh 'set'
         sh "echo OUTSIDE_CONTAINER_ENV_VAR = ${CONTAINER_ENV_VAR}"
-        container('maven') {
+        container(name: 'maven', shell: '/bin/bash') {
           sh 'echo INSIDE_CONTAINER_ENV_VAR = ${CONTAINER_ENV_VAR}'
           sh 'mvn -version'
         }

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/declarative.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/declarative.groovy
@@ -18,11 +18,18 @@ pipeline {
       steps {
         sh 'set'
         sh "echo OUTSIDE_CONTAINER_ENV_VAR = ${CONTAINER_ENV_VAR}"
-        container(name: 'maven', shell: '/bin/bash') {
+        container('maven') {
           sh 'echo INSIDE_CONTAINER_ENV_VAR = ${CONTAINER_ENV_VAR}'
           sh 'mvn -version'
         }
       }
     }
+	stage('Run maven with a different shell') {
+		steps {
+		  container(name: 'maven', shell: '/bin/bash') {
+			sh 'mvn -version'
+		  }
+		}
+	  }
   }
 }

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runInPodWithDifferentShell.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runInPodWithDifferentShell.groovy
@@ -1,0 +1,14 @@
+podTemplate(label: 'mypod', containers: [
+        containerTemplate(name: 'busybox', image: 'busybox', ttyEnabled: true, command: '/bin/cat'),
+    ]) {
+
+    node ('mypod') {
+      stage('Run') {
+        container(name:'busybox', shell: '/bin/bash') {
+          sh """
+            echo "Run BusyBox shell"
+          """
+        }
+      }
+    }
+}


### PR DESCRIPTION
We need to be able, in our containers, to load profile files (.bash_rc, .profile, ...) at runtime. /bin/sh, while it's often just a link to /bin/bash puts you in a compatibility mode that doesn't load these files.

We run this Jenkins plugin against an OpenShift cluster that, by default, runs containers with an undefined UID. Being able to load variables from "profile" files is critical for us.

The implementation is retro compatible with the already written jenkinsfiles, but let's you override the interpreter you will use to run commands in your container (in our case, we mostly want to use bash).

An example of Jenkinsfile with the modification:
```
podTemplate(name: 'maven', label: 'maven', containers: [
  containerTemplate(name: 'maven', image: 'maven:latest', ttyEnabled: true, command: 'cat', alwaysPullImage: true),
  containerTemplate(name: 'jnlp', image: 'openshift/jenkins-slave-base-centos7', args: '${computer.jnlpmac} ${computer.name}', alwaysPullImage: true),
  ]) {

  node('maven') {
    stage('Build a Maven project') {
      container(name:'maven', shell:'/bin/bash') {
        sh 'mvn -version'
      }
    }
  }
}
```