### PR TITLE
populate jnlp tunnel in the jnlp endpoint

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
@@ -472,7 +472,7 @@ public class KubernetesSlave extends AbstractCloudSlave {
                     nodeDescription == null ? podTemplate.getName() : nodeDescription,
                     cloud.name,
                     label == null ? podTemplate.getLabel() : label,
-                    computerLauncher == null ? new KubernetesLauncher() : computerLauncher,
+                    computerLauncher == null ? new KubernetesLauncher(cloud.getJenkinsTunnel(), null) : computerLauncher,
                     retentionStrategy == null ? determineRetentionStrategy() : retentionStrategy);
         }
     }


### PR DESCRIPTION
Hi Maintainers
this fix will add missing -tunnel option at
$JENKINS_URL/computer/$JENKINS_NAME/slave-agent.jnlp endpoint

This will make possible to use command to launch agent independent whether jenkins is behind load balancer or not 