### PR TITLE
Write env variables to container in single write

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -25,6 +25,7 @@ import java.io.InterruptedIOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.Serializable;
+import java.lang.StringBuilder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -396,19 +397,23 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
             }
 
             private void setupEnvironmentVariable(EnvVars vars, ExecWatch watch) throws IOException {
+                StringBuilder envVars = new StringBuilder();
                 for (Map.Entry<String, String> entry : vars.entrySet()) {
                     //Check that key is bash compliant.
                     if (entry.getKey().matches("[a-zA-Z_][a-zA-Z0-9_]*")) {
-                            watch.getInput().write(
-                                    String.format(
-                                            "export %s='%s'%s",
-                                            entry.getKey(),
-                                            entry.getValue().replace("'", "'\\''"),
-                                            NEWLINE
-                                    ).getBytes(StandardCharsets.UTF_8)
-                            );
-                        }
+                        envVars.append(String.format(
+                            "%s='%s' ",
+                            entry.getKey(),
+                            entry.getValue().replace("'", "'\\''")
+                        ));
                     }
+                }
+                
+                if(envVars.Length > 0) {
+                    watch.getInput().write(
+                        String.format("export %s%s", envVars.toString(), NEWLINE).getBytes(StandardCharsets.UTF_8)
+                    );
+                }
             }
 
             private void waitUntilContainerIsReady() throws IOException {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -409,9 +409,9 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
                     }
                 }
                 
-                if(envVars.Length > 0) {
+                if(envVars.length() > 0) {
                     watch.getInput().write(
-                        String.format("export %s%s", envVars.toString(), NEWLINE).getBytes(StandardCharsets.UTF_8)
+                        envVars.insert(0, "export ").append(NEWLINE).toString().getBytes(StandardCharsets.UTF_8)
                     );
                 }
             }


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-50429. Address base performance of shell commands running in a container.

Use a String Builder to build a shell command exporting all env variables at once.

Instead of:

```
input.write("export FOO=bar\n")
input.write("export BAR=baz\n")
```

It will call:

```
input.write("export FOO=bar BAR=baz\n")
```