### PR TITLE
[JENKINS-44285] Tool Location overwrites are not preserved

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>org.csanchez.jenkins.plugins</groupId>
   <artifactId>kubernetes</artifactId>
-  <version>1.5.2</version>
+  <version>1.5.3-SNAPSHOT</version>
   <name>Kubernetes plugin</name>
   <description>Jenkins plugin to run dynamic agents in a Kubernetes cluster</description>
   <packaging>hpi</packaging>
@@ -18,7 +18,7 @@
     <connection>scm:git:ssh://git@github.com/jenkinsci/kubernetes-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/kubernetes-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/kubernetes-plugin</url>
-    <tag>kubernetes-1.5.2</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <licenses>

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -468,7 +468,7 @@ public class KubernetesCloud extends Cloud {
      * @param podTemplate the pod template to unwrap.
      * @return the unwrapped pod template
      */
-    public PodTemplate getUnwrappedTemplate(PodTemplate podTemplate) {
+    public PodTemplate getUnwrappedTemplate(PodTemplate podTemplate) throws IOException {
         return PodTemplateUtils.unwrap(podTemplate, getDefaultsProviderTemplate(), getAllTemplates());
     }
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -4,6 +4,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -110,7 +111,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
 
     private List<PodImagePullSecret> imagePullSecrets = new ArrayList<PodImagePullSecret>();
 
-    private transient List<ToolLocationNodeProperty> nodeProperties;
+    private List<ToolLocationNodeProperty> nodeProperties = new ArrayList<>();
 
     private String yaml;
 
@@ -135,6 +136,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
         this.setVolumes(from.getVolumes());
         this.setWorkspaceVolume(from.getWorkspaceVolume());
         this.setYaml(from.getYaml());
+        this.setNodeProperties(from.getNodeProperties());
     }
 
     @Deprecated
@@ -476,7 +478,14 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
 
     @DataBoundSetter
     public void setNodeProperties(List<ToolLocationNodeProperty> nodeProperties){
-        this.nodeProperties = nodeProperties;
+        if( nodeProperties != null){
+            this.nodeProperties.clear();
+            this.addNodeProperties(nodeProperties);
+        }
+    }
+
+    public void addNodeProperties(List<ToolLocationNodeProperty> nodeProperties){
+        this.nodeProperties.addAll(nodeProperties);
     }
 
     @Nonnull

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -112,8 +112,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
 
     private List<PodImagePullSecret> imagePullSecrets = new ArrayList<PodImagePullSecret>();
 
-    @SuppressFBWarnings(value = "SE_BAD_FIELD")
-    private List<ToolLocationNodeProperty> nodeProperties = new ArrayList<>();
+    private List<ToolLocationNodeProperty> nodeProperties;
 
     private String yaml;
 
@@ -480,20 +479,18 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
 
     @DataBoundSetter
     public void setNodeProperties(List<ToolLocationNodeProperty> nodeProperties){
+        if( this.nodeProperties == null)
+            this.nodeProperties = new ArrayList<>();
         if( nodeProperties != null){
             this.nodeProperties.clear();
-            this.addNodeProperties(nodeProperties);
+            this.nodeProperties.addAll(nodeProperties);
         }
-    }
-
-    public void addNodeProperties(List<ToolLocationNodeProperty> nodeProperties){
-        this.nodeProperties.addAll(nodeProperties);
     }
 
     @Nonnull
     public List<ToolLocationNodeProperty> getNodeProperties(){
         if (nodeProperties == null) {
-            return Collections.emptyList();
+            this.nodeProperties = new ArrayList<>();
         }
         return nodeProperties;
     }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -13,6 +13,7 @@ import java.util.logging.Logger;
 
 import javax.annotation.Nonnull;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.lang.StringUtils;
 import org.csanchez.jenkins.plugins.kubernetes.model.TemplateEnvVar;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.PodVolume;
@@ -111,6 +112,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
 
     private List<PodImagePullSecret> imagePullSecrets = new ArrayList<PodImagePullSecret>();
 
+    @SuppressFBWarnings(value = "SE_BAD_FIELD")
     private List<ToolLocationNodeProperty> nodeProperties = new ArrayList<>();
 
     private String yaml;

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -1,21 +1,18 @@
 package org.csanchez.jenkins.plugins.kubernetes;
 
 import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
 import javax.annotation.Nonnull;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.*;
 import hudson.slaves.NodeProperty;
@@ -30,14 +27,11 @@ import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
-
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
-
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.labels.LabelAtom;
-import hudson.tools.ToolLocationNodeProperty;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import jenkins.model.Jenkins;
@@ -489,9 +483,10 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
         this.getNodeProperties().replaceBy(properties);
     }
 
+    @NonNull
     public DescribableList<NodeProperty<?>, NodePropertyDescriptor> getNodeProperties(){
         if( this.nodeProperties == null)
-            this.nodeProperties = new DescribableList<NodeProperty<?>, NodePropertyDescriptor>(this);
+            this.nodeProperties = new DescribableList<>(this);
         return nodeProperties;
     }
 
@@ -669,9 +664,11 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
         }
     }
 
+    /**
+     * Empty implementation of Saveable interface. This interface is used for DescribableList implementation
+     */
     @Override
-    public void save()  {
-    }
+    public void save()  { }
 
     @Extension
     public static class DescriptorImpl extends Descriptor<PodTemplate> {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
@@ -4,6 +4,7 @@ import static hudson.Util.*;
 import static java.util.stream.Collectors.*;
 import static org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate.*;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -20,6 +21,10 @@ import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
+import hudson.slaves.NodeProperty;
+import hudson.slaves.NodePropertyDescriptor;
+import hudson.util.DescribableList;
+import jenkins.model.Jenkins;
 import org.csanchez.jenkins.plugins.kubernetes.model.TemplateEnvVar;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.PodVolume;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.workspace.WorkspaceVolume;
@@ -252,7 +257,7 @@ public class PodTemplateUtils {
      * @param template      The actual container template
      * @return              The combined container template.
      */
-    public static PodTemplate combine(PodTemplate parent, PodTemplate template) {
+    public static PodTemplate combine(PodTemplate parent, PodTemplate template) throws IOException {
         Preconditions.checkNotNull(template, "Pod template should not be null");
         if (parent == null) {
             return template;
@@ -288,8 +293,7 @@ public class PodTemplateUtils {
         WorkspaceVolume workspaceVolume = template.isCustomWorkspaceVolumeEnabled() && template.getWorkspaceVolume() != null ? template.getWorkspaceVolume() : parent.getWorkspaceVolume();
 
         //Tool location node properties
-        List<ToolLocationNodeProperty> toolLocationNodeProperties = new ArrayList<>();
-        toolLocationNodeProperties.addAll(parent.getNodeProperties());
+        DescribableList<NodeProperty<?>, NodePropertyDescriptor> toolLocationNodeProperties = parent.getNodeProperties();
         toolLocationNodeProperties.addAll(template.getNodeProperties());
 
         PodTemplate podTemplate = new PodTemplate();
@@ -319,7 +323,7 @@ public class PodTemplateUtils {
      * @param allTemplates               A collection of all the known templates
      * @return
      */
-    static PodTemplate unwrap(PodTemplate template, String defaultProviderTemplate, Collection<PodTemplate> allTemplates) {
+    static PodTemplate unwrap(PodTemplate template, String defaultProviderTemplate, Collection<PodTemplate> allTemplates) throws IOException {
         if (template == null) {
             return null;
         }
@@ -356,7 +360,7 @@ public class PodTemplateUtils {
      * @param allTemplates            A collection of all the known templates
      * @return
      */
-    static PodTemplate unwrap(PodTemplate template, Collection<PodTemplate> allTemplates) {
+    static PodTemplate unwrap(PodTemplate template, Collection<PodTemplate> allTemplates) throws IOException {
         return unwrap(template, null, allTemplates);
     }
 

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
@@ -81,7 +81,11 @@
       <f:textbox/>
     </f:entry>
 
-    <f:descriptorList title="${%Node Properties}" descriptors="${h.getNodePropertyDescriptors(descriptor.clazz)}" field="nodeProperties" />
+    <!-- descriptorList is not working somehow, repeatableProperty has same functionality, just ui changes a little -->
+    <f:entry title="${%Tool Locations}">
+        <f:repeatableProperty field="nodeProperties" noAddButton="true" />
+    </f:entry>
+
     <f:block>
       <table>
         <f:optionalBlock title="${%Use custom workspace volume}" field="customWorkspaceVolumeEnabled" inline="true">

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
@@ -83,7 +83,7 @@
 
     <!-- descriptorList is not working somehow, repeatableProperty has same functionality, just ui changes a little -->
     <f:entry title="${%Tool Locations}">
-        <f:repeatableProperty field="nodeProperties" noAddButton="true" />
+        <f:repeatableProperty field="nodeProperties" noAddButton="false" />
     </f:entry>
 
     <f:block>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
@@ -81,11 +81,7 @@
       <f:textbox/>
     </f:entry>
 
-    <!-- descriptorList is not working somehow, repeatableProperty has same functionality, just ui changes a little -->
-    <f:entry title="${%Tool Locations}">
-        <f:repeatableProperty field="nodeProperties" noAddButton="false" />
-    </f:entry>
-
+    <f:descriptorList title="${%Node Properties}" descriptors="${h.getNodePropertyDescriptors(descriptor.clazz)}" field="nodeProperties" />
     <f:block>
       <table>
         <f:optionalBlock title="${%Use custom workspace volume}" field="customWorkspaceVolumeEnabled" inline="true">

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudTest.java
@@ -1,5 +1,6 @@
 package org.csanchez.jenkins.plugins.kubernetes;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -25,7 +26,7 @@ public class KubernetesCloudTest {
     }
 
     @Test
-    public void testInheritance() {
+    public void testInheritance() throws IOException {
 
         ContainerTemplate jnlp = new ContainerTemplate("jnlp", "jnlp:1");
         ContainerTemplate maven = new ContainerTemplate("maven", "maven:1");

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest.java
@@ -29,6 +29,8 @@ import static org.junit.Assert.*;
 import java.util.Arrays;
 import java.util.List;
 
+import hudson.slaves.NodePropertyDescriptor;
+import hudson.util.DescribableList;
 import org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.EmptyDirVolume;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.HostPathVolume;
@@ -98,7 +100,7 @@ public class KubernetesTest {
     public void upgradeFrom_0_10() throws Exception {
         List<PodTemplate> templates = cloud.getTemplates();
         PodTemplate template = templates.get(0);
-        List<ToolLocationNodeProperty> nodeProperties = template.getNodeProperties();
+        DescribableList<NodeProperty<?>,NodePropertyDescriptor> nodeProperties = template.getNodeProperties();
         assertEquals(1, nodeProperties.size());
         ToolLocationNodeProperty property = (ToolLocationNodeProperty) nodeProperties.get(0);
         assertEquals(1, property.getLocations().size());

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
@@ -30,12 +30,14 @@ import static org.csanchez.jenkins.plugins.kubernetes.PodTemplateUtils.*;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
+import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import hudson.model.Node;
+import hudson.slaves.NodeProperty;
 import hudson.tools.ToolLocationNodeProperty;
 import org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar;
 import org.csanchez.jenkins.plugins.kubernetes.model.SecretEnvVar;
@@ -87,7 +89,7 @@ public class PodTemplateUtilsTest {
 
 
     @Test
-    public void shouldReturnPodTemplateWhenParentIsNull() {
+    public void shouldReturnPodTemplateWhenParentIsNull() throws IOException {
         PodTemplate template = new PodTemplate();
         template.setName("template");
         template.setServiceAccount("sa1");
@@ -97,7 +99,7 @@ public class PodTemplateUtilsTest {
 
 
     @Test
-    public void shouldOverrideServiceAccountIfSpecified() {
+    public void shouldOverrideServiceAccountIfSpecified() throws IOException {
         PodTemplate parent = new PodTemplate();
         parent.setName("parent");
         parent.setServiceAccount("sa");
@@ -117,7 +119,7 @@ public class PodTemplateUtilsTest {
     }
 
     @Test
-    public void shouldOverrideNodeSelectorIfSpecified() {
+    public void shouldOverrideNodeSelectorIfSpecified() throws IOException {
         PodTemplate parent = new PodTemplate();
         parent.setName("parent");
         parent.setNodeSelector("key:value");
@@ -139,7 +141,7 @@ public class PodTemplateUtilsTest {
 
 
     @Test
-    public void shouldCombineAllImagePullSecrets() {
+    public void shouldCombineAllImagePullSecrets() throws IOException {
         PodTemplate parent = new PodTemplate();
         parent.setName("parent");
         parent.setNodeSelector("key:value");
@@ -168,7 +170,7 @@ public class PodTemplateUtilsTest {
 
 
     @Test
-    public void shouldCombineAllAnnotations() {
+    public void shouldCombineAllAnnotations() throws IOException {
         PodTemplate parent = new PodTemplate();
         parent.setName("parent");
         parent.setNodeSelector("key:value");
@@ -185,7 +187,7 @@ public class PodTemplateUtilsTest {
 
 
     @Test
-    public void shouldUnwrapParent() {
+    public void shouldUnwrapParent() throws IOException {
         PodTemplate parent = new PodTemplate();
         parent.setName("parent");
         parent.setLabel("parent");
@@ -207,7 +209,7 @@ public class PodTemplateUtilsTest {
     }
 
     @Test
-    public void shouldUnwrapMultipleParents() {
+    public void shouldUnwrapMultipleParents() throws IOException {
         PodTemplate parent = new PodTemplate();
         parent.setName("parent");
         parent.setLabel("parent");
@@ -247,7 +249,7 @@ public class PodTemplateUtilsTest {
     }
 
     @Test
-    public void shouldCombineAllPodKeyValueEnvVars() {
+    public void shouldCombineAllPodKeyValueEnvVars() throws IOException {
         PodTemplate template1 = new PodTemplate();
         KeyValueEnvVar podEnvVar1 = new KeyValueEnvVar("key-1", "value-1");
         template1.setEnvVars(singletonList(podEnvVar1));
@@ -263,7 +265,7 @@ public class PodTemplateUtilsTest {
     }
 
     @Test
-    public void shouldFilterOutNullOrEmptyPodKeyValueEnvVars() {
+    public void shouldFilterOutNullOrEmptyPodKeyValueEnvVars() throws IOException {
         PodTemplate template1 = new PodTemplate();
         KeyValueEnvVar podEnvVar1 = new KeyValueEnvVar("", "value-1");
         template1.setEnvVars(singletonList(podEnvVar1));
@@ -278,7 +280,7 @@ public class PodTemplateUtilsTest {
     }
 
     @Test
-    public void shouldCombineAllPodSecretEnvVars() {
+    public void shouldCombineAllPodSecretEnvVars() throws IOException {
         PodTemplate template1 = new PodTemplate();
         SecretEnvVar podSecretEnvVar1 = new SecretEnvVar("key-1", "secret-1", "secret-key-1");
         template1.setEnvVars(singletonList(podSecretEnvVar1));
@@ -294,7 +296,7 @@ public class PodTemplateUtilsTest {
     }
 
     @Test
-    public void shouldFilterOutNullOrEmptyPodSecretEnvVars() {
+    public void shouldFilterOutNullOrEmptyPodSecretEnvVars() throws IOException {
         PodTemplate template1 = new PodTemplate();
         SecretEnvVar podSecretEnvVar1 = new SecretEnvVar("", "secret-1", "secret-key-1");
         template1.setEnvVars(singletonList(podSecretEnvVar1));
@@ -356,7 +358,7 @@ public class PodTemplateUtilsTest {
     }
 
     @Test
-    public void shouldCombineAllMounts() {
+    public void shouldCombineAllMounts() throws IOException {
         PodTemplate template1 = new PodTemplate();
         HostPathVolume hostPathVolume1 = new HostPathVolume("/host/mnt1", "/container/mnt1");
         HostPathVolume hostPathVolume2 = new HostPathVolume("/host/mnt2", "/container/mnt2");
@@ -477,8 +479,8 @@ public class PodTemplateUtilsTest {
     }
 
     @Test
-    public void shouldCombineAllToolLocations()
-    {
+    public void shouldCombineAllToolLocations() throws IOException {
+
         PodTemplate podTemplate1 = new PodTemplate();
         List<ToolLocationNodeProperty> nodeProperties1 = new ArrayList<>();
         nodeProperties1.add(new ToolLocationNodeProperty(new ToolLocationNodeProperty.ToolLocation("toolKey1@Test","toolHome1")));
@@ -492,5 +494,6 @@ public class PodTemplateUtilsTest {
         PodTemplate result = combine(podTemplate1,podTemplate2);
 
         assertThat(result.getNodeProperties(), hasItems(nodeProperties1.get(0),nodeProperties2.get(0)));
+
     }
 }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
@@ -30,11 +30,13 @@ import static org.csanchez.jenkins.plugins.kubernetes.PodTemplateUtils.*;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import hudson.tools.ToolLocationNodeProperty;
 import org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar;
 import org.csanchez.jenkins.plugins.kubernetes.model.SecretEnvVar;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.HostPathVolume;
@@ -447,5 +449,23 @@ public class PodTemplateUtilsTest {
         properties.put("key1", "value1");
         properties.put("key2", "value2");
         assertEquals("value1 or value2 or ${key3}", substitute("${key1} or ${key2} or ${key3}", properties, "defaultValue"));
+    }
+
+    @Test
+    public void shouldCompineAllToolLocations()
+    {
+        PodTemplate podTemplate1 = new PodTemplate();
+        List<ToolLocationNodeProperty> nodeProperties1 = new ArrayList<>();
+        nodeProperties1.add(new ToolLocationNodeProperty(new ToolLocationNodeProperty.ToolLocation("toolKey1@Test","toolHome1")));
+        podTemplate1.setNodeProperties(nodeProperties1);
+
+        PodTemplate podTemplate2 = new PodTemplate();
+        List<ToolLocationNodeProperty> nodeProperties2 = new ArrayList<>();
+        nodeProperties2.add(new ToolLocationNodeProperty(new ToolLocationNodeProperty.ToolLocation("toolKey2@Test","toolHome2")));
+        podTemplate2.setNodeProperties(nodeProperties2);
+
+        PodTemplate result = combine(podTemplate1,podTemplate2);
+
+        assertThat(result.getNodeProperties(), hasItems(nodeProperties1.get(0),nodeProperties2.get(0)));
     }
 }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
@@ -452,7 +452,7 @@ public class PodTemplateUtilsTest {
     }
 
     @Test
-    public void shouldCompineAllToolLocations()
+    public void shouldCombineAllToolLocations()
     {
         PodTemplate podTemplate1 = new PodTemplate();
         List<ToolLocationNodeProperty> nodeProperties1 = new ArrayList<>();


### PR DESCRIPTION
NodeProperties implemented As DescribableList as in Jenkins Slave
UI preserved as in Node Configuration
SuppressFBWarning for SE_BAD_FIELD ( still need to user, DescribableList not solved this )
setNodeProperties throws IOException, throws added to methods which related.
Comments added.