### PR TITLE
[JENKINS-50879] Add volumes from pod template to JNLP container

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -214,7 +214,8 @@ public class PodTemplateBuilder {
         // default jnlp container
         Optional<Container> jnlpOpt = pod.getSpec().getContainers().stream().filter(c -> JNLP_NAME.equals(c.getName()))
                 .findFirst();
-        Container jnlp = jnlpOpt.orElse(new ContainerBuilder().withName(JNLP_NAME).build());
+        Container jnlp = jnlpOpt.orElse(new ContainerBuilder().withName(JNLP_NAME)
+                .withVolumeMounts(volumeMounts.values().toArray(new VolumeMount[volumeMounts.values().size()])).build());
         if (!jnlpOpt.isPresent()) {
             pod.getSpec().getContainers().add(jnlp);
         }


### PR DESCRIPTION
Fix for JENKINS-50879. I re-activated the "PodTemplateBuilderTest.testBuildFromTemplate" test which was failing without this patch. 