### PR TITLE
Parametrize wait for pod to be scheduled

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -78,6 +78,7 @@ import jenkins.model.JenkinsLocationConfiguration;
  */
 public class KubernetesCloud extends Cloud {
     public static final int DEFAULT_MAX_REQUESTS_PER_HOST = 32;
+    public static final Integer DEFAULT_WAIT_FOR_POD_SEC = 600;
 
     private static final Logger LOGGER = Logger.getLogger(KubernetesCloud.class.getName());
 
@@ -116,6 +117,10 @@ public class KubernetesCloud extends Cloud {
     private boolean usageRestricted;
 
     private int maxRequestsPerHost;
+
+    // Integer to differentiate null from 0
+    private Integer waitForPodSec;
+
     @CheckForNull
     private PodRetention podRetention = PodRetention.getKubernetesCloudDefault();
 
@@ -148,6 +153,7 @@ public class KubernetesCloud extends Cloud {
         this.connectTimeout = source.connectTimeout;
         this.usageRestricted = source.usageRestricted;
         this.podRetention = source.podRetention;
+        this.waitForPodSec = source.waitForPodSec;
     }
 
     @Deprecated
@@ -608,6 +614,15 @@ public class KubernetesCloud extends Cloud {
         PodTemplateMap.get().removeTemplate(this, t);
     }
 
+    public Integer getWaitForPodSec() {
+        return waitForPodSec;
+    }
+
+    @DataBoundSetter
+    public void setWaitForPodSec(Integer waitForPodSec) {
+        this.waitForPodSec = waitForPodSec;
+    }
+
     @Extension
     public static class DescriptorImpl extends Descriptor<Cloud> {
         @Override
@@ -725,6 +740,10 @@ public class KubernetesCloud extends Cloud {
         if (podRetention == null) {
             podRetention = PodRetention.getKubernetesCloudDefault();
         }
+        if (waitForPodSec == null) {
+            waitForPodSec = DEFAULT_WAIT_FOR_POD_SEC;
+        }
+
         return this;
     }
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
@@ -110,17 +110,18 @@ public class KubernetesLauncher extends JNLPLauncher {
             // otherwise this method keeps being called multiple times
             List<String> validStates = ImmutableList.of("Running");
 
-            int i = 0;
-            int j = 100; // wait 600 seconds
+            int waitForPodSec = cloud.getWaitForPodSec().intValue();
+            int waitedSec = 0;
 
             List<ContainerStatus> containerStatuses = null;
 
             // wait for Pod to be running
-            for (; i < j; i++) {
-                LOGGER.log(INFO, "Waiting for Pod to be scheduled ({1}/{2}): {0}", new Object[]{podId, i, j});
-                logger.printf("Waiting for Pod to be scheduled (%2$s/%3$s): %1$s%n", podId, i, j);
+            do {
+                LOGGER.log(INFO, "Waiting for Pod to be scheduled ({1}/{2}): {0}",
+                        new Object[]{podId, waitedSec, waitForPodSec});
+                logger.printf("Waiting for Pod to be scheduled (%2$s/%3$s): %1$s%n", podId, waitedSec, waitForPodSec);
 
-                Thread.sleep(6000);
+                Thread.sleep(1000);
                 pod = client.pods().inNamespace(namespace).withName(podId).get();
                 if (pod == null) {
                     throw new IllegalStateException("Pod no longer exists: " + podId);
@@ -163,32 +164,38 @@ public class KubernetesLauncher extends JNLPLauncher {
                 if (validStates.contains(pod.getStatus().getPhase())) {
                     break;
                 }
-            }
+
+                ++waitedSec;
+            } while (waitedSec < waitForPodSec);
             String status = pod.getStatus().getPhase();
             if (!validStates.contains(status)) {
-                throw new IllegalStateException("Container is not running after " + j + " attempts, status: " + status);
+                throw new IllegalStateException(
+                        "Container is not running after " + waitForPodSec + " seconds, status: " + status);
             }
 
-            j = unwrappedTemplate.getSlaveConnectTimeout();
+            int waitForSlaveToConnect = unwrappedTemplate.getSlaveConnectTimeout();
 
             // now wait for agent to be online
             SlaveComputer slaveComputer = slave.getComputer();
             if (slaveComputer == null) {
                 throw new IllegalStateException("Node was deleted, computer is null");
             }
-            for (; i < j; i++) {
+            for (int waitedForSlave = 0; waitedForSlave < waitForSlaveToConnect; waitedForSlave++) {
                 if (slaveComputer.isOnline()) {
                     break;
                 }
-                LOGGER.log(INFO, "Waiting for agent to connect ({1}/{2}): {0}", new Object[]{podId, i, j});
-                logger.printf("Waiting for agent to connect (%2$s/%3$s): %1$s%n", podId, i, j);
+                LOGGER.log(INFO, "Waiting for agent to connect ({1}/{2}): {0}",
+                        new Object[]{podId, waitedForSlave, waitForSlaveToConnect});
+                logger.printf("Waiting for agent to connect (%2$s/%3$s): %1$s%n",
+                        podId, waitedForSlave, waitForSlaveToConnect);
                 Thread.sleep(1000);
             }
             if (!slaveComputer.isOnline()) {
                 if (containerStatuses != null) {
                     logLastLines(containerStatuses, podId, namespace, slave, null, client);
                 }
-                throw new IllegalStateException("Agent is not connected after " + j + " attempts, status: " + status);
+                throw new IllegalStateException(
+                        "Agent is not connected after " + waitForSlaveToConnect + " seconds, status: " + status);
             }
             computer.setAcceptingTasks(true);
         } catch (Throwable ex) {

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/config.jelly
@@ -54,6 +54,10 @@
         <f:textbox default="32"/>
     </f:entry>
 
+    <f:entry title="Seconds to wait for pod to be running" field="waitForPodSec">
+        <f:number clazz="required number" min="0" step="1" default="600"/>
+    </f:entry>
+
     <f:advanced>
       <f:entry title="${%Container Cleanup Timeout (minutes)}" field="retentionTimeout">
         <f:textbox default="5"/>

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest.java
@@ -81,6 +81,7 @@ public class KubernetesTest {
         assertEquals(new Never(), cloud.getPodRetention());
         PodTemplate template = templates.get(0);
         assertEquals(new Default(), template.getPodRetention());
+        assertEquals(cloud.DEFAULT_WAIT_FOR_POD_SEC, cloud.getWaitForPodSec());
     }
 
     @Test
@@ -95,6 +96,7 @@ public class KubernetesTest {
         StringCredentialsImpl cred2 = (StringCredentialsImpl) credentials.get(2);
         assertEquals("mytoken", Secret.toString(cred2.getSecret()));
         assertThat(cloud.getLabels(), hasEntry("jenkins", "slave"));
+        assertEquals(cloud.DEFAULT_WAIT_FOR_POD_SEC, cloud.getWaitForPodSec());
     }
 
     @Test
@@ -104,6 +106,7 @@ public class KubernetesTest {
         assertPodTemplates(templates);
         assertEquals(Arrays.asList(new KeyValueEnvVar("pod_a_key", "pod_a_value"),
                 new KeyValueEnvVar("pod_b_key", "pod_b_value")), templates.get(0).getEnvVars());
+        assertEquals(cloud.DEFAULT_WAIT_FOR_POD_SEC, cloud.getWaitForPodSec());
     }
 
     @Test
@@ -119,6 +122,7 @@ public class KubernetesTest {
         assertEquals("Default", location.getName());
         assertEquals("/custom/path", location.getHome());
         assertEquals(GitTool.class, location.getType().clazz);
+        assertEquals(cloud.DEFAULT_WAIT_FOR_POD_SEC, cloud.getWaitForPodSec());
     }
 
     @Test
@@ -126,6 +130,7 @@ public class KubernetesTest {
     public void upgradeFrom_0_8() throws Exception {
         List<PodTemplate> templates = cloud.getTemplates();
         assertPodTemplates(templates);
+        assertEquals(cloud.DEFAULT_WAIT_FOR_POD_SEC, cloud.getWaitForPodSec());
     }
 
     private void assertPodTemplates(List<PodTemplate> templates) {


### PR DESCRIPTION
Allow users to modify how long we wait for pod to be scheduled. There
are several reasons for this change:

- After pod is being deleted, job that waits for this pod will have to
  wait in the queue again. It means that jobs can get resources out of
  order.
- Reduced time between API call to 1 sec to reduce the load on the
  kubernetes master(s).

Signed-off-by: Daniel Belenky <daniel.belenky@gmail.com>