### PR TITLE
[JENKINS-50533] Support multiple containers in declarative pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,69 @@ annotations: [
 
 Declarative Pipeline support requires Jenkins 2.66+
 
-Example at [examples/declarative.groovy](examples/declarative.groovy)
+Declarative agents can be defined from yaml
+
+```groovy
+pipeline {
+  agent {
+    kubernetes {
+      label 'mypod'
+      defaultContainer: 'jnlp'
+      yaml """
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    some-label: some-label-value
+spec:
+  containers:
+  - name: maven
+    image: maven:alpine
+    command:
+    - cat
+    tty: true
+  - name: busybox
+    image: busybox
+    command:
+    - cat
+    tty: true
+"""
+    }
+  }
+  stages {
+    stage('Run maven') {
+      steps {
+        container('maven') {
+          sh 'mvn -version'
+        }
+        container('busybox') {
+          sh '/bin/busybox'
+        }
+      }
+    }
+  }
+}
+```
+
+Note that it was previously possible to define `containerTemplate` but that has been deprecated in favor of the yaml format.
+
+```groovy
+pipeline {
+  agent {
+    kubernetes {
+      //cloud 'kubernetes'
+      label 'mypod'
+      containerTemplate {
+        name 'maven'
+        image 'maven:3.3.9-jdk-8-alpine'
+        ttyEnabled true
+        command 'cat'
+      }
+    }
+  }
+  stages { ... }
+}
+```
 
 ## Accessing container logs from the pipeline
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,6 @@
+# Kubernetes plugin pipeline examples
+
+In this dir you can find several pipeline examples.
+
+For more examples that are continuously tested, check the [`src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline`](src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline)
+resources directory.

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgent.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgent.java
@@ -2,19 +2,30 @@ package org.csanchez.jenkins.plugins.kubernetes.pipeline;
 
 import org.apache.commons.lang.StringUtils;
 import org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate;
+import org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgent;
 import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentDescriptor;
 import org.jenkinsci.plugins.variant.OptionalExtension;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class KubernetesDeclarativeAgent extends DeclarativeAgent<KubernetesDeclarativeAgent> {
-    private final String label;
+
+    private static final Logger LOGGER = Logger.getLogger(KubernetesDeclarativeAgent.class.getName());
+
+    private String label;
 
     private String cloud;
     private String inheritFrom;
@@ -26,8 +37,15 @@ public class KubernetesDeclarativeAgent extends DeclarativeAgent<KubernetesDecla
     private int activeDeadlineSeconds;
 
     private ContainerTemplate containerTemplate;
+    private List<ContainerTemplate> containerTemplates;
+    private String defaultContainer;
+    private String yaml;
 
     @DataBoundConstructor
+    public KubernetesDeclarativeAgent() {
+    }
+
+    @Deprecated
     public KubernetesDeclarativeAgent(String label, ContainerTemplate containerTemplate) {
         this.label = label;
         this.containerTemplate = containerTemplate;
@@ -35,6 +53,11 @@ public class KubernetesDeclarativeAgent extends DeclarativeAgent<KubernetesDecla
 
     public String getLabel() {
         return label;
+    }
+
+    @DataBoundSetter
+    public void setLabel(String label) {
+        this.label = label;
     }
 
     public String getCloud() {
@@ -91,8 +114,43 @@ public class KubernetesDeclarativeAgent extends DeclarativeAgent<KubernetesDecla
         this.workingDir = workingDir;
     }
 
+    public String getYaml() {
+        return yaml;
+    }
+
+    @DataBoundSetter
+    public void setYaml(String yaml) {
+        this.yaml = yaml;
+    }
+
+    @Deprecated
     public ContainerTemplate getContainerTemplate() {
         return containerTemplate;
+    }
+
+    @DataBoundSetter
+    @Restricted(DoNotUse.class)
+    public void setContainerTemplate(ContainerTemplate containerTemplate) {
+        this.containerTemplate = containerTemplate;
+    }
+
+    @NonNull
+    public List<ContainerTemplate> getContainerTemplates() {
+        return containerTemplates != null ? containerTemplates : Collections.emptyList();
+    }
+
+    @DataBoundSetter
+    public void setContainerTemplates(List<ContainerTemplate> containerTemplates) {
+        this.containerTemplates = containerTemplates;
+    }
+
+    public String getDefaultContainer() {
+        return defaultContainer;
+    }
+
+    @DataBoundSetter
+    public void setDefaultContainer(String defaultContainer) {
+        this.defaultContainer = defaultContainer;
     }
 
     public int getActiveDeadlineSeconds() {
@@ -100,15 +158,32 @@ public class KubernetesDeclarativeAgent extends DeclarativeAgent<KubernetesDecla
     }
 
     @DataBoundSetter
-    public void setActiveDeadlineSeconds(int activeDeadlineSeconds) { this.activeDeadlineSeconds = activeDeadlineSeconds; }
+    public void setActiveDeadlineSeconds(int activeDeadlineSeconds) {
+        this.activeDeadlineSeconds = activeDeadlineSeconds;
+    }
 
-    public Map<String,Object> getAsArgs() {
-        Map<String,Object> argMap = new TreeMap<>();
+    public Map<String, Object> getAsArgs() {
+        Map<String, Object> argMap = new TreeMap<>();
 
         argMap.put("label", label);
         argMap.put("name", label);
-        argMap.put("containers", Collections.singletonList(containerTemplate));
 
+        List<ContainerTemplate> containerTemplates = getContainerTemplates();
+        if (containerTemplate != null) {
+            LOGGER.log(Level.WARNING,
+                    "containerTemplate option in declarative pipeline is deprecated, use containerTemplates");
+            if (containerTemplates.isEmpty()) {
+                containerTemplates = Collections.singletonList(containerTemplate);
+            } else {
+                LOGGER.log(Level.WARNING,
+                        "Ignoring containerTemplate option as containerTemplates is also defined");
+            }
+        }
+        argMap.put("containers", containerTemplates);
+
+        if (!StringUtils.isEmpty(yaml)) {
+            argMap.put("yaml", yaml);
+        }
         if (!StringUtils.isEmpty(cloud)) {
             argMap.put("cloud", cloud);
         }
@@ -135,7 +210,8 @@ public class KubernetesDeclarativeAgent extends DeclarativeAgent<KubernetesDecla
         return argMap;
     }
 
-    @OptionalExtension(requirePlugins = "pipeline-model-extensions") @Symbol("kubernetes")
+    @OptionalExtension(requirePlugins = "pipeline-model-extensions")
+    @Symbol("kubernetes")
     public static class DescriptorImpl extends DeclarativeAgentDescriptor<KubernetesDeclarativeAgent> {
     }
 }

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgentScript.groovy
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgentScript.groovy
@@ -50,7 +50,16 @@ public class KubernetesDeclarativeAgentScript extends DeclarativeAgentScript<Kub
                                 script.checkout script.scm
                             }
                         }
-                        script.container(describable.containerTemplate.asArgs) {
+                        // what container to use for the main body
+                        def container = describable.defaultContainer ?: 'jnlp';
+
+                        if (describable.containerTemplate != null) {
+                            // run inside the container declared for backwards compatibility
+                            container = describable.containerTemplate.asArgs;
+                        }
+
+                        // call the main body
+                        script.container(container) {
                             body.call()
                         }
                     }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgentTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgentTest.java
@@ -47,4 +47,18 @@ public class KubernetesDeclarativeAgentTest extends AbstractKubernetesPipelineTe
         r.assertLogContains("OUTSIDE_CONTAINER_ENV_VAR = " + CONTAINER_ENV_VAR_VALUE + "\n", b);
     }
 
+    @Issue("JENKINS-48135")
+    @Test
+    public void declarativeFromYaml() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "job with dir");
+        p.setDefinition(new CpsFlowDefinition(loadPipelineScript("declarativeFromYaml.groovy"), true));
+        WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+        assertNotNull(b);
+        r.assertBuildStatusSuccess(r.waitForCompletion(b));
+        r.assertLogContains("Apache Maven 3.3.9", b);
+        r.assertLogContains("OUTSIDE_CONTAINER_ENV_VAR = jnlp\n", b);
+        r.assertLogContains("MAVEN_CONTAINER_ENV_VAR = maven\n", b);
+        r.assertLogContains("BUSYBOX_CONTAINER_ENV_VAR = busybox\n", b);
+    }
+
 }

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/declarative.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/declarative.groovy
@@ -17,6 +17,7 @@ pipeline {
     stage('Run maven') {
       steps {
         sh 'set'
+        sh 'test -f /usr/bin/mvn' // checking backwards compatibility
         sh "echo OUTSIDE_CONTAINER_ENV_VAR = ${CONTAINER_ENV_VAR}"
         container('maven') {
           sh 'echo INSIDE_CONTAINER_ENV_VAR = ${CONTAINER_ENV_VAR}'

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/declarativeFromYaml.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/declarativeFromYaml.groovy
@@ -1,0 +1,50 @@
+pipeline {
+  agent {
+    kubernetes {
+      label 'mypod'
+      yaml """
+metadata:
+  labels:
+    some-label: some-label-value
+spec:
+  containers:
+  - name: jnlp
+    env:
+    - name: CONTAINER_ENV_VAR
+      value: jnlp
+  - name: maven
+    image: maven:3.3.9-jdk-8-alpine
+    command:
+    - cat
+    tty: true
+    env:
+    - name: CONTAINER_ENV_VAR
+      value: maven
+  - name: busybox
+    image: busybox
+    command:
+    - cat
+    tty: true
+    env:
+    - name: CONTAINER_ENV_VAR
+      value: busybox
+"""
+    }
+  }
+  stages {
+    stage('Run maven') {
+      steps {
+        sh 'set'
+        sh "echo OUTSIDE_CONTAINER_ENV_VAR = ${CONTAINER_ENV_VAR}"
+        container('maven') {
+          sh 'echo MAVEN_CONTAINER_ENV_VAR = ${CONTAINER_ENV_VAR}'
+          sh 'mvn -version'
+        }
+        container('busybox') {
+          sh 'echo BUSYBOX_CONTAINER_ENV_VAR = ${CONTAINER_ENV_VAR}'
+          sh '/bin/busybox'
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Using the yaml syntax

[JENKINS-50533](https://issues.jenkins-ci.org/browse/JENKINS-48135)
Supersedes #260

Example:

```groovy
pipeline {
  agent {
    kubernetes {
      label 'mypod'
      defaultContainer 'jnlp'
      yaml """
apiVersion: v1
kind: Pod
metadata:
  labels:
    some-label: some-label-value
spec:
  containers:
  - name: maven
    image: maven:alpine
    command:
    - cat
    tty: true
  - name: busybox
    image: busybox
    command:
    - cat
    tty: true
"""
    }
  }
  stages {
    stage('Run maven') {
      steps {
        container('maven') {
          sh 'mvn -version'
        }
        container('busybox') {
          sh '/bin/busybox'
        }
      }
    }
  }
}
```