### PR TITLE
[JENKINS-50664] container cap limit hit due to default labels missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Known issues
 
 See the full list of issues at [JIRA](https://issues.jenkins-ci.org/issues/?filter=15575)
 
+1.6.1
+-----
+* Some fields are not inherited from parent template (InheritFrom, InstanceCap, SlaveConnectTimeout, IdleMinutes, ActiveDeadlineSeconds, ServiceAccount, CustomWorkspaceVolumeEnabled) [#319](https://github.com/jenkinsci/kubernetes-plugin/pull/319)
+
 1.6.0
 -----
 * Support multiple containers in declarative pipeline [#306](https://github.com/jenkinsci/kubernetes-plugin/pull/306) [JENKINS-48135](https://issues.jenkins-ci.org/browse/JENKINS-48135)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Known issues
 
 See the full list of issues at [JIRA](https://issues.jenkins-ci.org/issues/?filter=15575)
 
+1.6.2
+-----
+* Transfer any master proxy related envs that the remoting jar uses to the pod templates with `addMasterProxyEnvVars` option [#321](https://github.com/jenkinsci/kubernetes-plugin/pull/321)
+
 1.6.1
 -----
 * Some fields are not inherited from parent template (InheritFrom, InstanceCap, SlaveConnectTimeout, IdleMinutes, ActiveDeadlineSeconds, ServiceAccount, CustomWorkspaceVolumeEnabled) [#319](https://github.com/jenkinsci/kubernetes-plugin/pull/319)

--- a/examples/kaniko.groovy
+++ b/examples/kaniko.groovy
@@ -1,0 +1,43 @@
+/**
+ * This pipeline will build and deploy a Docker image with Kaniko
+ * https://github.com/GoogleContainerTools/kaniko
+ * without needing a Docker host
+ *
+ * You need to create a jenkins-docker-cfg secret with your docker config
+ * as described in
+ * https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-secret-in-the-cluster-that-holds-your-authorization-token
+ */
+
+ def label = "kaniko-${UUID.randomUUID().toString()}"
+
+ podTemplate(name: 'kaniko', label: label, yaml: """
+ kind: Pod
+ metadata:
+   name: kaniko
+ spec:
+   containers:
+   - name: kaniko
+     image: csanchez/kaniko:jenkins # we need a patched version of kaniko for now
+     imagePullPolicy: Always
+     command:
+     - cat
+     tty: true
+     volumeMounts:
+       - name: jenkins-docker-cfg
+         mountPath: /root
+   volumes:
+     - name: jenkins-docker-cfg
+       secret:
+         secretName: regcred
+ """
+   ) {
+
+   node(label) {
+     stage('Build with Kaniko') {
+       git 'https://github.com/jenkinsci/docker-jnlp-slave.git'
+       container('kaniko') {
+           sh '/kaniko/executor -c . --insecure-skip-tls-verify --destination=mydockerregistry:5000/myorg/myimage'
+       }
+     }
+   }
+ }

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>org.csanchez.jenkins.plugins</groupId>
   <artifactId>kubernetes</artifactId>
-  <version>1.6.1</version>
+  <version>1.6.2-SNAPSHOT</version>
   <name>Kubernetes plugin</name>
   <description>Jenkins plugin to run dynamic agents in a Kubernetes cluster</description>
   <packaging>hpi</packaging>
@@ -18,7 +18,7 @@
     <connection>scm:git:ssh://git@github.com/jenkinsci/kubernetes-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/kubernetes-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/kubernetes-plugin</url>
-    <tag>kubernetes-1.6.1</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>org.csanchez.jenkins.plugins</groupId>
   <artifactId>kubernetes</artifactId>
-  <version>1.6.2</version>
+  <version>1.6.3-SNAPSHOT</version>
   <name>Kubernetes plugin</name>
   <description>Jenkins plugin to run dynamic agents in a Kubernetes cluster</description>
   <packaging>hpi</packaging>
@@ -18,7 +18,7 @@
     <connection>scm:git:ssh://git@github.com/jenkinsci/kubernetes-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/kubernetes-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/kubernetes-plugin</url>
-    <tag>kubernetes-1.6.2</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>org.csanchez.jenkins.plugins</groupId>
   <artifactId>kubernetes</artifactId>
-  <version>1.6.1-SNAPSHOT</version>
+  <version>1.6.1</version>
   <name>Kubernetes plugin</name>
   <description>Jenkins plugin to run dynamic agents in a Kubernetes cluster</description>
   <packaging>hpi</packaging>
@@ -18,7 +18,7 @@
     <connection>scm:git:ssh://git@github.com/jenkinsci/kubernetes-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/kubernetes-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/kubernetes-plugin</url>
-    <tag>HEAD</tag>
+    <tag>kubernetes-1.6.1</tag>
   </scm>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>org.csanchez.jenkins.plugins</groupId>
   <artifactId>kubernetes</artifactId>
-  <version>1.6.2-SNAPSHOT</version>
+  <version>1.6.2</version>
   <name>Kubernetes plugin</name>
   <description>Jenkins plugin to run dynamic agents in a Kubernetes cluster</description>
   <packaging>hpi</packaging>
@@ -18,7 +18,7 @@
     <connection>scm:git:ssh://git@github.com/jenkinsci/kubernetes-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/kubernetes-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/kubernetes-plugin</url>
-    <tag>HEAD</tag>
+    <tag>kubernetes-1.6.2</tag>
   </scm>
 
   <licenses>

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -78,8 +78,8 @@ public class KubernetesCloud extends Cloud {
     private static final Logger LOGGER = Logger.getLogger(KubernetesCloud.class.getName());
 
     public static final String JNLP_NAME = "jnlp";
+
     /** label for all pods started by the plugin */
-    @Deprecated
     public static final Map<String, String> DEFAULT_POD_LABELS = ImmutableMap.of("jenkins", "slave");
 
     /** Default timeout for idle workers that don't correctly indicate exit. */
@@ -325,7 +325,7 @@ public class KubernetesCloud extends Cloud {
      * Labels for all pods started by the plugin
      */
     public Map<String, String> getLabels() {
-        return labels == null ? Collections.emptyMap() : labels;
+        return (labels == null || labels.isEmpty()) ? DEFAULT_POD_LABELS : labels;
     }
 
     public void setLabels(Map<String, String> labels) {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -94,6 +94,7 @@ public class KubernetesCloud extends Cloud {
     private String serverCertificate;
 
     private boolean skipTlsVerify;
+    private boolean addMasterProxyEnvVars;
 
     private String namespace;
     private String jenkinsUrl;
@@ -129,6 +130,7 @@ public class KubernetesCloud extends Cloud {
         this.templates.addAll(source.templates);
         this.serverUrl = source.serverUrl;
         this.skipTlsVerify = source.skipTlsVerify;
+        this.addMasterProxyEnvVars = source.addMasterProxyEnvVars;
         this.namespace = source.namespace;
         this.jenkinsUrl = source.jenkinsUrl;
         this.jenkinsTunnel = source.jenkinsTunnel;
@@ -218,6 +220,15 @@ public class KubernetesCloud extends Cloud {
     @DataBoundSetter
     public void setSkipTlsVerify(boolean skipTlsVerify) {
         this.skipTlsVerify = skipTlsVerify;
+    }
+    
+    public boolean isAddMasterProxyEnvVars() {
+    	return this.addMasterProxyEnvVars;
+    }
+    
+    @DataBoundSetter
+    public void setAddMasterProxyEnvVars(boolean addMasterProxyEnvVars) {
+    	this.addMasterProxyEnvVars = addMasterProxyEnvVars;
     }
 
     @Nonnull

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -351,6 +351,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
                 builder.put(label == null ? DEFAULT_ID : "jenkins/" + label.getName(), "true");
             }
         }
+        builder.putAll(KubernetesCloud.DEFAULT_POD_LABELS);
         return builder.build();
     }
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -273,6 +273,25 @@ public class PodTemplateBuilder {
             if (!StringUtils.isBlank(cloud.getJenkinsTunnel())) {
                 env.put("JENKINS_TUNNEL", cloud.getJenkinsTunnel());
             }
+
+            if (slave.getKubernetesCloud().isAddMasterProxyEnvVars()) {
+                // see if the env vars for proxy that the remoting.jar looks for 
+                // are set on the master, and if so, propagate them to the slave
+                // vs. having to set on each pod template; if explicitly set already
+                // the processing of globalEnvVars below will override;
+                // see org.jenkinsci.remoting.engine.JnlpAgentEndpointResolver
+                String noProxy = System.getenv("no_proxy");
+                if (!StringUtils.isBlank(noProxy)) {
+                	env.put("no_proxy", noProxy);
+                }
+                String httpProxy = null;
+                if (System.getProperty("http.proxyHost") == null) {
+                    httpProxy = System.getenv("http_proxy");
+                }
+                if (!StringUtils.isBlank(httpProxy)) {
+                	env.put("http_proxy", httpProxy);
+                }
+            }
         }
 
         // Running on OpenShift Enterprise, security concerns force use of arbitrary user ID

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
@@ -187,6 +187,9 @@ public class PodTemplateUtils {
         Map<String, String> podAnnotations = mergeMaps(parent.getMetadata().getAnnotations(),
                 template.getMetadata().getAnnotations());
 
+        Map<String, String> podLabels = mergeMaps(parent.getMetadata().getLabels(),
+                template.getMetadata().getLabels());
+
         Set<LocalObjectReference> imagePullSecrets = new LinkedHashSet<>();
         imagePullSecrets.addAll(parent.getSpec().getImagePullSecrets());
         imagePullSecrets.addAll(template.getSpec().getImagePullSecrets());
@@ -217,7 +220,9 @@ public class PodTemplateUtils {
 //        toolLocationNodeProperties.addAll(template.getNodeProperties());
 
         MetadataNested<PodBuilder> metadataBuilder = new PodBuilder().withNewMetadataLike(parent.getMetadata()) //
-                .withAnnotations(podAnnotations);
+                .withAnnotations(podAnnotations)
+                .withLabels(podLabels);
+
         if (!Strings.isNullOrEmpty(template.getMetadata().getName())) {
             metadataBuilder.withName(template.getMetadata().getName());
         }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
@@ -263,6 +263,9 @@ public class PodTemplateUtils {
             return template;
         }
 
+        LOGGER.log(Level.FINEST, "Combining pod templates, parent: {0}", parent);
+        LOGGER.log(Level.FINEST, "Combining pod templates, template: {0}", template);
+
         String name = template.getName();
         String label = template.getLabel();
         String nodeSelector = Strings.isNullOrEmpty(template.getNodeSelector()) ? parent.getNodeSelector() : template.getNodeSelector();
@@ -311,8 +314,31 @@ public class PodTemplateUtils {
         podTemplate.setAnnotations(new ArrayList<>(podAnnotations));
         podTemplate.setNodeProperties(toolLocationNodeProperties);
         podTemplate.setNodeUsageMode(nodeUsageMode);
+        podTemplate.setInheritFrom(!Strings.isNullOrEmpty(template.getInheritFrom()) ? 
+                                   template.getInheritFrom() : parent.getInheritFrom());
+        
+        podTemplate.setInstanceCap(template.getInstanceCap() != Integer.MAX_VALUE ? 
+                                   template.getInstanceCap() : parent.getInstanceCap());
+        
+        podTemplate.setSlaveConnectTimeout(template.getSlaveConnectTimeout() != PodTemplate.DEFAULT_SLAVE_JENKINS_CONNECTION_TIMEOUT ? 
+                                           template.getSlaveConnectTimeout() : parent.getSlaveConnectTimeout());
+
+        podTemplate.setIdleMinutes(template.getIdleMinutes() != 0 ? 
+                                   template.getIdleMinutes() : parent.getIdleMinutes()); 
+
+        podTemplate.setActiveDeadlineSeconds(template.getActiveDeadlineSeconds() != 0 ?
+                                             template.getActiveDeadlineSeconds() : parent.getActiveDeadlineSeconds()); 
+
+            
+        podTemplate.setServiceAccount(!Strings.isNullOrEmpty(template.getServiceAccount()) ? 
+                                      template.getServiceAccount() : parent.getServiceAccount());
+
+        podTemplate.setCustomWorkspaceVolumeEnabled(template.isCustomWorkspaceVolumeEnabled() ? 
+                                                    template.isCustomWorkspaceVolumeEnabled() : parent.isCustomWorkspaceVolumeEnabled());
+
         podTemplate.setYaml(template.getYaml() == null ? parent.getYaml() : template.getYaml());
 
+        LOGGER.log(Level.FINEST, "Pod templates combined: {0}", podTemplate);
         return podTemplate;
     }
 
@@ -350,7 +376,9 @@ public class PodTemplateUtils {
                     parent = combine(parent, unwrap(next, allTemplates));
                 }
             }
-            return combine(parent, template);
+            PodTemplate combined = combine(parent, template);
+            LOGGER.log(Level.FINEST, "Combined parent + template is {0}", combined);
+            return combined;
         }
     }
 

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/config.jelly
@@ -55,6 +55,10 @@
       <f:entry title="${%Container Cleanup Timeout (minutes)}" field="retentionTimeout">
         <f:textbox default="5"/>
       </f:entry>
+
+      <f:entry title="${%Transfer proxy related environment variables from master to agent}" field="addMasterProxyEnvVars">
+        <f:checkbox />
+      </f:entry>
     </f:advanced>
 
     <f:entry title="${%Defaults Provider Template Name}" field="defaultsProviderTemplate">

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/help-addMasterProxyEnvVars.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/help-addMasterProxyEnvVars.html
@@ -1,0 +1,7 @@
+With this option enabled, if any of the HTTP proxy related environment variables 
+recognized by the Jenkins remoting component are set on the Jenkins Master, they 
+will be added to the environment variables of any Pod Template.
+<p>
+Any explicit setting of those variables in the environment variables section of 
+the Pod Template or Container Template will take precedence over any variables 
+set in Jenkins Master. 

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
@@ -60,10 +60,14 @@
     <f:textbox/>
   </f:entry>
 
-    <f:entry title="${%Annotations}" description="${%List of annotations to set in slave pod}" field="annotations">
-      <f:repeatableHeteroProperty field="annotations" hasHeader="true" addCaption="Add Annotation"
-                                  deleteCaption="Delete annotation Variable" />
-    </f:entry>
+  <f:entry title="${%Annotations}" description="${%List of annotations to set in slave pod}" field="annotations">
+    <f:repeatableHeteroProperty field="annotations" hasHeader="true" addCaption="Add Annotation"
+                                deleteCaption="Delete annotation Variable" />
+  </f:entry>
+
+  <f:entry field="yaml" title="${%Raw yaml for the Pod}">
+    <f:textarea/>
+  </f:entry>
 
   <f:advanced>
 
@@ -74,14 +78,12 @@
 
     <f:entry field="serviceAccount" title="${%Service Account}">
           <f:textbox/>
-     </f:entry>
-
+    </f:entry>
 
     <f:entry field="nodeSelector" title="${%Node Selector}">
       <f:textbox/>
     </f:entry>
 
-    <f:descriptorList title="${%Node Properties}" descriptors="${h.getNodePropertyDescriptors(descriptor.clazz)}" field="nodeProperties" />
     <f:block>
       <table>
         <f:optionalBlock title="${%Use custom workspace volume}" field="customWorkspaceVolumeEnabled" inline="true">
@@ -92,10 +94,9 @@
         </f:optionalBlock>
       </table>
     </f:block>
-  </f:advanced>
 
-  <f:entry field="yaml" title="${%Raw yaml for the Pod}">
-    <f:textarea/>
-  </f:entry>
+    <f:descriptorList title="${%Node Properties}" descriptors="${h.getNodePropertyDescriptors(descriptor.clazz)}" field="nodeProperties" />
+
+  </f:advanced>
 
 </j:jelly>

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudTest.java
@@ -2,6 +2,7 @@ package org.csanchez.jenkins.plugins.kubernetes;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Map;
 
 import jenkins.model.JenkinsLocationConfiguration;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.EmptyDirVolume;
@@ -12,6 +13,7 @@ import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
 public class KubernetesCloudTest {
@@ -76,5 +78,17 @@ public class KubernetesCloudTest {
         assertEquals("http://mylocation/", cloud.getJenkinsUrlOrDie());
     }
 
+    @Test
+    public void has_default_labels_for_slave_pods() {
+        // GIVEN
+        KubernetesCloud cloud = new KubernetesCloud("name");
+
+        // WHEN
+        Map<String, String> defaultLabels = cloud.getLabels();
+
+        // THEN
+        assertNotNull(defaultLabels);
+        assertNotNull(defaultLabels.get("jenkins"));
+    }
 
 }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
@@ -21,7 +21,6 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 
 import io.fabric8.kubernetes.api.model.Container;
@@ -100,7 +99,9 @@ public class PodTemplateBuilderTest {
     }
 
     private void validatePod(Pod pod) {
-        assertEquals(ImmutableMap.of("some-label", "some-label-value"), pod.getMetadata().getLabels());
+        assertThat(pod.getMetadata().getLabels(), hasEntry("some-label", "some-label-value"));
+        assertThat(pod.getMetadata().getLabels(), hasEntry("jenkins", "slave"));
+
 
         // check containers
         Map<String, Container> containers = pod.getSpec().getContainers().stream()

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
@@ -42,6 +42,7 @@ import org.junit.Test;
 
 import com.google.common.collect.ImmutableMap;
 
+import hudson.model.Node;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
@@ -202,6 +203,44 @@ public class PodTemplateUtilsTest {
         assertEquals(3, result.getImagePullSecrets().size());
         assertEquals("sa1", result.getServiceAccount());
         assertEquals("key:value", result.getNodeSelector());
+    }
+
+    @Test
+    public void shouldDropNoDataWhenIdentical() {
+        PodTemplate podTemplate = new PodTemplate();
+        podTemplate.setName("Name");
+        podTemplate.setNamespace("NameSpace");
+        podTemplate.setLabel("Label");
+        podTemplate.setServiceAccount("ServiceAccount");
+        podTemplate.setNodeSelector("NodeSelector");
+        podTemplate.setNodeUsageMode(Node.Mode.EXCLUSIVE);
+        podTemplate.setImagePullSecrets(asList(SECRET_1));
+        podTemplate.setInheritFrom("Inherit");
+        podTemplate.setInstanceCap(99);        
+        podTemplate.setSlaveConnectTimeout(99);
+        podTemplate.setIdleMinutes(99);
+        podTemplate.setActiveDeadlineSeconds(99);
+        podTemplate.setServiceAccount("ServiceAccount");
+        podTemplate.setCustomWorkspaceVolumeEnabled(true);
+        podTemplate.setYaml("Yaml");
+        
+        PodTemplate selfCombined = combine(podTemplate, podTemplate);
+
+        assertEquals("Name", podTemplate.getName());
+        assertEquals("NameSpace", podTemplate.getNamespace());
+        assertEquals("Label", podTemplate.getLabel());
+        assertEquals("ServiceAccount", podTemplate.getServiceAccount());
+        assertEquals("NodeSelector", podTemplate.getNodeSelector());
+        assertEquals(Node.Mode.EXCLUSIVE, podTemplate.getNodeUsageMode());
+        assertEquals(asList(SECRET_1), podTemplate.getImagePullSecrets());
+        assertEquals("Inherit", podTemplate.getInheritFrom());
+        assertEquals(99, podTemplate.getInstanceCap());        
+        assertEquals(99, podTemplate.getSlaveConnectTimeout());
+        assertEquals(99, podTemplate.getIdleMinutes());
+        assertEquals(99, podTemplate.getActiveDeadlineSeconds());
+        assertEquals("ServiceAccount", podTemplate.getServiceAccount());
+        assertEquals(true, podTemplate.isCustomWorkspaceVolumeEnabled());
+        assertEquals("Yaml", podTemplate.getYaml());
     }
 
     @Test


### PR DESCRIPTION
Issue : Setting container cap limit configuration doesn't work correctly without Jenkins restart. The root cause of the issue is label management for slave pods. Once user set the container cap limit configuration for given namespace. Plugin fails to account slave pods/containers based using pods labels. It accounts for all pods/containers from the namespace which are not started by the Kubernetes plugin.
This patch fixes this issue using default slave labels "Jenkins"->"slave"
1) By adding default slave labels to pods/containers
2) By quering pods/containers with default slave labels

Fixes https://issues.jenkins-ci.org/browse/JENKINS-51286