### PR TITLE
[FIXED JENKINS-52259] Add yamlFile option for Declarative agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ See the full list of issues at [JIRA](https://issues.jenkins-ci.org/issues/?filt
 
 Preserve resources other than CPU and memory
 
+1.10.0
+-----
+
+* Add `yamlFile` option for Declarative agent to read yaml definition from a different file [#355](https://github.com/jenkinsci/kubernetes-plugin/pull/355) [JENKINS-52259](https://issues.jenkins-ci.org/browse/JENKINS-52259)
+
 1.9.3
 -----
 

--- a/Jenkinsfile-kubernetes
+++ b/Jenkinsfile-kubernetes
@@ -15,7 +15,7 @@ def jvmOptions = '-Xmx300M'
 timestamps {
 
   podTemplate(serviceAccount: 'jenkins', label: label, containers: [
-    containerTemplate(name: 'maven', image: 'maven:3.5.0-jdk-8-alpine', ttyEnabled: true, command: 'cat',
+    containerTemplate(name: 'maven', image: 'maven:3.5.4-jdk-8', ttyEnabled: true, command: 'cat',
         resourceRequestCpu: '100m',
         resourceLimitMemory: '1200Mi')
     ], envVars: [

--- a/README.md
+++ b/README.md
@@ -390,6 +390,23 @@ spec:
 }
 ```
 
+or using `yamlFile` to keep the pod template in a separate `KubernetesPod.yaml` file
+
+```
+pipeline {
+  agent {
+    kubernetes {
+      label 'mypod'
+      defaultContainer 'jnlp'
+      yamlFile 'KubernetesPod.yaml'
+    }
+  }
+  stages {
+      ...
+  }
+}
+```
+
 Note that it was previously possible to define `containerTemplate` but that has been deprecated in favor of the yaml format.
 
 ```groovy

--- a/examples/declarative_from_yaml_file/Jenkinsfile
+++ b/examples/declarative_from_yaml_file/Jenkinsfile
@@ -1,0 +1,24 @@
+pipeline {
+  agent {
+    kubernetes {
+      label 'mypod'
+      yamlFile 'KubernetesPod.yml'
+    }
+  }
+  stages {
+    stage('Run maven') {
+      steps {
+        sh 'set'
+        sh "echo OUTSIDE_CONTAINER_ENV_VAR = ${CONTAINER_ENV_VAR}"
+        container('maven') {
+          sh 'echo MAVEN_CONTAINER_ENV_VAR = ${CONTAINER_ENV_VAR}'
+          sh 'mvn -version'
+        }
+        container('busybox') {
+          sh 'echo BUSYBOX_CONTAINER_ENV_VAR = ${CONTAINER_ENV_VAR}'
+          sh '/bin/busybox'
+        }
+      }
+    }
+  }
+}

--- a/examples/declarative_from_yaml_file/Jenkinsfile
+++ b/examples/declarative_from_yaml_file/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
   agent {
     kubernetes {
       label 'mypod'
-      yamlFile 'examples/declarative_from_yaml_file/KubernetesPod.yml'
+      yamlFile 'examples/declarative_from_yaml_file/KubernetesPod.yaml'
     }
   }
   stages {

--- a/examples/declarative_from_yaml_file/Jenkinsfile
+++ b/examples/declarative_from_yaml_file/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
   agent {
     kubernetes {
       label 'mypod'
-      yamlFile 'KubernetesPod.yml'
+      yamlFile 'examples/declarative_from_yaml_file/KubernetesPod.yml'
     }
   }
   stages {

--- a/examples/declarative_from_yaml_file/KubernetesPod.yaml
+++ b/examples/declarative_from_yaml_file/KubernetesPod.yaml
@@ -1,0 +1,25 @@
+metadata:
+  labels:
+    some-label: some-label-value
+spec:
+  containers:
+  - name: jnlp
+    env:
+    - name: CONTAINER_ENV_VAR
+      value: jnlp
+  - name: maven
+    image: maven:3.3.9-jdk-8-alpine
+    command:
+    - cat
+    tty: true
+    env:
+    - name: CONTAINER_ENV_VAR
+      value: maven
+  - name: busybox
+    image: busybox
+    command:
+    - cat
+    tty: true
+    env:
+    - name: CONTAINER_ENV_VAR
+      value: busybox

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>scm-api</artifactId>
-      <version>2.0.7</version>
+      <version>2.2.6</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -177,6 +177,33 @@
       <artifactId>mockito-core</artifactId>
       <version>2.9.0</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>git</artifactId>
+      <version>3.7.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>git</artifactId>
+      <version>3.7.0</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>scm-api</artifactId>
+      <version>2.2.6</version>
+      <scope>test</scope>
+      <classifier>tests</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-scm-step</artifactId>
+      <version>2.4</version>
+      <scope>test</scope>
+      <classifier>tests</classifier>
     </dependency>
 
     <!-- for ContainerExecDecoratorPipelineTest -->
@@ -205,7 +232,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>credentials</artifactId>
-        <version>2.1.11</version>
+        <version>2.1.14</version>
       </dependency>
 
       <!-- just to fix enforcer RequireUpperBoundDeps -->
@@ -217,17 +244,32 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>structs</artifactId>
-        <version>1.6</version>
+        <version>1.10</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>ssh-credentials</artifactId>
-        <version>1.12</version>
+        <version>1.13</version>
       </dependency>
       <dependency>
         <groupId>org.apache.sshd</groupId>
         <artifactId>sshd-core</artifactId>
         <version>1.7.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci</groupId>
+        <artifactId>annotation-indexer</artifactId>
+        <version>1.12</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>mailer</artifactId>
+        <version>1.18</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>junit</artifactId>
+        <version>1.3</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgent.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgent.java
@@ -41,6 +41,7 @@ public class KubernetesDeclarativeAgent extends DeclarativeAgent<KubernetesDecla
     private List<ContainerTemplate> containerTemplates;
     private String defaultContainer;
     private String yaml;
+    private String yamlFile;
 
     @DataBoundConstructor
     public KubernetesDeclarativeAgent() {
@@ -170,6 +171,15 @@ public class KubernetesDeclarativeAgent extends DeclarativeAgent<KubernetesDecla
     @DataBoundSetter
     public void setActiveDeadlineSeconds(int activeDeadlineSeconds) {
         this.activeDeadlineSeconds = activeDeadlineSeconds;
+    }
+
+    public String getYamlFile() {
+        return yamlFile;
+    }
+
+    @DataBoundSetter
+    public void setYamlFile(String yamlFile) {
+        this.yamlFile = yamlFile;
     }
 
     public Map<String, Object> getAsArgs() {

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgentScript.groovy
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgentScript.groovy
@@ -38,6 +38,9 @@ public class KubernetesDeclarativeAgentScript extends DeclarativeAgentScript<Kub
     public Closure run(Closure body) {
         return {
             try {
+                if (describable.getYamlFile() != null && describable.hasScmContext(s)) {
+                    describable.setYaml(script.readTrusted(describable.getYamlFile()))
+                }
                 script.podTemplate(describable.asArgs) {
                     script.node(describable.label) {
                         if (describable.isDoCheckout() && describable.hasScmContext(script)) {

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgentScript.groovy
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgentScript.groovy
@@ -32,13 +32,14 @@ import org.jenkinsci.plugins.workflow.cps.CpsScript
 public class KubernetesDeclarativeAgentScript extends DeclarativeAgentScript<KubernetesDeclarativeAgent> {
     public KubernetesDeclarativeAgentScript(CpsScript s, KubernetesDeclarativeAgent a) {
         super(s, a)
+
     }
 
     @Override
     public Closure run(Closure body) {
         return {
             try {
-                if (describable.getYamlFile() != null && describable.hasScmContext(s)) {
+                if (describable.getYamlFile() != null && describable.hasScmContext(script)) {
                     describable.setYaml(script.readTrusted(describable.getYamlFile()))
                 }
                 script.podTemplate(describable.asArgs) {

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/declarative.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/declarative.groovy
@@ -1,7 +1,7 @@
 pipeline {
   agent {
     kubernetes {
-      label 'mypod'
+      label 'declarative-pod'
       containerTemplate {
         name 'maven'
         image 'maven:3.3.9-jdk-8-alpine'

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/declarativeFromYaml.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/declarativeFromYaml.groovy
@@ -1,11 +1,12 @@
 pipeline {
   agent {
     kubernetes {
-      label 'mypod'
+      label 'declarativefromyaml-pod'
       yaml """
 metadata:
   labels:
     some-label: some-label-value
+    class: KubernetesDeclarativeAgentTest
 spec:
   containers:
   - name: jnlp

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/declarativeFromYamlFile.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/declarativeFromYamlFile.groovy
@@ -1,0 +1,24 @@
+pipeline {
+  agent {
+    kubernetes {
+      label 'mypod'
+      yamlFile 'declarativeYamlFile.yml'
+    }
+  }
+  stages {
+    stage('Run maven') {
+      steps {
+        sh 'set'
+        sh "echo OUTSIDE_CONTAINER_ENV_VAR = ${CONTAINER_ENV_VAR}"
+        container('maven') {
+          sh 'echo MAVEN_CONTAINER_ENV_VAR = ${CONTAINER_ENV_VAR}'
+          sh 'mvn -version'
+        }
+        container('busybox') {
+          sh 'echo BUSYBOX_CONTAINER_ENV_VAR = ${CONTAINER_ENV_VAR}'
+          sh '/bin/busybox'
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/declarativeFromYamlFile.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/declarativeFromYamlFile.groovy
@@ -1,7 +1,7 @@
 pipeline {
   agent {
     kubernetes {
-      label 'mypod'
+      label 'declarativefromyamlfile-pod'
       yamlFile 'declarativeYamlFile.yml'
     }
   }

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/declarativeFromYamlFile.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/declarativeFromYamlFile.groovy
@@ -5,6 +5,10 @@ pipeline {
       yamlFile 'declarativeYamlFile.yml'
     }
   }
+  options {
+    // Because there's no way for the container to actually get at the git repo on the disk of the box we're running on.
+    skipDefaultCheckout(true)
+  }
   stages {
     stage('Run maven') {
       steps {

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/declarativeYamlFile.yml
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/declarativeYamlFile.yml
@@ -1,0 +1,25 @@
+metadata:
+  labels:
+    some-label: some-label-value
+spec:
+  containers:
+  - name: jnlp
+    env:
+    - name: CONTAINER_ENV_VAR
+      value: jnlp
+  - name: maven
+    image: maven:3.3.9-jdk-8-alpine
+    command:
+    - cat
+    tty: true
+    env:
+    - name: CONTAINER_ENV_VAR
+      value: maven
+  - name: busybox
+    image: busybox
+    command:
+    - cat
+    tty: true
+    env:
+    - name: CONTAINER_ENV_VAR
+      value: busybox

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/declarativeYamlFile.yml
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/declarativeYamlFile.yml
@@ -1,6 +1,7 @@
 metadata:
   labels:
     some-label: some-label-value
+    class: KubernetesDeclarativeAgentTest
 spec:
   containers:
   - name: jnlp


### PR DESCRIPTION
[JENKINS-52259](https://issues.jenkins-ci.org/browse/JENKINS-52259)

If given, it'll read from the specified file via `readTrusted` and use
that for the yaml to pass on.

I don't have a local k8s env on my laptop so I haven't actually tested this yet. =)