### PR TITLE
JENKINS-53817 - Allow custom workspace in declarative pipeline Kubern…

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,30 @@ pipeline {
 }
 ```
 
+Run the Pipeline or individual stage within a custom workspace - not required unless explicitly stated.
+
+```
+pipeline {
+  agent {
+    kubernetes {
+      label 'mypod'
+      customWorkspace 'some/other/path'
+      defaultContainer 'maven'
+      yamlFile 'KubernetesPod.yaml'
+    }
+  }
+
+  stages {
+    stage('Run maven') {
+      steps {
+        sh 'mvn -version'
+        sh "echo Workspace dir is ${pwd()}"
+      }
+    }
+  }
+}
+```
+
 ## Accessing container logs from the pipeline
 
 If you use the `containerTemplate` to run some service in the background

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgent.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgent.java
@@ -12,6 +12,7 @@ import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 import java.util.Collections;
@@ -26,6 +27,7 @@ public class KubernetesDeclarativeAgent extends DeclarativeAgent<KubernetesDecla
     private static final Logger LOGGER = Logger.getLogger(KubernetesDeclarativeAgent.class.getName());
 
     private String label;
+    private String customWorkspace;
 
     private String cloud;
     private String inheritFrom;
@@ -60,6 +62,16 @@ public class KubernetesDeclarativeAgent extends DeclarativeAgent<KubernetesDecla
     @DataBoundSetter
     public void setLabel(String label) {
         this.label = label;
+    }
+
+    @CheckForNull
+    public String getCustomWorkspace() {
+        return customWorkspace;
+    }
+
+    @DataBoundSetter
+    public void setCustomWorkspace(String customWorkspace) {
+        this.customWorkspace = customWorkspace;
     }
 
     public String getCloud() {
@@ -187,6 +199,10 @@ public class KubernetesDeclarativeAgent extends DeclarativeAgent<KubernetesDecla
 
         argMap.put("label", label);
         argMap.put("name", label);
+
+        if (!StringUtils.isEmpty(customWorkspace)) {
+            argMap.put("customWorkspace", customWorkspace);
+        }
 
         List<ContainerTemplate> containerTemplates = getContainerTemplates();
         if (containerTemplate != null) {

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgentScript.groovy
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgentScript.groovy
@@ -24,34 +24,31 @@
 package org.csanchez.jenkins.plugins.kubernetes.pipeline
 
 import hudson.model.Result
-import org.jenkinsci.plugins.pipeline.modeldefinition.SyntheticStageNames
 import org.jenkinsci.plugins.pipeline.modeldefinition.agent.CheckoutScript
 import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentScript
 import org.jenkinsci.plugins.workflow.cps.CpsScript
 
-
 public class KubernetesDeclarativeAgentScript extends DeclarativeAgentScript<KubernetesDeclarativeAgent> {
     public KubernetesDeclarativeAgentScript(CpsScript s, KubernetesDeclarativeAgent a) {
         super(s, a)
-
     }
 
     @Override
     public Closure run(Closure body) {
         return {
             try {
-                if (describable.getYamlFile() != null && describable.hasScmContext(script)) {
+                if ((describable.getYamlFile() != null) && (describable.hasScmContext(script))) {
                     describable.setYaml(script.readTrusted(describable.getYamlFile()))
                 }
                 script.podTemplate(describable.asArgs) {
                     script.node(describable.label) {
-                        CheckoutScript.doCheckout(script, describable) {
+                        CheckoutScript.doCheckout(script, describable, describable.customWorkspace) {
                             // what container to use for the main body
-                            def container = describable.defaultContainer ?: 'jnlp';
+                            def container = describable.defaultContainer ?: 'jnlp'
 
                             if (describable.containerTemplate != null) {
                                 // run inside the container declared for backwards compatibility
-                                container = describable.containerTemplate.asArgs;
+                                container = describable.containerTemplate.asArgs
                             }
 
                             // call the main body

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgentTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgentTest.java
@@ -98,4 +98,16 @@ public class KubernetesDeclarativeAgentTest extends AbstractKubernetesPipelineTe
         r.assertLogContains("Outside container: GIT_BRANCH is origin/master", b);
         r.assertLogContains("In container: GIT_BRANCH is origin/master", b);
     }
+
+    @Issue("JENKINS-53817")
+    @Test
+    public void declarativeUseCustomWorkspace() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "job with dir");
+        p.setDefinition(new CpsFlowDefinition(loadPipelineScript("declarativeCustomWorkspace.groovy"), true));
+        WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+        assertNotNull(b);
+        r.assertBuildStatusSuccess(r.waitForCompletion(b));
+        r.assertLogContains("Apache Maven 3.3.9", b);
+        r.assertLogContains("Workspace dir is", b);
+    }
 }

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/declarativeCustomWorkspace.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/declarativeCustomWorkspace.groovy
@@ -1,0 +1,38 @@
+pipeline {
+  agent {
+    kubernetes {
+      label 'declarative-custom-workspace-pod'
+      customWorkspace 'some/other/path'
+      defaultContainer 'maven'
+      yaml """
+metadata:
+  labels:
+    some-label: some-label-value
+    class: KubernetesDeclarativeAgentTest
+spec:
+  containers:
+  - name: jnlp
+    env:
+    - name: CONTAINER_ENV_VAR
+      value: jnlp
+  - name: maven
+    image: maven:3.3.9-jdk-8-alpine
+    command:
+    - cat
+    tty: true
+    env:
+    - name: CONTAINER_ENV_VAR
+      value: maven
+"""
+    }
+  }
+
+  stages {
+    stage('Run maven') {
+      steps {
+        sh 'mvn -version'
+        sh "echo Workspace dir is ${pwd()}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
…etes plugin

Declarative pipeline example:
```
pipeline {
  agent {
    kubernetes {
      label 'mypod'
      customWorkspace 'some/other/path'
      defaultContainer 'maven'
      yamlFile 'KubernetesPod.yaml'
    }
  }

  stages {
    stage('Run maven') {
      steps {
            sh "echo Workspace dir is ${pwd()}"
      }
    }
  }
}
```