### PR TITLE
Combine all resources declared in requests and limits not just CPU and memory

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -21,6 +22,7 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -134,12 +136,8 @@ public class PodTemplateUtils {
         List<String> command = template.getCommand() == null ? parent.getCommand() : template.getCommand();
         List<String> args = template.getArgs() == null ? parent.getArgs() : template.getArgs();
         Boolean tty = template.getTty() != null ? template.getTty() : parent.getTty();
-        Map<String, Quantity> requests = new HashMap<>();
-        safeGet(parent, template, ResourceRequirements::getRequests, "cpu", requests);
-        safeGet(parent, template, ResourceRequirements::getRequests, "memory", requests);
-        Map<String, Quantity> limits = new HashMap<>();
-        safeGet(parent, template, ResourceRequirements::getLimits, "cpu", limits);
-        safeGet(parent, template, ResourceRequirements::getLimits, "memory", limits);
+        Map<String, Quantity> requests = combineResources(parent, template, ResourceRequirements::getRequests);
+        Map<String, Quantity> limits = combineResources(parent, template, ResourceRequirements::getLimits);
         
         Map<String, VolumeMount> volumeMounts = parent.getVolumeMounts().stream()
                 .collect(Collectors.toMap(VolumeMount::getMountPath, Function.identity()));
@@ -166,22 +164,17 @@ public class PodTemplateUtils {
         return combined;
     }
 
-    private static void safeGet(Container parent, Container template,
-                                Function<ResourceRequirements, Map<String, Quantity>> resourceTypeMapper,
-                                String field, Map<String, Quantity> out) {
-        Quantity data;
-        data = Optional.ofNullable(template.getResources())
-                .map(resourceTypeMapper)
-                .map(rT -> rT.get(field))
-                .filter(tF -> !Strings.isNullOrEmpty(tF.getAmount()))
-                .orElse(Optional.ofNullable(parent.getResources())
-                        .map(resourceTypeMapper)
-                        .map(rT -> rT.get(field))
-                        .orElse(null)
+    private static Map<String, Quantity> combineResources(Container parent, Container template,
+                                                          Function<ResourceRequirements,
+                                                                   Map<String, Quantity>> resourceTypeMapper) {
+        return Stream.of(template.getResources(), parent.getResources()) //
+                .filter(Objects::nonNull) //
+                .map(resourceTypeMapper) //
+                .filter(Objects::nonNull) //
+                .map(Map::entrySet) //
+                .flatMap(Collection::stream) //
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (v1, v2) -> v1) // v2 (parent) loses
                 );
-        if (data != null) {
-            out.put(field, data);
-        }   
     }
 
     /**

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
@@ -94,6 +94,17 @@ public class PodTemplateBuilderTest {
         Pod pod = new PodTemplateBuilder(template).withSlave(slave).build();
         validatePod(pod);
         assertThat(pod.getMetadata().getLabels(), hasEntry("jenkins", "slave"));
+
+        Map<String, Container> containers = pod.getSpec().getContainers().stream()
+                .collect(Collectors.toMap(Container::getName, Function.identity()));
+        assertEquals(2, containers.size());
+
+        Container container0 = containers.get("busybox");
+        assertNotNull(container0.getResources());
+        assertNotNull(container0.getResources().getRequests());
+        assertNotNull(container0.getResources().getLimits());
+        assertThat(container0.getResources().getRequests(), hasEntry("example.com/dongle", new Quantity("42")));
+        assertThat(container0.getResources().getLimits(), hasEntry("example.com/dongle", new Quantity("42")));
     }
 
     @Test

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pod-busybox.yaml
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pod-busybox.yaml
@@ -28,6 +28,11 @@ spec:
   containers:
   - name: busybox
     image: busybox
+    resources:
+      requests:
+        example.com/dongle: 42
+      limits:
+        example.com/dongle: 42
     command:
     - cat
     tty: true


### PR DESCRIPTION
Combine all resources declared in `requests` and `limits`, not just the currently hardcoded CPU and memory. This allows users to declare other resources such as GPUs in their YAML fragments. The pipeline API itself still only allows CPU and memory to be changed.