### PR TITLE
Remove permission check

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesComputer.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesComputer.java
@@ -68,7 +68,6 @@ public class KubernetesComputer extends AbstractCloudComputer<KubernetesSlave> {
 
     @Exported
     public List<Container> getContainers() throws UnrecoverableKeyException, CertificateEncodingException, NoSuchAlgorithmException, KeyStoreException, IOException {
-        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         KubernetesSlave slave = getNode();
         if(slave == null) {
             return new ArrayList<>();
@@ -85,7 +84,6 @@ public class KubernetesComputer extends AbstractCloudComputer<KubernetesSlave> {
 
     @Exported
     public List<Event> getPodEvents() throws UnrecoverableKeyException, CertificateEncodingException, NoSuchAlgorithmException, KeyStoreException, IOException {
-        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
 
         KubernetesSlave slave = getNode();
         if(slave != null) {


### PR DESCRIPTION
Running Python Jenkins get_nodes() calls these 2 functions to
get details of running Kubernetes based nodes.

As get_nodes() can be called with a non administrator Jenkins
user having the admin check was causing a stack trace in the system
log + not returning the Kubernetes node details.

Basically reverts 96a848e87e674a70b11a9aaa0781a24e17bad690

FYI - part of the stack trace
```Jan 22, 2019 2:55:50 PM WARNING org.kohsuke.stapler.export.Property writeBuffered
skipping export of KubernetesComputer name: monitoring-clr6k-73rvh slave: KubernetesSlave name: monitoring-clr6k-73rvh
hudson.security.AccessDeniedException2: svr-jenkins-autoscaler@mergermarket.com is missing the Overall/Administer permission
	at hudson.security.ACL.checkPermission(ACL.java:73)
	at hudson.security.AccessControlled.checkPermission(AccessControlled.java:47)
	at org.csanchez.jenkins.plugins.kubernetes.KubernetesComputer.getContainers(KubernetesComputer.java:62)
	at org.kohsuke.stapler.export.MethodProperty.getValue(MethodProperty.java:72)
```