### PR TITLE
[FIXED JENKINS-52623] Use Declarative's CheckoutScript to populate env

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <dependency> <!-- Requires Permission -->
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>cloudbees-folder</artifactId>
-      <version>5.12</version>
+      <version>5.18</version>
     </dependency>
 
     <dependency> <!-- OnceRetentionStrategy -->
@@ -100,12 +100,12 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
-      <version>2.11</version>
+      <version>2.14</version>
     </dependency>
     <dependency> <!-- DeclarativeAgent -->
       <groupId>org.jenkinsci.plugins</groupId>
       <artifactId>pipeline-model-extensions</artifactId>
-      <version>1.1.2</version>
+      <version>1.3.1</version>
       <optional>true</optional>
     </dependency>
 
@@ -113,13 +113,13 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-job</artifactId>
-      <version>2.9</version>
+      <version>2.15</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-basic-steps</artifactId>
-      <version>2.3</version>
+      <version>2.6</version>
       <scope>test</scope>
     </dependency>
     <dependency> <!-- StepConfigTester -->
@@ -132,26 +132,26 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-support</artifactId>
-      <version>2.14</version>
+      <version>2.17</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-durable-task-step</artifactId>
-      <version>2.11</version>
+      <version>2.15</version>
       <scope>test</scope>
     </dependency>
     <dependency> <!-- SemaphoreStep -->
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-support</artifactId>
-      <version>2.14</version>
+      <version>2.17</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-scm-step</artifactId>
-      <version>2.4</version>
+      <version>2.6</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -163,19 +163,19 @@
     <dependency>
       <groupId>org.jenkinsci.plugins</groupId>
       <artifactId>pipeline-model-definition</artifactId>
-      <version>1.1.2</version>
+      <version>1.3.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-api</artifactId>
-      <version>2.11</version>
+      <version>2.25</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
-      <version>2.29</version>
+      <version>2.46</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -238,19 +238,29 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>credentials</artifactId>
-        <version>2.1.14</version>
+        <version>2.1.16</version>
       </dependency>
 
       <!-- just to fix enforcer RequireUpperBoundDeps -->
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>script-security</artifactId>
+        <version>1.42</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>git-client</artifactId>
+        <version>2.7.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>credentials-binding</artifactId>
-        <version>1.12</version>
+        <version>1.14</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>structs</artifactId>
-        <version>1.10</version>
+        <version>1.14</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
@@ -270,7 +280,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>mailer</artifactId>
-        <version>1.18</version>
+        <version>1.20</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgentTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgentTest.java
@@ -87,4 +87,15 @@ public class KubernetesDeclarativeAgentTest extends AbstractKubernetesPipelineTe
         r.assertLogContains("MAVEN_CONTAINER_ENV_VAR = maven\n", b);
         r.assertLogContains("BUSYBOX_CONTAINER_ENV_VAR = busybox\n", b);
     }
+
+    @Issue("JENKINS-52623")
+    @Test
+    public void declarativeSCMVars() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "job with repo");
+        // We can't use a local GitSampleRepoRule for this because the repo has to be accessible from within the container.
+        p.setDefinition(new CpsScmFlowDefinition(new GitStep("https://github.com/abayer/jenkins-52623.git").createSCM(), "Jenkinsfile"));
+        WorkflowRun b = r.buildAndAssertSuccess(p);
+        r.assertLogContains("Outside container: GIT_BRANCH is origin/master", b);
+        r.assertLogContains("In container: GIT_BRANCH is origin/master", b);
+    }
 }


### PR DESCRIPTION
[JENKINS-52623](https://issues.jenkins-ci.org/browse/JENKINS-52623)

Tada! Regrettably, I had to use an external repository for the test, though.

Basically replaces https://github.com/jenkinsci/kubernetes-plugin/pull/286

cc @carlossg 