### PR TITLE
kaniko.groovy fix argument spacing

### DIFF
--- a/examples/kaniko.groovy
+++ b/examples/kaniko.groovy
@@ -43,7 +43,7 @@ spec:
       container(name: 'kaniko', shell: '/busybox/sh') {
         withEnv(['PATH+EXTRA=/busybox:/kaniko']) {
           sh '''#!/busybox/sh
-          /kaniko/executor -f `pwd`/Dockerfile -c `pwd` --insecure-skip-tls-verify --cache=true --destination=mydockerregistry:5000/myorg/myimage
+          /kaniko/executor -f `pwd`/Dockerfile -c `pwd` --insecure --skip-tls-verify --cache=true --destination=mydockerregistry:5000/myorg/myimage
           '''
         }
       }


### PR DESCRIPTION
The kanikos.groovy example had the executor flags --insecure and --skip-tls-verify improperly formatted. 

This attempts to resolve that.  