### PR TITLE
Avoid streaming to 2 similar OutputStreams

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -268,7 +268,7 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
                 }
 
                 // Send to proc caller as well if they sent one
-                if (outputForCaller != null) {
+                if (outputForCaller != null && !outputForCaller.equals(stream)) {
                     stream = new TeeOutputStream(outputForCaller, stream);
                 }
                 ByteArrayOutputStream error = new ByteArrayOutputStream();


### PR DESCRIPTION
I have an issue when running launcher.launch().stdout(listener) from a different plugin. 

**Background**: 
ContainerExecDecorator decorates the launcher. 

**The issue:**
ContainerExecDecorator's `doLaunch()` gets an OutputStream and splits the output to both the OutputStream and launcher's logger. In my case, OutputStream and and launcher's logger are the same.
**Expected:** All lines printed properly in job's log
**Actual:** Lines are printed twice in job's log

**Reconstruction:**
Run [this line](https://github.com/jfrog/project-examples/blob/master/jenkins-examples/pipeline-examples/maven-example/Jenkinsfile#L18) inside a pod:
```
container('maven') {
    rtMaven.run pom: 'maven-example/pom.xml', goals: 'clean install', buildInfo: buildInfo
}
```