### PR TITLE
[JENKINS-51582] - Use Jackson and Apache HttpComponents Client libraries from API plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,8 +44,6 @@
     <java.level>8</java.level>
 
     <!-- dependency versions -->
-    <httpclient.version>4.5.1</httpclient.version>
-    <jackson.version>2.5.0</jackson.version>
     <jenkins.version>2.32.1</jenkins.version>
 
     <kubernetes-client.version>3.1.10</kubernetes-client.version>
@@ -74,15 +72,30 @@
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-client</artifactId>
       <version>${kubernetes-client.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <version>${httpclient.version}</version>
+      <exclusions>
+        <!-- Jackson logic comes from plugins -->
+        <exclusion>
+          <artifactId>com.fasterxml.jackson.core</artifactId>
+          <groupId>jackson-core</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>com.fasterxml.jackson.core</artifactId>
+          <groupId>jackson-databind</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- required plugins -->
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>jackson2-api</artifactId>
+      <version>2.7.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>apache-httpcomponents-client-4-api</artifactId>
+      <version>4.5.3-2.0</version>
+    </dependency>
     <dependency>
       <groupId>org.jenkinsci.plugins</groupId>
       <artifactId>kubernetes-credentials</artifactId>


### PR DESCRIPTION
JCasC Plugin CI is now failing due to the upper bounds checks on libraries.
I propose to switch K8s plugin to use API Plugins instead of directly bundled libs.

CC @ewelinawilkosz @ndeloof @carlossg 

@reviewbybees 
