### PR TITLE
Add copy constructor for ContainerTemplate

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
@@ -79,6 +79,25 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
         this.args = args;
     }
 
+    public ContainerTemplate(ContainerTemplate from) {
+        this.setName(from.getName());
+        this.setImage(from.getImage());
+        this.setPrivileged(from.isPrivileged());
+        this.setAlwaysPullImage(from.isAlwaysPullImage());
+        this.setWorkingDir(from.getWorkingDir());
+        this.setCommand(from.getCommand());
+        this.setArgs(from.getArgs());
+        this.setTtyEnabled(from.isTtyEnabled());
+        this.setResourceRequestCpu(from.getResourceRequestCpu());
+        this.setResourceRequestMemory(from.getResourceRequestMemory());
+        this.setResourceLimitCpu(from.getResourceLimitCpu());
+        this.setResourceLimitMemory(from.getResourceLimitMemory());
+        this.setShell(from.getShell());
+        this.setEnvVars(from.getEnvVars());
+        this.setPorts(from.getPorts());
+        this.setLivenessProbe(from.getLivenessProbe());
+    }
+
     @DataBoundSetter
     public void setName(String name) {
         this.name = name;
@@ -264,6 +283,86 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
                 (ports == null || ports.isEmpty() ? "" : ", ports=" + ports) +
                 (livenessProbe == null ? "" : ", livenessProbe=" + livenessProbe) +
                 '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ContainerTemplate that = (ContainerTemplate) o;
+
+        if (privileged != that.privileged) {
+            return false;
+        }
+        if (alwaysPullImage != that.alwaysPullImage) {
+            return false;
+        }
+        if (ttyEnabled != that.ttyEnabled) {
+            return false;
+        }
+        if (name != null ? !name.equals(that.name) : that.name != null) {
+            return false;
+        }
+        if (image != null ? !image.equals(that.image) : that.image != null) {
+            return false;
+        }
+        if (workingDir != null ? !workingDir.equals(that.workingDir) : that.workingDir != null) {
+            return false;
+        }
+        if (command != null ? !command.equals(that.command) : that.command != null) {
+            return false;
+        }
+        if (args != null ? !args.equals(that.args) : that.args != null) {
+            return false;
+        }
+        if (resourceRequestCpu != null ? !resourceRequestCpu.equals(that.resourceRequestCpu) : that.resourceRequestCpu != null) {
+            return false;
+        }
+        if (resourceRequestMemory != null ? !resourceRequestMemory.equals(that.resourceRequestMemory) : that.resourceRequestMemory != null) {
+            return false;
+        }
+        if (resourceLimitCpu != null ? !resourceLimitCpu.equals(that.resourceLimitCpu) : that.resourceLimitCpu != null) {
+            return false;
+        }
+        if (resourceLimitMemory != null ? !resourceLimitMemory.equals(that.resourceLimitMemory) : that.resourceLimitMemory != null) {
+            return false;
+        }
+        if (shell != null ? !shell.equals(that.shell) : that.shell != null) {
+            return false;
+        }
+        if (envVars != null ? !envVars.equals(that.envVars) : that.envVars != null) {
+            return false;
+        }
+        if (ports != null ? !ports.equals(that.ports) : that.ports != null) {
+            return false;
+        }
+        return livenessProbe != null ? livenessProbe.equals(that.livenessProbe) : that.livenessProbe == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name != null ? name.hashCode() : 0;
+        result = 31 * result + (image != null ? image.hashCode() : 0);
+        result = 31 * result + (privileged ? 1 : 0);
+        result = 31 * result + (alwaysPullImage ? 1 : 0);
+        result = 31 * result + (workingDir != null ? workingDir.hashCode() : 0);
+        result = 31 * result + (command != null ? command.hashCode() : 0);
+        result = 31 * result + (args != null ? args.hashCode() : 0);
+        result = 31 * result + (ttyEnabled ? 1 : 0);
+        result = 31 * result + (resourceRequestCpu != null ? resourceRequestCpu.hashCode() : 0);
+        result = 31 * result + (resourceRequestMemory != null ? resourceRequestMemory.hashCode() : 0);
+        result = 31 * result + (resourceLimitCpu != null ? resourceLimitCpu.hashCode() : 0);
+        result = 31 * result + (resourceLimitMemory != null ? resourceLimitMemory.hashCode() : 0);
+        result = 31 * result + (shell != null ? shell.hashCode() : 0);
+        result = 31 * result + (envVars != null ? envVars.hashCode() : 0);
+        result = 31 * result + (ports != null ? ports.hashCode() : 0);
+        result = 31 * result + (livenessProbe != null ? livenessProbe.hashCode() : 0);
+        return result;
     }
 
     public String getShell() {

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplateTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplateTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ContainerTemplateTest {
+
+    @Test
+    public void testCopyConstructorCreatesEqualInstance() {
+        ContainerTemplate originalTemplate = new ContainerTemplate("myname", "myimage");
+        originalTemplate.setPrivileged(true);
+        originalTemplate.setAlwaysPullImage(true);
+        originalTemplate.setWorkingDir("some/bogus/dir");
+        originalTemplate.setCommand("run this");
+        originalTemplate.setArgs("args");
+        originalTemplate.setTtyEnabled(true);
+        originalTemplate.setResourceRequestCpu("200m");
+        originalTemplate.setResourceRequestMemory("2GiB");
+        originalTemplate.setResourceLimitCpu("1000m");
+        originalTemplate.setResourceLimitMemory("4GiB");
+        originalTemplate.setShell("zsh");
+        originalTemplate.setEnvVars(Collections.emptyList());
+        originalTemplate.setPorts(Collections.emptyList());
+        originalTemplate.setLivenessProbe(new ContainerLivenessProbe("test", 1, 2, 3, 4, 5));
+
+        ContainerTemplate clonedTemplate = new ContainerTemplate(originalTemplate);
+
+        Assert.assertEquals("Cloned ContainerTemplate is not equal to the original one!", originalTemplate, clonedTemplate);
+        Assert.assertEquals("String representation (toString()) of the cloned and original ContainerTemplate is not equal!",
+                originalTemplate.toString(), clonedTemplate.toString());
+    }
+
+}


### PR DESCRIPTION
The copy constructor is very useful when creating a new template based
on an existing one. The new container usually needs some config changes
without affecting the original container.