### PR TITLE
[JENKINS-55392] Do not close Kubernetes client after containerLog step

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerLogStepExecution.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerLogStepExecution.java
@@ -105,18 +105,12 @@ public class ContainerLogStepExecution extends SynchronousNonBlockingStepExecuti
             logger().println(message);
             LOGGER.log(Level.WARNING, message, e);
             return "";
-        } finally {
-            closeQuietly(getContext(), client);
         }
     }
 
     @Override
     public void stop(Throwable cause) throws Exception {
         LOGGER.log(Level.FINE, "Stopping container log step.");
-        try {
-            super.stop(cause);
-        } finally {
-            closeQuietly(getContext(), client);
-        }
+        super.stop(cause);
     }
 }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerStepExecution.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerStepExecution.java
@@ -107,7 +107,7 @@ public class ContainerStepExecution extends StepExecution {
     @Override
     public void stop(@Nonnull Throwable cause) throws Exception {
         LOGGER.log(Level.FINE, "Stopping container step.");
-        closeQuietly(getContext(), client, decorator);
+        closeQuietly(getContext(), decorator);
     }
 
     private static class ContainerExecCallback extends BodyExecutionCallback.TailCall {


### PR DESCRIPTION
as it is being cached and reused