### PR TITLE
update deleting pods in bad state 

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,7 +535,7 @@ at `DEBUG` level.
 
 ## Deleting pods in bad state
 
-    kubectl get -a pods -o name --selector=jenkins=agent | xargs -I {} kubectl delete {}
+    kubectl get pods -o name --selector=jenkins=slave --all-namespaces  | xargs -I {} kubectl delete {}
 
 # Building and Testing
 


### PR DESCRIPTION
current version the pods label is `jenkins=slave` 
and Flag --show-all has been deprecated, will be removed in an upcoming release