### PR TITLE
[JENKINS-55234] Update parent pom to benefit from new Mockito version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.12</version>
+    <version>3.31</version>
   </parent>
 
   <groupId>org.csanchez.jenkins.plugins</groupId>
@@ -181,7 +181,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.9.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -286,6 +285,11 @@
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>junit</artifactId>
         <version>1.3</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>3.7</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
[Issue](https://issues.jenkins-ci.org/browse/JENKINS-55234)

Updating the parent pom so we can benefit from the Mockito Managed version.

@jenkinsci/java11-support 