### PR TITLE
Allow customization of NodeProvisioner.PlannedNode using extension point

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -51,7 +51,6 @@ import hudson.Extension;
 import hudson.Util;
 import hudson.init.InitMilestone;
 import hudson.init.Initializer;
-import hudson.model.Computer;
 import hudson.model.Descriptor;
 import hudson.model.Label;
 import hudson.model.Node;
@@ -405,9 +404,7 @@ public class KubernetesCloud extends Cloud {
                     if (!addProvisionedSlave(t, label)) {
                         break;
                     }
-
-                    r.add(new NodeProvisioner.PlannedNode(t.getDisplayName(), Computer.threadPoolForRemoting
-                                .submit(new ProvisioningCallback(this, t, label)), 1));
+                    r.add(PlannedNodeBuilderFactory.createInstance().cloud(this).template(t).label(label).build());
                 }
                 if (r.size() > 0) {
                     // Already found a matching template
@@ -485,6 +482,15 @@ public class KubernetesCloud extends Cloud {
      */
     public PodTemplate getTemplate(@CheckForNull Label label) {
         return PodTemplateUtils.getTemplateByLabel(label, getAllTemplates());
+    }
+
+    /**
+     * Unwraps the given pod template.
+     * @param podTemplate the pod template to unwrap.
+     * @return the unwrapped pod template
+     */
+    public PodTemplate getUnwrappedTemplate(PodTemplate podTemplate) {
+        return PodTemplateUtils.unwrap(podTemplate, getDefaultsProviderTemplate(), getAllTemplates());
     }
 
     /**

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PlannedNodeBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PlannedNodeBuilder.java
@@ -1,0 +1,81 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import hudson.model.Label;
+import hudson.slaves.NodeProvisioner;
+
+/**
+ * A builder of {@link hudson.slaves.NodeProvisioner.PlannedNode} implementations for Kubernetes.
+ * Can be subclassed to provide alternative implementations of {@link hudson.slaves.NodeProvisioner.PlannedNode}.
+ */
+public abstract class PlannedNodeBuilder {
+    private KubernetesCloud cloud;
+    private PodTemplate template;
+    private Label label;
+    private int numExecutors = 1;
+
+    /**
+     * Returns the {@link KubernetesCloud}.
+     * @return the {@link KubernetesCloud}.
+     */
+    public KubernetesCloud getCloud() {
+        return cloud;
+    }
+
+    /**
+     * Returns the {@link PodTemplate}.
+     * @return
+     */
+    public PodTemplate getTemplate() {
+        return template;
+    }
+
+    public Label getLabel() {
+        return label;
+    }
+
+    public int getNumExecutors() {
+        return numExecutors;
+    }
+
+    /**
+     * @param cloud the {@link KubernetesCloud} instance to use.
+     * @return the current builder.
+     */
+    public PlannedNodeBuilder cloud(KubernetesCloud cloud) {
+        this.cloud = cloud;
+        return this;
+    }
+
+    /**
+     * @param template the {@link PodTemplate} instance to use.
+     * @return the current builder.
+     */
+    public PlannedNodeBuilder template(PodTemplate template) {
+        this.template = template;
+        return this;
+    }
+
+    /**
+     * @param label the {@link Label} to use.
+     * @return the current builder.
+     */
+    public PlannedNodeBuilder label(Label label) {
+        this.label = label;
+        return this;
+    }
+
+    /**
+     * @param numExecutors the number of executors.
+     * @return the current builder.
+     */
+    public PlannedNodeBuilder numExecutors(int numExecutors) {
+        this.numExecutors = numExecutors;
+        return this;
+    }
+
+    /**
+     * Builds the {@link hudson.slaves.NodeProvisioner.PlannedNode} instance based on the given inputs.
+     * @return a {@link hudson.slaves.NodeProvisioner.PlannedNode} configured from this builder.
+     */
+    public abstract NodeProvisioner.PlannedNode build();
+}

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PlannedNodeBuilderFactory.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PlannedNodeBuilderFactory.java
@@ -1,0 +1,37 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import hudson.ExtensionList;
+import hudson.ExtensionPoint;
+
+/**
+ * A factory of {@link PlannedNodeBuilder} instances.
+ */
+public abstract class PlannedNodeBuilderFactory implements ExtensionPoint {
+    /**
+     * Returns all registered implementations of {@link PlannedNodeBuilderFactory}.
+     * @return all registered implementations of {@link PlannedNodeBuilderFactory}.
+     */
+    public static ExtensionList<PlannedNodeBuilderFactory> all() {
+        return ExtensionList.lookup(PlannedNodeBuilderFactory.class);
+    }
+
+    /**
+     * Returns a new instance of {@link PlannedNodeBuilder}.
+     * @return a new instance of {@link PlannedNodeBuilder}.
+     */
+    public static PlannedNodeBuilder createInstance() {
+        for (PlannedNodeBuilderFactory factory: all()) {
+            PlannedNodeBuilder plannedNodeBuilder = factory.newInstance();
+            if (plannedNodeBuilder != null) {
+                return plannedNodeBuilder;
+            }
+        }
+        return new StandardPlannedNodeBuilder();
+    }
+
+    /**
+     * Creates a new instance of {@link PlannedNodeBuilder}.
+     * @return a new instance of {@link PlannedNodeBuilder}.
+     */
+    public abstract PlannedNodeBuilder newInstance();
+}

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ProvisioningCallback.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ProvisioningCallback.java
@@ -26,8 +26,10 @@ package org.csanchez.jenkins.plugins.kubernetes;
 
 import java.util.concurrent.Callable;
 
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
+import hudson.model.Label;
 import hudson.model.Node;
 
 /**
@@ -41,6 +43,14 @@ class ProvisioningCallback implements Callable<Node> {
     private final KubernetesCloud cloud;
     @Nonnull
     private final PodTemplate t;
+
+    /**
+     * @deprecated Use {@link ProvisioningCallback#ProvisioningCallback(KubernetesCloud, PodTemplate)} instead.
+     */
+    @Deprecated
+    public ProvisioningCallback(@Nonnull KubernetesCloud cloud, @Nonnull PodTemplate t, @CheckForNull Label label) {
+        this(cloud, t);
+    }
 
     public ProvisioningCallback(@Nonnull KubernetesCloud cloud, @Nonnull PodTemplate t) {
         this.cloud = cloud;

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/StandardPlannedNodeBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/StandardPlannedNodeBuilder.java
@@ -1,0 +1,16 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import hudson.model.Computer;
+import hudson.slaves.NodeProvisioner;
+
+/**
+ * The default {@link PlannedNodeBuilder} implementation, in case there is other registered.
+ */
+public class StandardPlannedNodeBuilder extends PlannedNodeBuilder {
+    @Override
+    public NodeProvisioner.PlannedNode build() {
+        return new NodeProvisioner.PlannedNode(getTemplate().getDisplayName(),
+                Computer.threadPoolForRemoting.submit(new ProvisioningCallback(getCloud(), getTemplate())),
+                getNumExecutors());
+    }
+}


### PR DESCRIPTION
* New extension point PlannedNodeBuilderFactory to allow extensions to provide alternative PlannedNode implementations.
* Builder pattern for KubernetesSlave to stop the explosion of constructors