### PR TITLE
Use slave template namespace in logs

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -435,7 +435,7 @@ public class KubernetesCloud extends Cloud {
         if (slaveListItems != null && containerCap <= slaveListItems.size()) {
             LOGGER.log(Level.INFO,
                     "Total container cap of {0} reached, not provisioning: {1} running or errored in namespace {2} with Kubernetes labels {3}",
-                    new Object[] { containerCap, slaveListItems.size(), client.getNamespace(), getLabels() });
+                    new Object[] { containerCap, slaveListItems.size(), templateNamespace, getLabels() });
             return false;
         }
 
@@ -443,7 +443,7 @@ public class KubernetesCloud extends Cloud {
             LOGGER.log(Level.INFO,
                     "Template instance cap of {0} reached for template {1}, not provisioning: {2} running or errored in namespace {3} with label \"{4}\" and Kubernetes labels {5}",
                     new Object[] { template.getInstanceCap(), template.getName(), slaveListItems.size(),
-                            client.getNamespace(), label == null ? "" : label.toString(), labelsMap });
+                            templateNamespace, label == null ? "" : label.toString(), labelsMap });
             return false; // maxed out
         }
         return true;


### PR DESCRIPTION
This defaults to client namespace as before. Currently it logs the `master` namespace, even if the slaves are being provisioned elsewhere.