### PR TITLE
Allow adding jenkins job metadata to the pods using the KubernetesComputer extenion point

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesComputerFactory.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesComputerFactory.java
@@ -1,0 +1,37 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import hudson.ExtensionList;
+import hudson.ExtensionPoint;
+
+/**
+ * A factory of {@link KubernetesComputer} instances.
+ */
+public abstract class KubernetesComputerFactory implements ExtensionPoint {
+    /**
+     * Returns all registered implementations of {@link KubernetesComputerFactory}.
+     * @return all registered implementations of {@link KubernetesComputerFactory}.
+     */
+    public static ExtensionList<KubernetesComputerFactory> all() {
+        return ExtensionList.lookup(KubernetesComputerFactory.class);
+    }
+
+    /**
+     * Returns a new instance of {@link KubernetesComputer}.
+     * @return a new instance of {@link KubernetesComputer}.
+     */
+    public static KubernetesComputer createInstance(KubernetesSlave slave) {
+        for (KubernetesComputerFactory factory: all()) {
+            KubernetesComputer kubernetesComputer = factory.newInstance(slave);
+            if (kubernetesComputer != null) {
+                return kubernetesComputer;
+            }
+        }
+        return new KubernetesComputer(slave);
+    }
+
+    /**
+     * Creates a new instance of {@link KubernetesComputer}.
+     * @return a new instance of {@link KubernetesComputer}.
+     */
+    public abstract KubernetesComputer newInstance(KubernetesSlave slave);
+}

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
@@ -180,7 +180,7 @@ public class KubernetesSlave extends AbstractCloudSlave {
 
     @Override
     public KubernetesComputer createComputer() {
-        return new KubernetesComputer(this);
+        return KubernetesComputerFactory.createInstance(this);
     }
 
     public PodRetention getPodRetention(KubernetesCloud cloud) {


### PR DESCRIPTION
Kubernetes Computer ExtensionPoint

Similar to #238, we would like to add metadata of the running jenkins jobs to
the pods.

Ideally we would like to have the JOB_NAME, BUILD_NUMBER, BUILD_TAG (of which
may or may not be meaningful) available in the pods. Unlike #238, we
would like to use labels not annotations as it is easier to correlate those in
prometheus using the kube_node_labels series.

In our discussions we've realized that the display name of a job may differ
based on the job type and our naming scheme would only hold for certain jobs
and it is difficult to come up with a generic solution (especially keeping in
mind that label values can only use the following chars :[a-z0-9A-Z], dashes
(-), underscores (_), dots (.)).

One of the solutions we can think of is to create an extension point that will
allow different KubernetesComputer implementations.  I've tried to reuse the
implementation in the refactoring of PlanningNode but i also feel that having
multiple providers of KubernetesComputer may lead to ambiguous class
resolution. A better approach could be to manage/activate KubernetesComputer
providers from the plugin configuration.

I can probably work on this further to get at least JOB_NAME and job status in
with the default KubernetesComputer implementation (similar to #238) and focus on the not so
generic requests (BUILD_TAG, BUILD_NUMBER) on a separate plugin that will use
the extension point provided by this change.
