### PR TITLE
[FIXES JENKINS-52593] upgrade kubernetes-client to version 4.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-client</artifactId>
-      <version>4.0.0</version>
+      <version>4.1.0</version>
       <exclusions>
         <!-- Jackson logic comes from plugins -->
         <exclusion>


### PR DESCRIPTION
Upgrading the kubernetes client library to version 4.1.0 enables the use of external authenticator tools such as aws-iam-authenticator in the kubeconfig file. The fix is described [here](https://github.com/fabric8io/kubernetes-client/pull/1224).