### PR TITLE
Supporting fieldRef and resourceFieldRef

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/model/FieldEnvVar.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/model/FieldEnvVar.java
@@ -1,0 +1,69 @@
+package org.csanchez.jenkins.plugins.kubernetes.model;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import io.fabric8.kubernetes.api.model.EnvVarSourceBuilder;
+import io.fabric8.kubernetes.api.model.ObjectFieldSelectorBuilder;
+
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class FieldEnvVar extends TemplateEnvVar {
+
+    private final static String DEFAULT_API_VERSION = "v1";
+
+    private String fieldPath;
+
+    private String apiVersion;
+
+    @DataBoundConstructor
+    public FieldEnvVar(String key, String fieldPath) {
+        this(key, fieldPath, DEFAULT_API_VERSION);
+    }
+
+    @DataBoundConstructor
+    public FieldEnvVar(String key, String fieldPath, String apiVersion) {
+        super(key);
+        this.fieldPath = fieldPath;
+        this.apiVersion = apiVersion;
+    }
+
+    @Override
+    public EnvVar buildEnvVar() {
+        return new EnvVarBuilder() //
+                .withName(getKey()) //
+                .withValueFrom(new EnvVarSourceBuilder() //
+                        .withFieldRef(
+                                new ObjectFieldSelectorBuilder() //
+                                        .withFieldPath(fieldPath) //
+                                        .withApiVersion(apiVersion) //
+                                        .build() //
+                        ) //
+                        .build()) //
+                .build();
+    }
+
+    public String getFieldPath() { return fieldPath; }
+
+    public void setFieldPath(String fieldPath) { this.fieldPath = fieldPath; }
+
+    public String getApiVersion() { return apiVersion; }
+
+    public String setApiVersion(String apiVersion) { this.apiVersion = apiVersion; }
+
+    @Override
+    public String toString() {
+        return "FieldEnvVar [fieldPath=" + fieldPath + ",apiVersion=" + apiVersion + ",getKey()=" + getKey() + "]";
+    }
+
+    @Extension
+    @Symbol("fieldEnvVar")
+    public static class DescriptorImpl extends Descriptor<TemplateEnvVar> {
+        @Override
+        public String getDisplayName() {
+            return "Environment Variable from Object Field";
+        }
+    }
+}

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/model/ResourceFieldEnvVar.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/model/ResourceFieldEnvVar.java
@@ -1,0 +1,87 @@
+package org.csanchez.jenkins.plugins.kubernetes.model;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import io.fabric8.kubernetes.api.model.EnvVarSourceBuilder;
+import io.fabric8.kubernetes.api.model.ResourceFieldSelectorBuilder;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class ResourceFieldEnvVar extends TemplateEnvVar {
+
+    private final static String DEFAULT_DIVISOR = "1";
+
+    private String resource;
+
+    private String containerName;
+
+    private String divisor;
+
+    @DataBoundConstructor
+    public ResourceFieldEnvVar(String key, String resource, String containerName, String divisor) {
+        super(key);
+        this.resource = resource;
+        this.containerName = containerName;
+        this.divisor = divisor;
+    }
+
+    @DataBoundConstructor
+    public ResourceFieldEnvVar(String key, String resource, String divisor) {
+        this(key, resource, null, divisor);
+    }
+
+    @DataBoundConstructor
+    public ResourceFieldEnvVar(String key, String resource) {
+        this(key, resource, null, DEFAULT_DIVISOR);
+    }
+
+    @Override
+    public EnvVar buildEnvVar() {
+        ResourceFieldSelectorBuilder resourceFieldSelectorBuilder = new ResourceFieldSelectorBuilder()
+                .withResource(resource)
+                .withNewDivisor(divisor);
+
+        if (containerName != null) {
+            resourceFieldSelectorBuilder.withContainerName(containerName);
+        }
+
+        return new EnvVarBuilder() //
+                .withName(getKey()) //
+                .withValueFrom(new EnvVarSourceBuilder() //
+                        .withResourceFieldRef(
+                                resourceFieldSelectorBuilder.build() //
+                        ) //
+                        .build()) //
+                .build();
+    }
+
+
+    public String getResource() { return resource; }
+
+    public void setResource(String resource) { this.resource = resource; }
+
+    public String getContainerName() { return containerName; }
+
+    public void setContainerName(String containerName) { this.containerName = containerName; }
+
+    public String getDivisor() { return divisor; }
+
+    public void setDivisor(String divisor) { this.divisor = divisor; }
+
+    @Override
+    public String toString() {
+        return "ResourceFieldEnvVar [resource=" + resource + ",divisor=" + divisor + ",containerName=" + containerName + ", getKey()=" + getKey() + "]";
+    }
+
+    @Extension
+    @Symbol("resourceFieldEnvVar")
+    public static class DescriptorImpl extends Descriptor<TemplateEnvVar> {
+        @Override
+        public String getDisplayName() {
+            return "Environment Variable from Resource Field";
+        }
+    }
+
+}

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runWithEnvVars.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runWithEnvVars.groovy
@@ -1,14 +1,19 @@
 podTemplate(label: 'mypod',
     envVars: [
         envVar(key: 'POD_ENV_VAR', value: 'pod-env-var-value'),
-        secretEnvVar(key: 'POD_ENV_VAR_FROM_SECRET', secretName: 'pod-secret', secretKey: 'password')
+        secretEnvVar(key: 'POD_ENV_VAR_FROM_SECRET', secretName: 'pod-secret', secretKey: 'password'),
+        fieldEnvVar(key: 'POD_ENV_VAR_FROM_FIELD', fieldPath: 'metadata.name', apiVersion: 'v1'),
+        resourceFieldEnvVar(key: 'POD_ENV_VAR_FROM_RESOURCE_FIELD', resource: 'limits.cpu', containerName: 'busybox', divisor: '1')
+
     ],
     containers: [
         containerTemplate(name: 'busybox', image: 'busybox', ttyEnabled: true, command: '/bin/cat',
             envVars: [
                 containerEnvVar(key: 'CONTAINER_ENV_VAR_LEGACY', value: 'container-env-var-value'),
                 envVar(key: 'CONTAINER_ENV_VAR', value: 'container-env-var-value'),
-                secretEnvVar(key: 'CONTAINER_ENV_VAR_FROM_SECRET', secretName: 'container-secret', secretKey: 'password')
+                secretEnvVar(key: 'CONTAINER_ENV_VAR_FROM_SECRET', secretName: 'container-secret', secretKey: 'password'),
+                fieldEnvVar(key: 'CONTAINER_ENV_VAR_FROM_FIELD', fieldPath: 'metadata.namespace'),
+                resourceFieldEnvVar(key: 'CONTAINER_ENV_VAR_FROM_RESOURCE_FIELD', resource: 'limits.cpu')
             ],
         ),
         containerTemplate(name: 'java7', image: 'openjdk:7u151-jre-alpine', ttyEnabled: true, command: '/bin/cat'),
@@ -23,8 +28,12 @@ podTemplate(label: 'mypod',
         echo OUTSIDE_CONTAINER_ENV_VAR = \$CONTAINER_ENV_VAR
         echo OUTSIDE_CONTAINER_ENV_VAR_LEGACY = \$CONTAINER_ENV_VAR_LEGACY
         echo OUTSIDE_CONTAINER_ENV_VAR_FROM_SECRET = \$CONTAINER_ENV_VAR_FROM_SECRET
+        echo OUTSIDE_CONTAINER_ENV_VAR_FROM_FIELD = \$CONTAINER_ENV_VAR_FROM_FIELD
+        echo OUTSIDE_CONTAINER_ENV_VAR_FROM_RESOURCE_FIELD = \$CONTAINER_ENV_VAR_FROM_RESOURCE_FIELD
         echo OUTSIDE_POD_ENV_VAR = \$POD_ENV_VAR
         echo OUTSIDE_POD_ENV_VAR_FROM_SECRET = \$POD_ENV_VAR_FROM_SECRET
+        echo OUTSIDE_POD_ENV_VAR_FROM_FIELD = \$POD_ENV_VAR_FROM_FIELD
+        echo OUTSIDE_POD_ENV_VAR_FROM_RESOURCE_FIELD = \$POD_ENV_VAR_FROM_RESOURCE_FIELD
         echo OUTSIDE_JAVA_HOME_X = \$JAVA_HOME_X
         echo OUTSIDE_GLOBAL = \$GLOBAL
         """
@@ -37,8 +46,12 @@ podTemplate(label: 'mypod',
                 echo INSIDE_CONTAINER_ENV_VAR = \$CONTAINER_ENV_VAR
                 echo INSIDE_CONTAINER_ENV_VAR_LEGACY = \$CONTAINER_ENV_VAR_LEGACY
                 echo INSIDE_CONTAINER_ENV_VAR_FROM_SECRET = \$CONTAINER_ENV_VAR_FROM_SECRET
+                echo INSIDE_CONTAINER_ENV_VAR_FROM_FIELD = \$CONTAINER_ENV_VAR_FROM_FIELD
+                echo INSIDE_CONTAINER_ENV_VAR_FROM_RESOURCE_FIELD = \$CONTAINER_ENV_VAR_FROM_RESOURCE_FIELD
                 echo INSIDE_POD_ENV_VAR = \$POD_ENV_VAR
                 echo INSIDE_POD_ENV_VAR_FROM_SECRET = \$POD_ENV_VAR_FROM_SECRET
+                echo INSIDE_POD_ENV_VAR_FROM_FIELD = \$POD_ENV_VAR_FROM_FIELD
+                echo INSIDE_POD_ENV_VAR_FROM_RESOURCE_FIELD = \$POD_ENV_VAR_FROM_RESOURCE_FIELD
                 echo INSIDE_JAVA_HOME_X = \$JAVA_HOME_X
                 echo INSIDE_JAVA_HOME = \$JAVA_HOME
                 echo INSIDE_GLOBAL = \$GLOBAL

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runWithEnvVars.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runWithEnvVars.groovy
@@ -3,8 +3,7 @@ podTemplate(label: 'mypod',
         envVar(key: 'POD_ENV_VAR', value: 'pod-env-var-value'),
         secretEnvVar(key: 'POD_ENV_VAR_FROM_SECRET', secretName: 'pod-secret', secretKey: 'password'),
         fieldEnvVar(key: 'POD_ENV_VAR_FROM_FIELD', fieldPath: 'metadata.name', apiVersion: 'v1'),
-        resourceFieldEnvVar(key: 'POD_ENV_VAR_FROM_RESOURCE_FIELD', resource: 'limits.cpu', containerName: 'busybox', divisor: '1')
-
+        resourceFieldEnvVar(key: 'POD_ENV_VAR_FROM_RESOURCE_FIELD', resource: 'requests.cpu', containerName: 'busybox', divisor: '1000m')
     ],
     containers: [
         containerTemplate(name: 'busybox', image: 'busybox', ttyEnabled: true, command: '/bin/cat',
@@ -15,6 +14,8 @@ podTemplate(label: 'mypod',
                 fieldEnvVar(key: 'CONTAINER_ENV_VAR_FROM_FIELD', fieldPath: 'metadata.namespace'),
                 resourceFieldEnvVar(key: 'CONTAINER_ENV_VAR_FROM_RESOURCE_FIELD', resource: 'limits.cpu')
             ],
+            resourceRequestCpu: '100m',
+            resourceLimitCpu: '1.0'
         ),
         containerTemplate(name: 'java7', image: 'openjdk:7u151-jre-alpine', ttyEnabled: true, command: '/bin/cat'),
         containerTemplate(name: 'java8', image: 'openjdk:8u151-jre-alpine', ttyEnabled: true, command: '/bin/cat')


### PR DESCRIPTION
Downward API support for `envVars` in PodTemplate and ContainerTemplate. The `containerName` field being optional was tricky since you can't set a default value for it.