### PR TITLE
[JENKINS-56155] Allow non-admin to call the methods to ease API usage

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesComputer.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesComputer.java
@@ -70,12 +70,12 @@ public class KubernetesComputer extends AbstractCloudComputer<KubernetesSlave> {
     public List<Container> getContainers() throws UnrecoverableKeyException, CertificateEncodingException, NoSuchAlgorithmException, KeyStoreException, IOException {
         if(!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
             LOGGER.log(Level.FINE, " Computer {0} getContainers, lack of admin permission, returning empty list", this);
-            return new ArrayList<>();
+            return Collections.emptyList();
         }
 
         KubernetesSlave slave = getNode();
         if(slave == null) {
-            return new ArrayList<>();
+            return Collections.emptyList();
         }
 
         KubernetesCloud cloud = slave.getKubernetesCloud();
@@ -91,7 +91,7 @@ public class KubernetesComputer extends AbstractCloudComputer<KubernetesSlave> {
     public List<Event> getPodEvents() throws UnrecoverableKeyException, CertificateEncodingException, NoSuchAlgorithmException, KeyStoreException, IOException {
         if(!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
             LOGGER.log(Level.FINE, " Computer {0} getPodEvents, lack of admin permission, returning empty list", this);
-            return new ArrayList<>();
+            return Collections.emptyList();
         }
 
         KubernetesSlave slave = getNode();

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesComputer.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesComputer.java
@@ -68,7 +68,11 @@ public class KubernetesComputer extends AbstractCloudComputer<KubernetesSlave> {
 
     @Exported
     public List<Container> getContainers() throws UnrecoverableKeyException, CertificateEncodingException, NoSuchAlgorithmException, KeyStoreException, IOException {
-        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+        if(!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+            LOGGER.log(Level.FINE, " Computer {0} getContainers, lack of admin permission, returning empty list", this);
+            return new ArrayList<>();
+        }
+
         KubernetesSlave slave = getNode();
         if(slave == null) {
             return new ArrayList<>();
@@ -85,7 +89,10 @@ public class KubernetesComputer extends AbstractCloudComputer<KubernetesSlave> {
 
     @Exported
     public List<Event> getPodEvents() throws UnrecoverableKeyException, CertificateEncodingException, NoSuchAlgorithmException, KeyStoreException, IOException {
-        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+        if(!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+            LOGGER.log(Level.FINE, " Computer {0} getPodEvents, lack of admin permission, returning empty list", this);
+            return new ArrayList<>();
+        }
 
         KubernetesSlave slave = getNode();
         if(slave != null) {


### PR DESCRIPTION
- no information leakage, just avoid stacktrace

Different approach proposed to improve #419.
See [JENKINS-56155](https://issues.jenkins-ci.org/browse/JENKINS-56155).