### PR TITLE
Set nodeUsageMode to EXCLUSIVE as default

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -93,7 +93,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
 
     private String nodeSelector;
 
-    private Node.Mode nodeUsageMode;
+    private Node.Mode nodeUsageMode = Node.Mode.EXCLUSIVE;
 
     private String resourceRequestCpu;
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep.java
@@ -54,7 +54,7 @@ public class PodTemplateStep extends Step implements Serializable {
 
     private String serviceAccount;
     private String nodeSelector;
-    private Node.Mode nodeUsageMode;
+    private Node.Mode nodeUsageMode = Node.Mode.EXCLUSIVE;
     private String workingDir = ContainerTemplate.DEFAULT_WORKING_DIR;
 
     private String yaml;

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep.java
@@ -196,7 +196,6 @@ public class PodTemplateStep extends Step implements Serializable {
         return nodeUsageMode;
     }
 
-    @DataBoundSetter
     public void setNodeUsageMode(Node.Mode nodeUsageMode) {
         this.nodeUsageMode = nodeUsageMode;
     }
@@ -205,7 +204,7 @@ public class PodTemplateStep extends Step implements Serializable {
     public void setNodeUsageMode(String nodeUsageMode) {
         this.nodeUsageMode = Node.Mode.valueOf(nodeUsageMode);
     }
-    
+
     public String getWorkingDir() {
         return workingDir;
     }

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
@@ -17,12 +17,8 @@
     <f:textbox/>
   </f:entry>
 
-  <f:entry title="${%Usage}" help="/help/system-config/master-slave/usage.html">
-    <select class="setting-input" name="nodeUsageMode">
-      <j:forEach var="m" items="${h.getNodeModes()}">
-        <f:option value="${m.name}" selected="${m==instance.nodeUsageMode}">${m.description}</f:option>
-      </j:forEach>
-    </select>
+  <f:entry field="nodeUsageMode" title="${%Usage}" help="/help/system-config/master-slave/usage.html">
+     <f:enum>${it.description}</f:enum>
   </f:entry>
 
   <f:entry field="inheritFrom" title="${%Pod template to inherit from}"

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
@@ -18,7 +18,7 @@
   </f:entry>
 
   <f:entry field="nodeUsageMode" title="${%Usage}" help="/help/system-config/master-slave/usage.html">
-     <f:enum>${it.description}</f:enum>
+     <f:enum default="EXCLUSIVE">${it.description}</f:enum>
   </f:entry>
 
   <f:entry field="inheritFrom" title="${%Pod template to inherit from}"

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep/config.jelly
@@ -18,6 +18,9 @@
     <f:textbox/>
   </f:entry>
 
+  <f:entry field="nodeUsageMode" title="${%Usage}" help="/help/system-config/master-slave/usage.html">
+     <f:enum>${it.description}</f:enum>
+  </f:entry>
 
   <f:entry field="inheritFrom" title="${%Pod template to inherit from}"
     help="/plugin/kubernetes/help/inheritFrom.html">
@@ -38,6 +41,11 @@
     field="annotations" help="/plugin/kubernetes/help/annotations.html">
     <f:repeatableHeteroProperty field="annotations" hasHeader="true" addCaption="Add Annotation"
                                 deleteCaption="Delete Annotation" />
+  </f:entry>
+
+  <f:entry field="yaml" title="${%Raw yaml for the Pod}"
+    help="/plugin/kubernetes/help/yaml.html">
+    <f:textarea/>
   </f:entry>
 
   <f:advanced>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep/config.jelly
@@ -19,7 +19,7 @@
   </f:entry>
 
   <f:entry field="nodeUsageMode" title="${%Usage}" help="/help/system-config/master-slave/usage.html">
-     <f:enum>${it.description}</f:enum>
+     <f:enum default="EXCLUSIVE">${it.description}</f:enum>
   </f:entry>
 
   <f:entry field="inheritFrom" title="${%Pod template to inherit from}"


### PR DESCRIPTION
This is an attempt to give "nodeUsageMode" more visibility, due to a "race-condition" discovered while this was set to its default value "NORMAL" (other jobs "stealing" the pod from a job).

PS: Having `@DataBoundSetter` on two overloads of the same method seems to confuse the snippet generator... Switching the order of those cases fixed it for me... (Maybe removing the non-String version is the "correct" fix, but might break backwards compatibility)