### PR TITLE
Use default http://jenkins/ url as master

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -283,7 +283,7 @@ public class KubernetesCloud extends Cloud {
         if (url == null) {
             url = "http://jenkins/";
             this.setJenkinsUrl(url);
-            LOGGER.log(Level.FINE, "Using default Jenkins URL for Kubernetes: {0}", url)
+            LOGGER.log(Level.FINE, "Using default Jenkins URL for Kubernetes: {0}", url);
                 
         }
         url = url.endsWith("/") ? url : url + "/";

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -281,7 +281,10 @@ public class KubernetesCloud extends Cloud {
                 )
         );
         if (url == null) {
-            throw new IllegalStateException("Jenkins URL for Kubernetes is null");
+            url = "http://jenkins/";
+            this.setJenkinsUrl(url);
+            LOGGER.log(Level.FINE, "Using default Jenkins URL for Kubernetes: {0}", url)
+                
         }
         url = url.endsWith("/") ? url : url + "/";
         return url;


### PR DESCRIPTION
I've set the jenkins default value master url if it is NULL . 