### PR TITLE
kaniko needs another dir in the path

### DIFF
--- a/examples/kaniko-declarative.groovy
+++ b/examples/kaniko-declarative.groovy
@@ -23,7 +23,7 @@ metadata:
 spec:
   containers:
   - name: kaniko
-    image: gcr.io/kaniko-project/executor:debug
+    image: gcr.io/kaniko-project/executor:debug-539ddefcae3fd6b411a95982a830d987f4214251
     imagePullPolicy: Always
     command:
     - /busybox/cat
@@ -46,7 +46,7 @@ spec:
   stages {
     stage('Build with Kaniko') {
       environment {
-        PATH = "/busybox:$PATH"
+        PATH = "/busybox:/kaniko:$PATH"
       }
       steps {
         git 'https://github.com/jenkinsci/docker-jnlp-slave.git'

--- a/examples/kaniko.groovy
+++ b/examples/kaniko.groovy
@@ -17,7 +17,7 @@ metadata:
 spec:
   containers:
   - name: kaniko
-    image: gcr.io/kaniko-project/executor:debug
+    image: gcr.io/kaniko-project/executor:debug-539ddefcae3fd6b411a95982a830d987f4214251
     imagePullPolicy: Always
     command:
     - /busybox/cat
@@ -41,7 +41,7 @@ spec:
     stage('Build with Kaniko') {
       git 'https://github.com/jenkinsci/docker-jnlp-slave.git'
       container(name: 'kaniko', shell: '/busybox/sh') {
-        withEnv(['PATH+EXTRA=/busybox']) {
+        withEnv(['PATH+EXTRA=/busybox:/kaniko']) {
           sh '''#!/busybox/sh
           /kaniko/executor -f `pwd`/Dockerfile -c `pwd` --insecure-skip-tls-verify --cache=true --destination=mydockerregistry:5000/myorg/myimage
           '''


### PR DESCRIPTION
Lock version to avoid breaking changes in Kaniko, e.g. https://github.com/GoogleContainerTools/kaniko/issues/482