### PR TITLE
Ensuring all data on pod template is copied during combine

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
@@ -258,6 +258,9 @@ public class PodTemplateUtils {
             return template;
         }
 
+        LOGGER.log(Level.FINEST, "Combining pod templates, parent: {0}", parent);
+        LOGGER.log(Level.FINEST, "Combining pod templates, template: {0}", template);
+
         String name = template.getName();
         String label = template.getLabel();
         String nodeSelector = Strings.isNullOrEmpty(template.getNodeSelector()) ? parent.getNodeSelector() : template.getNodeSelector();
@@ -306,8 +309,31 @@ public class PodTemplateUtils {
         podTemplate.setAnnotations(new ArrayList<>(podAnnotations));
         podTemplate.setNodeProperties(toolLocationNodeProperties);
         podTemplate.setNodeUsageMode(nodeUsageMode);
+        podTemplate.setInheritFrom(!Strings.isNullOrEmpty(template.getInheritFrom()) ? 
+                                   template.getInheritFrom() : parent.getInheritFrom());
+        
+        podTemplate.setInstanceCap(template.getInstanceCap() != Integer.MAX_VALUE ? 
+                                   template.getInstanceCap() : parent.getInstanceCap());
+        
+        podTemplate.setSlaveConnectTimeout(template.getSlaveConnectTimeout() != PodTemplate.DEFAULT_SLAVE_JENKINS_CONNECTION_TIMEOUT ? 
+                                           template.getSlaveConnectTimeout() : parent.getSlaveConnectTimeout());
+
+        podTemplate.setIdleMinutes(template.getIdleMinutes() != 0 ? 
+                                   template.getIdleMinutes() : parent.getIdleMinutes()); 
+
+        podTemplate.setActiveDeadlineSeconds(template.getActiveDeadlineSeconds() != 0 ?
+                                             template.getActiveDeadlineSeconds() : parent.getActiveDeadlineSeconds()); 
+
+            
+        podTemplate.setServiceAccount(!Strings.isNullOrEmpty(template.getServiceAccount()) ? 
+                                      template.getServiceAccount() : parent.getServiceAccount());
+
+        podTemplate.setCustomWorkspaceVolumeEnabled(template.isCustomWorkspaceVolumeEnabled() ? 
+                                                    template.isCustomWorkspaceVolumeEnabled() : parent.isCustomWorkspaceVolumeEnabled());
+
         podTemplate.setYaml(template.getYaml() == null ? parent.getYaml() : template.getYaml());
 
+        LOGGER.log(Level.FINEST, "Pod templates combined: {0}", podTemplate);
         return podTemplate;
     }
 
@@ -345,7 +371,9 @@ public class PodTemplateUtils {
                     parent = combine(parent, unwrap(next, allTemplates));
                 }
             }
-            return combine(parent, template);
+            PodTemplate combined = combine(parent, template);
+            LOGGER.log(Level.FINEST, "Combined parent + template is {0}", combined);
+            return combined;
         }
     }
 

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
@@ -42,6 +42,7 @@ import org.junit.Test;
 
 import com.google.common.collect.ImmutableMap;
 
+import hudson.model.Node;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
@@ -202,6 +203,44 @@ public class PodTemplateUtilsTest {
         assertEquals(3, result.getImagePullSecrets().size());
         assertEquals("sa1", result.getServiceAccount());
         assertEquals("key:value", result.getNodeSelector());
+    }
+
+    @Test
+    public void shouldDropNoDataWhenIdentical() {
+        PodTemplate podTemplate = new PodTemplate();
+        podTemplate.setName("Name");
+        podTemplate.setNamespace("NameSpace");
+        podTemplate.setLabel("Label");
+        podTemplate.setServiceAccount("ServiceAccount");
+        podTemplate.setNodeSelector("NodeSelector");
+        podTemplate.setNodeUsageMode(Node.Mode.EXCLUSIVE);
+        podTemplate.setImagePullSecrets(asList(SECRET_1));
+        podTemplate.setInheritFrom("Inherit");
+        podTemplate.setInstanceCap(99);        
+        podTemplate.setSlaveConnectTimeout(99);
+        podTemplate.setIdleMinutes(99);
+        podTemplate.setActiveDeadlineSeconds(99);
+        podTemplate.setServiceAccount("ServiceAccount");
+        podTemplate.setCustomWorkspaceVolumeEnabled(true);
+        podTemplate.setYaml("Yaml");
+        
+        PodTemplate selfCombined = combine(podTemplate, podTemplate);
+
+        assertEquals("Name", podTemplate.getName());
+        assertEquals("NameSpace", podTemplate.getNamespace());
+        assertEquals("Label", podTemplate.getLabel());
+        assertEquals("ServiceAccount", podTemplate.getServiceAccount());
+        assertEquals("NodeSelector", podTemplate.getNodeSelector());
+        assertEquals(Node.Mode.EXCLUSIVE, podTemplate.getNodeUsageMode());
+        assertEquals(asList(SECRET_1), podTemplate.getImagePullSecrets());
+        assertEquals("Inherit", podTemplate.getInheritFrom());
+        assertEquals(99, podTemplate.getInstanceCap());        
+        assertEquals(99, podTemplate.getSlaveConnectTimeout());
+        assertEquals(99, podTemplate.getIdleMinutes());
+        assertEquals(99, podTemplate.getActiveDeadlineSeconds());
+        assertEquals("ServiceAccount", podTemplate.getServiceAccount());
+        assertEquals(true, podTemplate.isCustomWorkspaceVolumeEnabled());
+        assertEquals("Yaml", podTemplate.getYaml());
     }
 
     @Test


### PR DESCRIPTION
Really 3 things going on in this diff:
1) I found that setting idle timeout wasn't keeping slaves around - they'd get killed once each job finished. Tracking this down - it turned out combine ( PodTemplate, PodTemplate ) was creating a new object to copy data into but was copying an incomplete set of data in - dropping a number of fields. These are now copied in similar to the existing fields - preferring template over parent. 
2) Added some logging in combine for PodTemplate to mimic what already existed for combine for Pod. 
3) Added a simple unit test for the remaining non-deprecated fields on PodTemplate. 