### PR TITLE
Parametrize how long to wait for pod to be running

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -79,6 +79,7 @@ import jenkins.model.JenkinsLocationConfiguration;
  */
 public class KubernetesCloud extends Cloud {
     public static final int DEFAULT_MAX_REQUESTS_PER_HOST = 32;
+    public static final Integer DEFAULT_WAIT_FOR_POD_SEC = 600;
 
     private static final Logger LOGGER = Logger.getLogger(KubernetesCloud.class.getName());
 
@@ -117,6 +118,10 @@ public class KubernetesCloud extends Cloud {
     private boolean usageRestricted;
 
     private int maxRequestsPerHost;
+
+    // Integer to differentiate null from 0
+    private Integer waitForPodSec;
+
     @CheckForNull
     private PodRetention podRetention = PodRetention.getKubernetesCloudDefault();
 
@@ -150,6 +155,7 @@ public class KubernetesCloud extends Cloud {
         this.usageRestricted = source.usageRestricted;
         this.maxRequestsPerHost = source.maxRequestsPerHost;
         this.podRetention = source.podRetention;
+        this.waitForPodSec = source.waitForPodSec;
     }
 
     @Deprecated
@@ -633,12 +639,22 @@ public class KubernetesCloud extends Cloud {
                 Objects.equals(jenkinsTunnel, that.jenkinsTunnel) &&
                 Objects.equals(credentialsId, that.credentialsId) &&
                 Objects.equals(labels, that.labels) &&
-                Objects.equals(podRetention, that.podRetention);
+                Objects.equals(podRetention, that.podRetention) &&
+                Objects.equals(waitForPodSec, that.waitForPodSec);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(defaultsProviderTemplate, templates, serverUrl, serverCertificate, skipTlsVerify, addMasterProxyEnvVars, capOnlyOnAlivePods, namespace, jenkinsUrl, jenkinsTunnel, credentialsId, containerCap, retentionTimeout, connectTimeout, readTimeout, labels, usageRestricted, maxRequestsPerHost, podRetention);
+    }
+
+        public Integer getWaitForPodSec() {
+        return waitForPodSec;
+    }
+
+    @DataBoundSetter
+    public void setWaitForPodSec(Integer waitForPodSec) {
+        this.waitForPodSec = waitForPodSec;
     }
 
     @Extension
@@ -758,6 +774,10 @@ public class KubernetesCloud extends Cloud {
         if (podRetention == null) {
             podRetention = PodRetention.getKubernetesCloudDefault();
         }
+        if (waitForPodSec == null) {
+            waitForPodSec = DEFAULT_WAIT_FOR_POD_SEC;
+        }
+
         return this;
     }
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -120,7 +120,7 @@ public class KubernetesCloud extends Cloud {
     private int maxRequestsPerHost;
 
     // Integer to differentiate null from 0
-    private Integer waitForPodSec;
+    private Integer waitForPodSec = DEFAULT_WAIT_FOR_POD_SEC;
 
     @CheckForNull
     private PodRetention podRetention = PodRetention.getKubernetesCloudDefault();
@@ -648,7 +648,7 @@ public class KubernetesCloud extends Cloud {
         return Objects.hash(defaultsProviderTemplate, templates, serverUrl, serverCertificate, skipTlsVerify, addMasterProxyEnvVars, capOnlyOnAlivePods, namespace, jenkinsUrl, jenkinsTunnel, credentialsId, containerCap, retentionTimeout, connectTimeout, readTimeout, labels, usageRestricted, maxRequestsPerHost, podRetention);
     }
 
-        public Integer getWaitForPodSec() {
+    public Integer getWaitForPodSec() {
         return waitForPodSec;
     }
 

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/config.jelly
@@ -54,6 +54,10 @@
         <f:textbox default="32" checkMethod="post"/>
     </f:entry>
 
+    <f:entry title="Seconds to wait for pod to be running" field="waitForPodSec">
+        <f:number clazz="required number" min="0" step="1" default="600"/>
+    </f:entry>
+
     <f:advanced>
       <f:entry title="${%Container Cleanup Timeout (minutes)}" field="retentionTimeout">
         <f:textbox default="5"/>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/help-waitForPodSec.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/help-waitForPodSec.html
@@ -1,0 +1,3 @@
+<div>
+    How long to wait (seconds) for pod to be in running state.
+</div>

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest.java
@@ -81,6 +81,7 @@ public class KubernetesTest {
         assertEquals(new Never(), cloud.getPodRetention());
         PodTemplate template = templates.get(0);
         assertEquals(new Default(), template.getPodRetention());
+        assertEquals(cloud.DEFAULT_WAIT_FOR_POD_SEC, cloud.getWaitForPodSec());
     }
 
     @Test
@@ -95,6 +96,7 @@ public class KubernetesTest {
         StringCredentialsImpl cred2 = (StringCredentialsImpl) credentials.get(2);
         assertEquals("mytoken", Secret.toString(cred2.getSecret()));
         assertThat(cloud.getLabels(), hasEntry("jenkins", "slave"));
+        assertEquals(cloud.DEFAULT_WAIT_FOR_POD_SEC, cloud.getWaitForPodSec());
     }
 
     @Test
@@ -104,6 +106,7 @@ public class KubernetesTest {
         assertPodTemplates(templates);
         assertEquals(Arrays.asList(new KeyValueEnvVar("pod_a_key", "pod_a_value"),
                 new KeyValueEnvVar("pod_b_key", "pod_b_value")), templates.get(0).getEnvVars());
+        assertEquals(cloud.DEFAULT_WAIT_FOR_POD_SEC, cloud.getWaitForPodSec());
     }
 
     @Test
@@ -119,6 +122,7 @@ public class KubernetesTest {
         assertEquals("Default", location.getName());
         assertEquals("/custom/path", location.getHome());
         assertEquals(GitTool.class, location.getType().clazz);
+        assertEquals(cloud.DEFAULT_WAIT_FOR_POD_SEC, cloud.getWaitForPodSec());
     }
 
     @Test
@@ -126,6 +130,7 @@ public class KubernetesTest {
     public void upgradeFrom_0_8() throws Exception {
         List<PodTemplate> templates = cloud.getTemplates();
         assertPodTemplates(templates);
+        assertEquals(cloud.DEFAULT_WAIT_FOR_POD_SEC, cloud.getWaitForPodSec());
     }
 
     private void assertPodTemplates(List<PodTemplate> templates) {


### PR DESCRIPTION
Allow users to modify how many times we will try to reconnect to the pod
and how much time to sleep between each reconnect attempt. In cases
where the Kubernetes cluster is under high load, we might want to reduce
the amount of API calls.

Signed-off-by: Daniel Belenky <daniel.belenky@gmail.com>