### PR TITLE
Print agent specification upon node allocation

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
@@ -293,6 +293,11 @@ public class KubernetesSlave extends AbstractCloudSlave {
         return super.createLauncher(listener);
     }
 
+    protected Object readResolve() {
+        this.executables = new HashSet<>();
+        return this;
+    }
+
     /**
      * Returns a new {@link Builder} instance.
      * @return a new {@link Builder} instance.

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -597,6 +597,40 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
         return new PodTemplateBuilder(this).build(slave);
     }
 
+    public String getDescriptionForLogging() {
+        return String.format("Agent specification [%s] (%s): \n%s",
+                getDisplayName(),
+                getLabel(),
+                getContainersDescriptionForLogging());
+    }
+
+    private String getContainersDescriptionForLogging() {
+        List<ContainerTemplate> containers = getContainers();
+        StringBuilder sb = new StringBuilder();
+        for (ContainerTemplate ct : containers) {
+            sb.append("* [").append(ct.getName()).append("] ").append(ct.getImage());
+            StringBuilder optional = new StringBuilder();
+            optionalField(optional, "resourceRequestCpu", ct.getResourceRequestCpu());
+            optionalField(optional, "resourceRequestMemory", ct.getResourceRequestMemory());
+            optionalField(optional, "resourceLimitCpu", ct.getResourceLimitCpu());
+            optionalField(optional, "resourceLimitMemory", ct.getResourceLimitMemory());
+            if (optional.length() > 0) {
+                sb.append("(").append(optional).append(")");
+            }
+            sb.append("\n");
+        }
+        return sb.toString();
+    }
+
+    private void optionalField(StringBuilder builder, String label, String value) {
+        if (value != null) {
+            if (builder.length() > 0) {
+                builder.append(", ");
+            }
+            builder.append(label).append(": ").append(value);
+        }
+    }
+
     @Extension
     public static class DescriptorImpl extends Descriptor<PodTemplate> {
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -598,7 +598,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
     }
 
     public String getDescriptionForLogging() {
-        return String.format("Agent specification [%s] (%s): \n%s",
+        return String.format("Agent specification [%s] (%s): %n%s",
                 getDisplayName(),
                 getLabel(),
                 getContainersDescriptionForLogging());

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/Messages.properties
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/Messages.properties
@@ -1,2 +1,3 @@
 offline=Kubernetes agent is going offline
 NonConfigurableKubernetesCloud.displayName=Kubernetes (predefined settings)
+KubernetesSlave.AgentIsProvisionedFromTemplate=Agent {0} is provisioned from template {1}

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
@@ -101,6 +101,9 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
         WorkflowRun b = p.scheduleBuild2(0).waitForStart();
         assertNotNull(b);
         r.assertBuildStatusSuccess(r.waitForCompletion(b));
+        r.assertLogContains("[jnlp] jenkins/jnlp-slave:3.10-1-alpine", b);
+        r.assertLogContains("[maven] maven:3.3.9-jdk-8-alpine", b);
+        r.assertLogContains("[golang] golang:1.6.3-alpine", b);
         r.assertLogContains("My Kubernetes Pipeline", b);
         r.assertLogContains("my-mount", b);
         r.assertLogContains("Apache Maven 3.3.9", b);


### PR DESCRIPTION
First shot at printing agent specification upon first use.

This prints the docker image used for each container as well as the resource constraints if they are defined.