### PR TITLE
[JENKINS-53422] Declarative: do not wrap steps with `container` statement unless default container is changed

### DIFF
--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgentScript.groovy
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgentScript.groovy
@@ -55,8 +55,14 @@ public class KubernetesDeclarativeAgentScript extends DeclarativeAgentScript<Kub
                             }
 
                             // call the main body
-                            script.container(container) {
+                            if (container == 'jnlp') {
+                                // If default container is not changed by the pipeline user,
+                                // do not enclose the body with a `container` statement.
                                 body.call()
+                            } else {
+                                script.container(container) {
+                                    body.call()
+                                }
                             }
                         }.call()
                     }


### PR DESCRIPTION
We met a weird issue when migrating the scripted syntax to declarative
with Kubernetes plugin: The `Launcher` doesn't forward `stdin`,
`stdout`, or `stderr` even though they are requested to be forwarded.
This breaks many plugins that use `Launcher` to start a remote process on Jenkins slaves.

This happens because when Kubernetes plugin converts declarative syntax to scripted syntax,
all build steps are enclosed with a `container` statement.
As a result, remote commands are run via the Kubernetes exec API rather than
the jnlp agent.

Since running steps via Kubernetes exec API is still considered ALPHA
and there are some compatibility issues to solve,
I would like to make a small change to the syntax converting process:
The declarative steps will not be enclosed with a `container` statement unless
an alternate default container is specified by the pipeline user.

Issue link: https://issues.jenkins-ci.org/browse/JENKINS-53422