### PR TITLE
[JENKINS-50525] Fix duplicated volume mounts

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes/HostPathVolume.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes/HostPathVolume.java
@@ -65,4 +65,9 @@ public class HostPathVolume extends PodVolume {
             return "Host Path Volume";
         }
     }
+
+    @Override
+    public String toString() {
+        return "HostPathVolume [mountPath=" + mountPath + ", hostPath=" + hostPath + "]";
+    }
 }

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pod-busybox.yaml
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pod-busybox.yaml
@@ -34,6 +34,12 @@ spec:
     env:
     - name: CONTAINER_ENV_VAR
       value: container-env-var-value
+    volumeMounts:
+    - mountPath: /container/data
+      name: host-volume
   volumes:
   - name: empty-volume
     emptyDir: {}
+  - name: host-volume
+    hostPath:
+      path: /host/data

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pod-overrides.yaml
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pod-overrides.yaml
@@ -1,0 +1,11 @@
+spec:
+  containers:
+  - name: jnlp
+    image: jenkins-jnlp-override
+    volumeMounts:
+    - mountPath: /home/jenkins
+      name: host-volume
+  volumes:
+  - name: host-volume
+    hostPath:
+      path: /host/data


### PR DESCRIPTION
Volume mounts were being compared by name instead of mountPath which needs to be unique per container

[JENKINS-50525](https://issues.jenkins-ci.org/browse/JENKINS-50525)
