### PR TITLE
Use git plugin beta and git client beta - DO NOT MERGE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>apache-httpcomponents-client-4-api</artifactId>
-      <version>4.5.3-2.0</version>
+      <version>4.5.5-3.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkinsci.plugins</groupId>
@@ -159,7 +159,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>scm-api</artifactId>
-      <version>2.2.6</version>
+      <version>2.3.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -188,20 +188,20 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
-      <version>3.7.0</version>
+      <version>4.0.0-beta4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
-      <version>3.7.0</version>
+      <version>4.0.0-beta4</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>scm-api</artifactId>
-      <version>2.2.6</version>
+      <version>2.3.0</version>
       <scope>test</scope>
       <classifier>tests</classifier>
     </dependency>
@@ -251,7 +251,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>git-client</artifactId>
-        <version>2.7.0</version>
+        <version>3.0.0-beta6</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>scm-api</artifactId>
-      <version>2.3.0</version>
+      <version>2.2.6</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -201,7 +201,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>scm-api</artifactId>
-      <version>2.3.0</version>
+      <version>2.2.6</version>
       <scope>test</scope>
       <classifier>tests</classifier>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>scm-api</artifactId>
-      <version>2.2.6</version>
+      <version>2.3.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -201,7 +201,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>scm-api</artifactId>
-      <version>2.2.6</version>
+      <version>2.3.0</version>
       <scope>test</scope>
       <classifier>tests</classifier>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>apache-httpcomponents-client-4-api</artifactId>
-      <version>4.5.3-2.0</version>
+      <version>4.5.5-3.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkinsci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>apache-httpcomponents-client-4-api</artifactId>
-      <version>4.5.3-2.0</version>
+      <version>4.5.5-3.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkinsci.plugins</groupId>
@@ -159,7 +159,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>scm-api</artifactId>
-      <version>2.2.6</version>
+      <version>2.3.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -201,7 +201,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>scm-api</artifactId>
-      <version>2.2.6</version>
+      <version>2.3.0</version>
       <scope>test</scope>
       <classifier>tests</classifier>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -188,13 +188,13 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
-      <version>3.9.1</version>
+      <version>4.0.0-beta4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
-      <version>3.9.1</version>
+      <version>4.0.0-beta4</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
@@ -251,7 +251,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>git-client</artifactId>
-        <version>2.7.5</version>
+        <version>3.0.0-beta6</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>apache-httpcomponents-client-4-api</artifactId>
-      <version>4.5.5-3.0</version>
+      <version>4.5.3-2.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkinsci.plugins</groupId>
@@ -159,7 +159,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>scm-api</artifactId>
-      <version>2.3.0</version>
+      <version>2.2.6</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -201,7 +201,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>scm-api</artifactId>
-      <version>2.3.0</version>
+      <version>2.2.6</version>
       <scope>test</scope>
       <classifier>tests</classifier>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -188,13 +188,13 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
-      <version>4.0.0-beta4</version>
+      <version>3.9.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
-      <version>4.0.0-beta4</version>
+      <version>3.9.1</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
@@ -251,7 +251,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>git-client</artifactId>
-        <version>3.0.0-beta6</version>
+        <version>2.7.5</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>apache-httpcomponents-client-4-api</artifactId>
-      <version>4.5.3-2.0</version>
+      <version>4.5.5-3.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkinsci.plugins</groupId>
@@ -159,7 +159,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>scm-api</artifactId>
-      <version>2.2.6</version>
+      <version>2.3.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -188,20 +188,20 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
-      <version>3.7.0</version>
+      <version>3.9.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
-      <version>3.7.0</version>
+      <version>3.9.1</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>scm-api</artifactId>
-      <version>2.2.6</version>
+      <version>2.3.0</version>
       <scope>test</scope>
       <classifier>tests</classifier>
     </dependency>
@@ -251,7 +251,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>git-client</artifactId>
-        <version>2.7.0</version>
+        <version>2.7.5</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>apache-httpcomponents-client-4-api</artifactId>
-      <version>4.5.5-3.0</version>
+      <version>4.5.3-2.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkinsci.plugins</groupId>
@@ -159,7 +159,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>scm-api</artifactId>
-      <version>2.3.0</version>
+      <version>2.2.6</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -188,20 +188,20 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
-      <version>3.9.1</version>
+      <version>3.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
-      <version>3.9.1</version>
+      <version>3.7.0</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>scm-api</artifactId>
-      <version>2.3.0</version>
+      <version>2.2.6</version>
       <scope>test</scope>
       <classifier>tests</classifier>
     </dependency>
@@ -251,7 +251,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>git-client</artifactId>
-        <version>2.7.5</version>
+        <version>2.7.0</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>apache-httpcomponents-client-4-api</artifactId>
-      <version>4.5.5-3.0</version>
+      <version>4.5.3-2.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkinsci.plugins</groupId>


### PR DESCRIPTION
Update dependency versions to use latest git plugin beta and latest git client plugin beta.

That update required an update of the apache-httpcomponents-client-4-api and the scm-api.

Exploring https://issues.jenkins-ci.org/browse/JENKINS-55387

**DO NOT MERGE**