### PR TITLE
[JENKINS-50913] Do not pass arguments to jnlp container

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -52,7 +52,6 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
@@ -233,9 +232,6 @@ public class PodTemplateBuilder {
         }
         if (StringUtils.isBlank(jnlp.getImage())) {
             jnlp.setImage(DEFAULT_JNLP_IMAGE);
-        }
-        if (jnlp.getArgs().isEmpty() && slave != null) {
-            jnlp.setArgs(ImmutableList.of(slave.getComputer().getJnlpMac(), slave.getComputer().getName()));
         }
         Map<String, EnvVar> envVars = defaultEnvVars(slave,
                 jnlp.getWorkingDir() != null ? jnlp.getWorkingDir() : ContainerTemplate.DEFAULT_WORKING_DIR,

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
@@ -133,7 +133,7 @@ public class PodTemplateBuilderTest {
                 new EnvVar("HOME", "/home/jenkins", null) //
         );
         if (slave != null) {
-            assertThat(jnlp.getArgs(), contains(AGENT_SECRET, AGENT_NAME));
+            assertThat(jnlp.getArgs(), empty());
             envVars.add(new EnvVar("JENKINS_URL", JENKINS_URL, null));
             envVars.add(new EnvVar("JENKINS_SECRET", AGENT_SECRET, null));
             envVars.add(new EnvVar("JENKINS_NAME", AGENT_NAME, null));


### PR DESCRIPTION
They haven't been needed for a while and can't be merged easily from parent to children

Fixes regression introduced in #305 