### PR TITLE
[JENKINS-49817] Support kubeconfig from secretFile credentials

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubectlBuildWrapper.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubectlBuildWrapper.java
@@ -93,6 +93,9 @@ public class KubectlBuildWrapper extends SimpleBuildWrapper {
         FilePath configFile = workspace.createTempFile(".kube", "config");
         Set<String> tempFiles = newHashSet(configFile.getRemote());
 
+        context.env("KUBECONFIG", configFile.getRemote());
+        context.setDisposer(new CleanupDisposer(tempFiles));
+
         String tlsConfig;
         if (caCertificate != null && !caCertificate.isEmpty()) {
             FilePath caCrtFile = workspace.createTempFile("cert-auth", "crt");
@@ -130,9 +133,6 @@ public class KubectlBuildWrapper extends SimpleBuildWrapper {
             } finally {
                 reader.close();
             }
-
-            context.setDisposer(new CleanupDisposer(tempFiles));
-            context.env("KUBECONFIG", configFile.getRemote());
             return;
         }
 
@@ -191,10 +191,6 @@ public class KubectlBuildWrapper extends SimpleBuildWrapper {
                 .cmdAsSingleString("kubectl config --kubeconfig=\"" + configFile.getRemote() + "\" use-context k8s")
                 .join();
         if (status != 0) throw new IOException("Failed to run kubectl config "+status);
-
-        context.setDisposer(new CleanupDisposer(tempFiles));
-
-        context.env("KUBECONFIG", configFile.getRemote());
     }
 
     /**

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubectlBuildWrapper.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubectlBuildWrapper.java
@@ -26,6 +26,7 @@ import hudson.util.Secret;
 import jenkins.model.Jenkins;
 import jenkins.tasks.SimpleBuildWrapper;
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.kubernetes.credentials.TokenProducer;
 import org.jenkinsci.plugins.plaincredentials.FileCredentials;
@@ -38,6 +39,7 @@ import javax.annotation.Nonnull;
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
@@ -125,13 +127,8 @@ public class KubectlBuildWrapper extends SimpleBuildWrapper {
         }
 
         if (c instanceof FileCredentials) {
-            InputStream configStream = ((FileCredentials) c).getContent();
-            BufferedReader reader = new BufferedReader(new InputStreamReader(configStream, StandardCharsets.UTF_8));
-            try {
-                String kubeconfigContents = reader.lines().collect(Collectors.joining("\n"));
-                configFile.write(kubeconfigContents, null);
-            } finally {
-                reader.close();
+            try (InputStream in = ((FileCredentials) c).getContent(); OutputStream out = configFile.write()) {
+                IOUtils.copy(in, out);
             }
             return;
         }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -26,6 +26,7 @@ import javax.servlet.ServletException;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+import org.jenkinsci.plugins.plaincredentials.FileCredentials;
 import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -593,6 +594,7 @@ public class KubernetesCloud extends Cloud {
                     .withMatching( //
                             CredentialsMatchers.anyOf(
                                     CredentialsMatchers.instanceOf(StandardUsernamePasswordCredentials.class),
+                                    CredentialsMatchers.instanceOf(FileCredentials.class),
                                     CredentialsMatchers.instanceOf(TokenProducer.class),
                                     CredentialsMatchers.instanceOf(
                                             org.jenkinsci.plugins.kubernetes.credentials.TokenProducer.class),


### PR DESCRIPTION
~~Note: this is a WIP because it is blocked by this PR on the fabric8 kubernetes-client: [config: support loading from kubeconfig string](https://github.com/fabric8io/kubernetes-client/pull/1029).~~

~~* Updates to the 3.x version of the `kubernetes-client` package~~
* Supports `kubeconfig` files (`secretFile` credentails) as cluster credentials

I have (minimally) tested it, however. Sending it now so people can take a look. I'll update the title when it's no longer blocked.

This is my preferred way of handling all credentials for kubernetes clusters, whenever the credentials are "portable" and sealed. For example, when producing limiting service accounts in remote namespaces and then generating kubeconfigs for them.

Fixes: [JENKINS-49817](https://issues.jenkins-ci.org/browse/JENKINS-49817)