### PR TITLE
transfer any master proxy related envs that the remoting jar uses to …

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -94,6 +94,7 @@ public class KubernetesCloud extends Cloud {
     private String serverCertificate;
 
     private boolean skipTlsVerify;
+    private boolean addMasterProxyEnvVars;
 
     private String namespace;
     private String jenkinsUrl;
@@ -129,6 +130,7 @@ public class KubernetesCloud extends Cloud {
         this.templates.addAll(source.templates);
         this.serverUrl = source.serverUrl;
         this.skipTlsVerify = source.skipTlsVerify;
+        this.addMasterProxyEnvVars = source.addMasterProxyEnvVars;
         this.namespace = source.namespace;
         this.jenkinsUrl = source.jenkinsUrl;
         this.jenkinsTunnel = source.jenkinsTunnel;
@@ -218,6 +220,15 @@ public class KubernetesCloud extends Cloud {
     @DataBoundSetter
     public void setSkipTlsVerify(boolean skipTlsVerify) {
         this.skipTlsVerify = skipTlsVerify;
+    }
+    
+    public boolean isAddMasterProxyEnvVars() {
+    	return this.addMasterProxyEnvVars;
+    }
+    
+    @DataBoundSetter
+    public void setAddMasterProxyEnvVars(boolean addMasterProxyEnvVars) {
+    	this.addMasterProxyEnvVars = addMasterProxyEnvVars;
     }
 
     @Nonnull

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -273,6 +273,25 @@ public class PodTemplateBuilder {
             if (!StringUtils.isBlank(cloud.getJenkinsTunnel())) {
                 env.put("JENKINS_TUNNEL", cloud.getJenkinsTunnel());
             }
+
+            if (slave.getKubernetesCloud().isAddMasterProxyEnvVars()) {
+                // see if the env vars for proxy that the remoting.jar looks for 
+                // are set on the master, and if so, propagate them to the slave
+                // vs. having to set on each pod template; if explicitly set already
+                // the processing of globalEnvVars below will override;
+                // see org.jenkinsci.remoting.engine.JnlpAgentEndpointResolver
+                String noProxy = System.getenv("no_proxy");
+                if (!StringUtils.isBlank(noProxy)) {
+                	env.put("no_proxy", noProxy);
+                }
+                String httpProxy = null;
+                if (System.getProperty("http.proxyHost") == null) {
+                    httpProxy = System.getenv("http_proxy");
+                }
+                if (!StringUtils.isBlank(httpProxy)) {
+                	env.put("http_proxy", httpProxy);
+                }
+            }
         }
 
         // Running on OpenShift Enterprise, security concerns force use of arbitrary user ID

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/config.jelly
@@ -55,6 +55,10 @@
       <f:entry title="${%Container Cleanup Timeout (minutes)}" field="retentionTimeout">
         <f:textbox default="5"/>
       </f:entry>
+
+      <f:entry title="${%Transfer proxy related environment variables from master to agent}" field="addMasterProxyEnvVars">
+        <f:checkbox />
+      </f:entry>
     </f:advanced>
 
     <f:entry title="${%Defaults Provider Template Name}" field="defaultsProviderTemplate">

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/help-addMasterProxyEnvVars.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/help-addMasterProxyEnvVars.html
@@ -1,0 +1,7 @@
+With this option enabled, if any of the HTTP proxy related environment variables 
+recognized by the Jenkins remoting component are set on the Jenkins Master, they 
+will be added to the environment variables of any Pod Template.
+<p>
+Any explicit setting of those variables in the environment variables section of 
+the Pod Template or Container Template will take precedence over any variables 
+set in Jenkins Master. 


### PR DESCRIPTION
…the pod templates

hey @carlossg - this PR as much is intending to initiate discussion; @bparees and I have had a recent customer situation where they are leverage jenkins on openshift with http_proxy and no_proxy employed

one of the customer's complaints was why could he not set the env's the remoting jar was looking for on the master and then have them propagated by default to each of his pod templates

as I mentioned in the TODO I can certainly add some level of on/off configuration switch if desired (preserving default behavior, etc.) but wanted to get some form of general consensus before investing addition time

thanks
