### PR TITLE
Fix for [JENKINS-50664] container cap limit hit due to default labels

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -78,8 +78,8 @@ public class KubernetesCloud extends Cloud {
     private static final Logger LOGGER = Logger.getLogger(KubernetesCloud.class.getName());
 
     public static final String JNLP_NAME = "jnlp";
+
     /** label for all pods started by the plugin */
-    @Deprecated
     public static final Map<String, String> DEFAULT_POD_LABELS = ImmutableMap.of("jenkins", "slave");
 
     /** Default timeout for idle workers that don't correctly indicate exit. */
@@ -325,7 +325,7 @@ public class KubernetesCloud extends Cloud {
      * Labels for all pods started by the plugin
      */
     public Map<String, String> getLabels() {
-        return labels == null ? Collections.emptyMap() : labels;
+        return (labels == null || labels.isEmpty()) ? DEFAULT_POD_LABELS : labels;
     }
 
     public void setLabels(Map<String, String> labels) {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -351,6 +351,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
                 builder.put(label == null ? DEFAULT_ID : "jenkins/" + label.getName(), "true");
             }
         }
+        builder.putAll(KubernetesCloud.DEFAULT_POD_LABELS);
         return builder.build();
     }
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
@@ -187,6 +187,9 @@ public class PodTemplateUtils {
         Map<String, String> podAnnotations = mergeMaps(parent.getMetadata().getAnnotations(),
                 template.getMetadata().getAnnotations());
 
+        Map<String, String> podLabels = mergeMaps(parent.getMetadata().getLabels(),
+                template.getMetadata().getLabels());
+
         Set<LocalObjectReference> imagePullSecrets = new LinkedHashSet<>();
         imagePullSecrets.addAll(parent.getSpec().getImagePullSecrets());
         imagePullSecrets.addAll(template.getSpec().getImagePullSecrets());
@@ -217,7 +220,9 @@ public class PodTemplateUtils {
 //        toolLocationNodeProperties.addAll(template.getNodeProperties());
 
         MetadataNested<PodBuilder> metadataBuilder = new PodBuilder().withNewMetadataLike(parent.getMetadata()) //
-                .withAnnotations(podAnnotations);
+                .withAnnotations(podAnnotations)
+                .withLabels(podLabels);
+
         if (!Strings.isNullOrEmpty(template.getMetadata().getName())) {
             metadataBuilder.withName(template.getMetadata().getName());
         }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudTest.java
@@ -2,6 +2,7 @@ package org.csanchez.jenkins.plugins.kubernetes;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Map;
 
 import jenkins.model.JenkinsLocationConfiguration;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.EmptyDirVolume;
@@ -12,6 +13,7 @@ import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
 public class KubernetesCloudTest {
@@ -76,5 +78,17 @@ public class KubernetesCloudTest {
         assertEquals("http://mylocation/", cloud.getJenkinsUrlOrDie());
     }
 
+    @Test
+    public void has_default_labels_for_slave_pods() {
+        // GIVEN
+        KubernetesCloud cloud = new KubernetesCloud("name");
+
+        // WHEN
+        Map<String, String> defaultLabels = cloud.getLabels();
+
+        // THEN
+        assertNotNull(defaultLabels);
+        assertNotNull(defaultLabels.get("jenkins"));
+    }
 
 }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
@@ -21,7 +21,6 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 
 import io.fabric8.kubernetes.api.model.Container;
@@ -100,7 +99,9 @@ public class PodTemplateBuilderTest {
     }
 
     private void validatePod(Pod pod) {
-        assertEquals(ImmutableMap.of("some-label", "some-label-value"), pod.getMetadata().getLabels());
+        assertThat(pod.getMetadata().getLabels(), hasEntry("some-label", "some-label-value"));
+        assertThat(pod.getMetadata().getLabels(), hasEntry("jenkins", "slave"));
+
 
         // check containers
         Map<String, Container> containers = pod.getSpec().getContainers().stream()


### PR DESCRIPTION
Issue: Setting container cap limit configuration doesn't work correctly without Jenkins restart. The root cause of the issue is label management for slave pods. Once user set the container cap limit configuration for given namespace. Plugin fails to account slave pods/containers based using pods labels. It accounts all pods/containers from the namespace which are not started by the Kubernetes plugin.
This patch fixes this issue using default slave labels "jenkins"->"slave"
1) By adding defualt slave lables to pods/containers
2) By quering pods/containers with default slave labels

- added default lables to PodTemplate
- fixed getLables for querying container cap in KubernetesCloud
- updated test cases for PodtemplateBuilder

Fixes https://issues.jenkins-ci.org/browse/JENKINS-51286