### PR TITLE
changing to groovy style comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Nodes can be defined in a pipeline and then used, however, default execution alw
 
 This will run in jnlp container
 ```groovy
-# this guarantees the node will use this template
+// this guarantees the node will use this template
 def label = "mypod-${UUID.randomUUID().toString()}"
 podTemplate(label: label) {
     node(label) {


### PR DESCRIPTION
Complete nit - copy/paste of the example blew up because of the `#` character, so updating this example to the groovy style single-line comment syntax