### PR TITLE
JENKINS-42582: fix nondesired injection of computer variables into container

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesComputer.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesComputer.java
@@ -1,8 +1,10 @@
 package org.csanchez.jenkins.plugins.kubernetes;
 
+import hudson.EnvVars;
 import hudson.model.Executor;
 import hudson.model.Queue;
 import hudson.slaves.AbstractCloudComputer;
+import java.io.IOException;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -42,4 +44,15 @@ public class KubernetesComputer extends AbstractCloudComputer<KubernetesSlave> {
     public String toString() {
         return String.format("KubernetesComputer name: %s slave: %s", getName(), getNode());
     }
+
+    /*
+    Return empty EnvVars since we don't want to inject jnlp agent system variables;
+    */
+    @Override
+      public EnvVars getEnvironment() throws IOException, InterruptedException {
+        return new EnvVars();
+    }
+
+
+
 }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -214,8 +214,6 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
                 LOGGER.log(Level.FINEST, "Launch proc with environment: {0}", Arrays.toString(starter.envs()));
                 boolean quiet = starter.quiet();
                 FilePath pwd = starter.pwd();
-
-
                 List<String> procStarter = Arrays.asList(starter.envs());
                 List<String> cmdEnvs = new ArrayList<String>();
                 // One issue that cropped up was that when executing sh commands, we would get the jnlp agent's injected
@@ -225,7 +223,7 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
                 // Currently, build level properties will be provided by the Run Context anyways.
                 boolean javaHome_detected = false;
                 for (String env : procStarter) {
-                    if (env.contains("JAVA_HOME")) {
+                    if (env.equalsIgnoreCase("JAVA_HOME")) {
                         LOGGER.log(Level.FINEST, "Detected JAVA_HOME in {0}", env);
                         javaHome_detected = true;
                         break;

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorPipelineTest.java
@@ -47,7 +47,11 @@ public class ContainerExecDecoratorPipelineTest extends AbstractKubernetesPipeli
         assertNotNull(b);
         r.waitForCompletion(b);
         r.assertLogContains("Identity added:", b);
-        //check that we don't accidentally start exporting sensitive info to the log
+        //Assert that ssh-agent provided envVar is now properly contributed and set.
+        r.assertLogContains("SSH_AGENT_PID=", b);
+        //assert that our private key was loaded and is visible within the ssh-agent scope
+        r.assertLogContains("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDhvmTBXRnSbtpnkt/Ldw7ws4LFdoX9oI+5NexgpBC4Otqbn8+Ui6FGWeYflOQUcl3rgmBxsHIeFnPr9qSvgME1TWPIyHSQh2kPMd3NQgkEvioBxghnWRy7sal4KBr2P8m7Iusm8j0aCNLZ3nYjJSywWZxiqqrcpnhFuTD//FPIEhXOu2sk2FEP7YsA9TdL8mAruxy/6Ys2pRC2dQhBtmkEOyEGiBnk3ioT5iCw/Qqe+pU0yaYu69vPyAFCuazBMopPcOuRxFgKvrfCPVqcQb3HERJh5eiW5+5Vg3RwoByQUtQMK5PDBVWPo9srB0Q9Aw9DXmeJCgdtFJqhhh4SR+al /home/jenkins/workspace/sshagent@tmp/private_key",b);
+         //check that we don't accidentally start exporting sensitive info to the log
         r.assertLogNotContains("secret_passphrase", b);
     }
 }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
@@ -152,7 +152,7 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
         WorkflowRun b = p.scheduleBuild2(0).waitForStart();
         assertNotNull(b);
         r.assertBuildStatusSuccess(r.waitForCompletion(b));
-        r.assertLogNotContains("The value of FROM_ENV_DEFINITION is ABC", b);
+        r.assertLogContains("The value of FROM_ENV_DEFINITION is ABC", b);
         r.assertLogContains("The value of FROM_WITHENV_DEFINITION is DEF", b);
         r.assertLogContains("The value of WITH_QUOTE is \"WITH_QUOTE", b);
         r.assertLogContains("The value of AFTER_QUOTE is AFTER_QUOTE\"", b);

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runWithEnvVarsFromContext.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runWithEnvVarsFromContext.groovy
@@ -4,6 +4,7 @@ podTemplate(label: 'mypod',
         containerTemplate(name: 'busybox', image: 'busybox', ttyEnabled: true, command: '/bin/cat'),
     ]) {
 
+    //we should expect outer environment variables to show up here.
     env.FROM_ENV_DEFINITION = "ABC"
     node ('mypod') {
         stage('Run busybox') {

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/sshagent.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/sshagent.groovy
@@ -5,6 +5,8 @@ podTemplate(label: 'mypod', containers: [
         stage('container log') {
             container('ssh-client') {
                 sshagent (credentials: ['ContainerExecDecoratorPipelineTest-sshagent']) {
+                    sh 'env'
+                    sh 'ssh-add -L'
                     sh 'ssh -vT -o "StrictHostKeyChecking=no" git@github.com'
                 }
             }


### PR DESCRIPTION
This fixes the long outstanding issues with plugin contributed envVars and should allow EnvVars to work as expected when compared to any other executor provider. 