### PR TITLE
[JENKINS-49956] Wait for up to 2 minutes before killing the container

### DIFF
--- a/src/main/kubernetes/jenkins.yml
+++ b/src/main/kubernetes/jenkins.yml
@@ -52,12 +52,14 @@ spec:
               port: 8080
             initialDelaySeconds: 60
             timeoutSeconds: 5
+            failureThreshold: 12 # ~2 minutes
           readinessProbe:
             httpGet:
               path: /login
               port: 8080
             initialDelaySeconds: 60
             timeoutSeconds: 5
+            failureThreshold: 12 # ~2 minutes
       securityContext:
         fsGroup: 1000
   volumeClaimTemplates:


### PR DESCRIPTION
Otherwise a plugin installation causes 2 restarts

[JENKINS-49956](https://issues.jenkins-ci.org/browse/JENKINS-49956)
