### PR TITLE
Added missing --cert-type option for certificate check

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,7 +534,7 @@ The client certificate needs to be converted to PKCS, will need a password
 
 Validate that the certificates work
 
-    curl --cacert ~/.minikube/ca.crt --cert ~/.minikube/minikube.pfx:secret https://$(minikube ip):8443
+    curl --cacert ~/.minikube/ca.crt --cert ~/.minikube/minikube.pfx:secret --cert-type P12 https://$(minikube ip):8443
 
 Add a Jenkins credential of type certificate, upload it from `~/.minikube/minikube.pfx`, password `secret`
 


### PR DESCRIPTION
When validate that the certificate works, the --cert-type option is missing.

From the curl man page :
> If --cert-type is missing from the curl command 'PEM' is used by default

but we use a P12 certificate type