### PR TITLE
[JENKINS-50664] added missing fixed jenkins slave labels

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -345,9 +345,10 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
 
     public Map<String, String> getLabelsMap() {
         Set<LabelAtom> labelSet = getLabelSet();
-        ImmutableMap.Builder<String, String> builder = ImmutableMap.<String, String> builder();
+        ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
         if (!labelSet.isEmpty()) {
             for (LabelAtom label : labelSet) {
+                builder.put("jenkins/slave", "true");
                 builder.put(label == null ? DEFAULT_ID : "jenkins/" + label.getName(), "true");
             }
         }


### PR DESCRIPTION
Regarding following issue https://issues.jenkins-ci.org/browse/JENKINS-50664

Jenkins slave pod doesn't have fixed label which can be used for generic NetworkPolicy to secure master-slave communication within Kubernetes namespace.

Example policy for JNLP access:
```
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: jenkins
  namespace: XXX
spec:
  podSelector:
    matchLabels:
      run: jenkins-master-XXX
  policyTypes:
  - Ingress
  ingress:
   - from:
    - podSelector:
        matchLabels:
          jenkins/slave: true
    ports:
    - protocol: TCP
      port: 50000
```

ofc it might be different label but should be present on every jenkins slave Pod.