### PR TITLE
update maven version for compatability

### DIFF
--- a/examples/maven-with-cache.groovy
+++ b/examples/maven-with-cache.groovy
@@ -10,7 +10,7 @@
 def label = "maven-${UUID.randomUUID().toString()}"
 
 podTemplate(label: label, containers: [
-  containerTemplate(name: 'maven', image: 'maven:3.3.9-jdk-8-alpine', ttyEnabled: true, command: 'cat')
+  containerTemplate(name: 'maven', image: 'maven:3.6.0-jdk-8-alpine', ttyEnabled: true, command: 'cat')
   ], volumes: [
   persistentVolumeClaim(mountPath: '/root/.m2/repository', claimName: 'maven-repo', readOnly: false)
   ]) {


### PR DESCRIPTION
Some of the plugins being build expect Maven version 3.5+, else the build fails.
So updating to 3.6.0 as that is the current version, confirmed it builds with this.