### PR TITLE
Use a watcher to monitor pod status while launching the agent

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/AllContainersRunningPodWatcher.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/AllContainersRunningPodWatcher.java
@@ -1,0 +1,142 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import io.fabric8.kubernetes.api.model.ContainerStatus;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodStatus;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.KubernetesClientTimeoutException;
+import io.fabric8.kubernetes.client.Watcher;
+
+/**
+ * A pod watcher reporting when all containers are running
+ */
+public class AllContainersRunningPodWatcher implements Watcher<Pod> {
+    private static final Logger LOGGER = Logger.getLogger(AllContainersRunningPodWatcher.class.getName());
+
+    private final CountDownLatch latch = new CountDownLatch(1);
+    private final AtomicReference<Pod> reference = new AtomicReference<>();
+
+    private Pod pod;
+
+    private KubernetesClient client;
+
+    private PodStatus podStatus;
+
+    public AllContainersRunningPodWatcher(KubernetesClient client, Pod pod) {
+        this.client = client;
+        this.pod = pod;
+        this.podStatus = pod.getStatus();
+        if (areAllContainersRunning(pod)) {
+            reference.set(pod);
+            latch.countDown();
+        }
+    }
+
+    @Override
+    public void eventReceived(Action action, Pod pod) {
+        LOGGER.log(Level.FINEST, "[{0}] {1}", new Object[]{action, pod.getMetadata().getName()});
+        this.podStatus = pod.getStatus();
+        switch (action) {
+            case MODIFIED:
+                if (areAllContainersRunning(pod)) {
+                    LOGGER.log(Level.FINE, "All containers are running for pod {0}", new Object[] {pod.getMetadata().getName()});
+                    reference.set(pod);
+                    latch.countDown();
+                }
+                break;
+            default:
+        }
+    }
+
+    boolean areAllContainersRunning(Pod pod) {
+        boolean allContainersAreReady = true;
+        PodStatus podStatus = pod.getStatus();
+        if (podStatus == null) {
+            return false;
+        }
+        List<ContainerStatus> containerStatuses = pod.getStatus().getContainerStatuses();
+        if (containerStatuses.isEmpty()) {
+            allContainersAreReady = false;
+        }
+        for (ContainerStatus containerStatus : containerStatuses) {
+            if (containerStatus != null) {
+                if (containerStatus.getState().getWaiting() != null) {
+                    allContainersAreReady = false;
+                }
+                if (containerStatus.getState().getTerminated() != null) {
+                    allContainersAreReady = false;
+                }
+                if (!containerStatus.getReady()) {
+                    allContainersAreReady = false;
+                }
+            }
+        }
+        return allContainersAreReady;
+    }
+
+    @Override
+    public void onClose(KubernetesClientException cause) {
+
+    }
+
+    public Pod await(long amount, TimeUnit timeUnit) {
+        long started = System.currentTimeMillis();
+        long alreadySpent = System.currentTimeMillis() - started;
+        long remaining = timeUnit.toMillis(amount) - alreadySpent;
+        if (remaining <= 0) {
+            return periodicAwait(0, System.currentTimeMillis(), 0, 0);
+        }
+        try {
+            return periodicAwait(10, System.currentTimeMillis(), Math.max(remaining / 10, 1000L), remaining);
+        } catch (KubernetesClientTimeoutException e) {
+            // Wrap using the right timeout
+            throw new KubernetesClientTimeoutException(pod, amount, timeUnit);
+        }
+    }
+
+    private Pod awaitWatcher(long amount, TimeUnit timeUnit) {
+        try {
+            if (latch.await(amount, timeUnit)) {
+                return reference.get();
+            }
+            throw new KubernetesClientTimeoutException(pod, amount, timeUnit);
+        } catch (InterruptedException e) {
+            throw new KubernetesClientTimeoutException(pod, amount, timeUnit);
+        }
+    }
+
+    private Pod periodicAwait(int i, long started, long interval, long amount) {
+        Pod pod = client.pods().inNamespace(this.pod.getMetadata().getNamespace())
+                .withName(this.pod.getMetadata().getName()).get();
+        if (pod == null) {
+            throw new IllegalStateException(String.format("Pod is no longer available: %s/%s",
+                    this.pod.getMetadata().getNamespace(), this.pod.getMetadata().getName()));
+        }
+        if (areAllContainersRunning(pod)) {
+            return pod;
+        }
+        try {
+            return awaitWatcher(interval, TimeUnit.MILLISECONDS);
+        } catch (KubernetesClientTimeoutException e) {
+            if (i <= 0) {
+                throw e;
+            }
+        }
+
+        long remaining = (started + amount) - System.currentTimeMillis();
+        long next = Math.max(0, Math.min(remaining, interval));
+        return periodicAwait(i - 1, started, next, amount);
+    }
+
+    public PodStatus getPodStatus() {
+        return podStatus;
+    }
+}

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
@@ -27,38 +27,43 @@ package org.csanchez.jenkins.plugins.kubernetes;
 import static java.util.logging.Level.*;
 
 import java.io.IOException;
-import java.io.PrintStream;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
+import javax.annotation.CheckForNull;
+
+import io.fabric8.kubernetes.client.Watch;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableList;
 
 import hudson.model.TaskListener;
 import hudson.slaves.JNLPLauncher;
 import hudson.slaves.SlaveComputer;
-import io.fabric8.kubernetes.api.model.ContainerStatus;
+
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.dsl.LogWatch;
-import io.fabric8.kubernetes.client.dsl.PrettyLoggable;
 
 /**
  * Launches on Kubernetes the specified {@link KubernetesComputer} instance.
  */
 public class KubernetesLauncher extends JNLPLauncher {
 
+    @CheckForNull
+    private transient AllContainersRunningPodWatcher watcher;
+
     private static final Logger LOGGER = Logger.getLogger(KubernetesLauncher.class.getName());
 
     private boolean launched;
+
+    /**
+     * Provisioning exception if any.
+     */
+    @CheckForNull
+    private transient Throwable problem;
 
     @DataBoundConstructor
     public KubernetesLauncher(String tunnel, String vmargs) {
@@ -76,7 +81,6 @@ public class KubernetesLauncher extends JNLPLauncher {
 
     @Override
     public void launch(SlaveComputer computer, TaskListener listener) {
-        PrintStream logger = listener.getLogger();
 
         if (!(computer instanceof KubernetesComputer)) {
             throw new IllegalArgumentException("This Launcher can be used only with KubernetesComputer");
@@ -93,140 +97,41 @@ public class KubernetesLauncher extends JNLPLauncher {
             return;
         }
 
-        KubernetesCloud cloud = slave.getKubernetesCloud();
-        final PodTemplate unwrappedTemplate = slave.getTemplate();
+        final PodTemplate template = slave.getTemplate();
         try {
-            KubernetesClient client = cloud.connect();
-            Pod pod = getPodTemplate(client, slave, unwrappedTemplate);
+            KubernetesClient client = slave.getKubernetesCloud().connect();
+            Pod pod = template.build(client, slave);
 
             String podId = pod.getMetadata().getName();
 
             String namespace = Arrays.asList( //
-                    pod.getMetadata() != null ? pod.getMetadata().getNamespace() : null,
-                    unwrappedTemplate.getNamespace(), client.getNamespace()) //
+                    pod.getMetadata().getNamespace(),
+                    template.getNamespace(), client.getNamespace()) //
                     .stream().filter(s -> StringUtils.isNotBlank(s)).findFirst().orElse(null);
             slave.setNamespace(namespace);
 
             LOGGER.log(Level.FINE, "Creating Pod: {0} in namespace {1}", new Object[]{podId, namespace});
             pod = client.pods().inNamespace(namespace).create(pod);
             LOGGER.log(INFO, "Created Pod: {0} in namespace {1}", new Object[]{podId, namespace});
-            logger.printf("Created Pod: %s in namespace %s%n", podId, namespace);
-
-            // We need the pod to be running and connected before returning
-            // otherwise this method keeps being called multiple times
-            List<String> validStates = ImmutableList.of("Running");
-
-            int waitForPodSec = cloud.getWaitForPodSec().intValue();
-            int waitedSec = 0;
-
-            List<ContainerStatus> containerStatuses = null;
-
-            // wait for Pod to be running
-            do {
-                LOGGER.log(INFO, "Waiting for Pod to be scheduled ({1}/{2}): {0}",
-                        new Object[]{podId, waitedSec, waitForPodSec});
-                logger.printf("Waiting for Pod to be scheduled (%2$s/%3$s): %1$s%n", podId, waitedSec, waitForPodSec);
-
-                Thread.sleep(1000);
-                ++waitedSec;
-                pod = client.pods().inNamespace(namespace).withName(podId).get();
-                if (pod == null) {
-                    throw new IllegalStateException("Pod no longer exists: " + podId);
-                }
-
-                containerStatuses = pod.getStatus().getContainerStatuses();
-                List<ContainerStatus> terminatedContainers = new ArrayList<>();
-                Boolean allContainersAreReady = true;
-                for (ContainerStatus info : containerStatuses) {
-                    if (info != null) {
-                        if (info.getState().getWaiting() != null) {
-                            // Pod is waiting for some reason
-                            LOGGER.log(INFO, "Container is waiting {0} [{2}]: {1}",
-                                    new Object[]{podId, info.getState().getWaiting(), info.getName()});
-                            logger.printf("Container is waiting %1$s [%3$s]: %2$s%n",
-                                    podId, info.getState().getWaiting(), info.getName());
-                            // break;
-                        }
-                        if (info.getState().getTerminated() != null) {
-                            terminatedContainers.add(info);
-                        } else if (!info.getReady()) {
-                            allContainersAreReady = false;
-                        }
-                    }
-                }
-
-                checkTerminatedContainers(terminatedContainers, podId, namespace, slave, client);
-
-                if (!allContainersAreReady) {
-                    continue;
-                }
-
-                if (validStates.contains(pod.getStatus().getPhase())) {
-                    break;
-                }
-
-            } while (waitedSec < waitForPodSec);
-            String status = pod.getStatus().getPhase();
-            if (!validStates.contains(status)) {
-                throw new IllegalStateException(
-                        "Container is not running after " + waitForPodSec + " seconds, status: " + status);
+            listener.getLogger().printf("Created Pod: %s in namespace %s%n", podId, namespace);
+            String podName = pod.getMetadata().getName();
+            String namespace1 = pod.getMetadata().getNamespace();
+            watcher = new AllContainersRunningPodWatcher(client, pod);
+            try (Watch _ = client.pods().inNamespace(namespace1).withName(podName).watch(watcher)){
+                watcher.await(template.getSlaveConnectTimeout(), TimeUnit.SECONDS);
             }
 
-            int waitForSlaveToConnect = unwrappedTemplate.getSlaveConnectTimeout();
-            int waitedForSlave;
-
-            // now wait for agent to be online
-            SlaveComputer slaveComputer = null;
-            for (waitedForSlave = 0; waitedForSlave < waitForSlaveToConnect; waitedForSlave++) {
-                slaveComputer = slave.getComputer();
-                if (slaveComputer == null) {
-                    throw new IllegalStateException("Node was deleted, computer is null");
-                }
-                if (slaveComputer.isOnline()) {
-                    break;
-                }
-
-                // Check that the pod hasn't failed already
-                pod = client.pods().inNamespace(namespace).withName(podId).get();
-                if (pod == null) {
-                    throw new IllegalStateException("Pod no longer exists: " + podId);
-                }
-                status = pod.getStatus().getPhase();
-                if (!validStates.contains(status)) {
-                    break;
-                }
-
-                containerStatuses = pod.getStatus().getContainerStatuses();
-                List<ContainerStatus> terminatedContainers = new ArrayList<>();
-                for (ContainerStatus info : containerStatuses) {
-                    if (info != null) {
-                        if (info.getState().getTerminated() != null) {
-                            // Container has errored
-                            LOGGER.log(INFO, "Container is terminated {0} [{2}]: {1}",
-                                    new Object[]{podId, info.getState().getTerminated(), info.getName()});
-                            logger.printf("Container is terminated %1$s [%3$s]: %2$s%n",
-                                    podId, info.getState().getTerminated(), info.getName());
-                            terminatedContainers.add(info);
-                        }
-                    }
-                }
-
-                checkTerminatedContainers(terminatedContainers, podId, namespace, slave, client);
-
-                LOGGER.log(INFO, "Waiting for agent to connect ({1}/{2}): {0}",
-                        new Object[]{podId, waitedForSlave, waitForSlaveToConnect});
-                logger.printf("Waiting for agent to connect (%2$s/%3$s): %1$s%n",
-                        podId, waitedForSlave, waitForSlaveToConnect);
-                Thread.sleep(1000);
-            }
-            if (slaveComputer == null || slaveComputer.isOffline()) {
-                logLastLines(containerStatuses, podId, namespace, slave, null, client);
-                throw new IllegalStateException(
-                        "Agent is not connected after " + waitedForSlave + " seconds, status: " + status);
-            }
             computer.setAcceptingTasks(true);
+            launched = true;
+            try {
+                // We need to persist the "launched" setting...
+                slave.save();
+            } catch (IOException e) {
+                LOGGER.log(Level.WARNING, "Could not save() agent: " + e.getMessage(), e);
+            }
         } catch (Throwable ex) {
-            LOGGER.log(Level.WARNING, String.format("Error in provisioning; agent=%s, template=%s", slave, unwrappedTemplate), ex);
+            setProblem(ex);
+            LOGGER.log(Level.WARNING, String.format("Error in provisioning; agent=%s, template=%s", slave, template), ex);
             LOGGER.log(Level.FINER, "Removing Jenkins node: {0}", slave.getNodeName());
             try {
                 slave.terminate();
@@ -235,49 +140,23 @@ public class KubernetesLauncher extends JNLPLauncher {
             }
             throw Throwables.propagate(ex);
         }
-        launched = true;
-        try {
-            // We need to persist the "launched" setting...
-            slave.save();
-        } catch (IOException e) {
-            LOGGER.log(Level.WARNING, "Could not save() agent: " + e.getMessage(), e);
-        }
-    }
-
-    private void checkTerminatedContainers(List<ContainerStatus> terminatedContainers, String podId, String namespace,
-            KubernetesSlave slave, KubernetesClient client) {
-        if (!terminatedContainers.isEmpty()) {
-            Map<String, Integer> errors = terminatedContainers.stream().collect(Collectors
-                    .toMap(ContainerStatus::getName, (info) -> info.getState().getTerminated().getExitCode()));
-
-            // Print the last lines of failed containers
-            logLastLines(terminatedContainers, podId, namespace, slave, errors, client);
-            throw new IllegalStateException("Containers are terminated with exit codes: " + errors);
-        }
-    }
-
-    private Pod getPodTemplate(KubernetesClient client, KubernetesSlave slave, PodTemplate template) {
-        return template == null ? null : template.build(client, slave);
     }
 
     /**
-     * Log the last lines of containers logs
+     * The last problem that occurred, if any.
+     * @return
      */
-    private void logLastLines(List<ContainerStatus> containers, String podId, String namespace, KubernetesSlave slave,
-                              Map<String, Integer> errors, KubernetesClient client) {
-        for (ContainerStatus containerStatus : containers) {
-            String containerName = containerStatus.getName();
-            PrettyLoggable<String, LogWatch> tailingLines = client.pods().inNamespace(namespace)
-                    .withName(podId).inContainer(containerStatus.getName()).tailingLines(30);
-            String log = tailingLines.getLog();
-            if (!StringUtils.isBlank(log)) {
-                String msg = errors != null ? String.format(" exited with error %s", errors.get(containerName))
-                        : "";
-                LOGGER.log(Level.SEVERE,
-                        "Error in provisioning; agent={0}, template={1}. Container {2}{3}. Logs: {4}",
-                        new Object[]{slave, slave.getTemplate(), containerName, msg, tailingLines.getLog()});
-            }
-        }
+    @CheckForNull
+    public Throwable getProblem() {
+        return problem;
+    }
+
+    public void setProblem(@CheckForNull Throwable problem) {
+        this.problem = problem;
+    }
+
+    public AllContainersRunningPodWatcher getWatcher() {
+        return watcher;
     }
 
 }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
@@ -71,6 +71,7 @@ public class KubernetesSlave extends AbstractCloudSlave {
     private final PodTemplate template;
     private transient Set<Queue.Executable> executables = new HashSet<>();
 
+    @Nonnull
     public PodTemplate getTemplate() {
         return template;
     }
@@ -115,7 +116,7 @@ public class KubernetesSlave extends AbstractCloudSlave {
         this(getSlaveName(template), template, nodeDescription, cloudName, labelStr, new KubernetesLauncher(), rs);
     }
 
-    protected KubernetesSlave(String name, PodTemplate template, String nodeDescription, String cloudName, String labelStr,
+    protected KubernetesSlave(String name, @Nonnull PodTemplate template, String nodeDescription, String cloudName, String labelStr,
                            ComputerLauncher computerLauncher, RetentionStrategy rs)
             throws Descriptor.FormException, IOException {
         super(name,


### PR DESCRIPTION
Replaces the active wait by a proper watcher.

Submitting this to get the testing to run.