### PR TITLE
Feature: Handle Dynamic PVC

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM jenkins/jenkins:lts-alpine
 ARG VERSION=1.14.8
 RUN /usr/local/bin/install-plugins.sh kubernetes:${VERSION}
 
-COPY target/kubernetes.hpi /usr/share/jenkins/ref/plugins/kubernetes.hpi
+# COPY target/kubernetes.hpi /usr/share/jenkins/ref/plugins/kubernetes.hpi
 # RUN curl -o /usr/share/jenkins/ref/plugins/kubernetes.hpi \
 #  http://repo.jenkins-ci.org/snapshots/org/csanchez/jenkins/plugins/kubernetes/0.12/kubernetes-$VERSION.hpi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM jenkins/jenkins:lts-alpine
 ARG VERSION=1.14.8
 RUN /usr/local/bin/install-plugins.sh kubernetes:${VERSION}
 
-# COPY target/kubernetes.hpi /usr/share/jenkins/ref/plugins/kubernetes.hpi
+COPY target/kubernetes.hpi /usr/share/jenkins/ref/plugins/kubernetes.hpi
 # RUN curl -o /usr/share/jenkins/ref/plugins/kubernetes.hpi \
 #  http://repo.jenkins-ci.org/snapshots/org/csanchez/jenkins/plugins/kubernetes/0.12/kubernetes-$VERSION.hpi
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PvcTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PvcTemplate.java
@@ -1,0 +1,148 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import hudson.util.EnumConverter;
+import io.fabric8.kubernetes.api.model.*;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.Stapler;
+
+import java.io.Serializable;
+import java.util.Collections;
+
+
+public class PvcTemplate extends AbstractDescribableImpl<PvcTemplate> implements Serializable {
+
+    private String mountPath;
+    private String claimName;
+    private String storageClass;
+    private Integer storageCapacity;
+    private StorageUnit storageUnit;
+    private AccessMode accessMode;
+
+    @DataBoundConstructor
+    public PvcTemplate(
+            String mountPath, String claimName, String storageClass,
+            Integer storageCapacity, StorageUnit storageUnit, AccessMode accessMode
+    ) {
+        this.mountPath = mountPath;
+        this.claimName = claimName;
+        this.storageClass = storageClass;
+        this.storageCapacity = storageCapacity;
+        this.storageUnit = storageUnit;
+        this.accessMode = accessMode;
+    }
+
+    public static enum StorageUnit {
+        Ei, Pi, Ti, Gi, Mi, Ki;
+
+        public String getName() {
+            return this.name();
+        }
+
+        static {
+            Stapler.CONVERT_UTILS.register(new EnumConverter(), AccessMode.class);
+        }
+    }
+
+    public static enum AccessMode {
+        ReadWriteOnce, ReadOnlyMany, ReadWriteMany;
+
+        public String getName() {
+            return this.name();
+        }
+
+        static {
+            Stapler.CONVERT_UTILS.register(new EnumConverter(), AccessMode.class);
+        }
+    }
+
+    public String getMountPath() {
+        return mountPath;
+    }
+
+    public String getClaimName() {
+        return claimName;
+    }
+
+    public String getStorageClass() {
+        return storageClass;
+    }
+
+    public Integer  getStorageCapacity() {
+        return storageCapacity;
+    }
+
+    public StorageUnit getStorageUnit() {
+        return storageUnit;
+    }
+
+    public String getStorageRequest() {
+        return String.format("%d%s", getStorageCapacity(), getStorageUnit());
+    }
+
+    public AccessMode getAccessMode() {
+        return accessMode;
+    }
+
+    public PersistentVolumeClaim buildPVC(String claimName) {
+        return new PersistentVolumeClaimBuilder()
+            // metadata
+            .withNewMetadata()
+                .withName(getClaimName() + "-" + claimName + "-pvc")
+            .endMetadata()
+            // spec
+            .withNewSpec()
+                .withAccessModes(getAccessMode().getName())
+                .withStorageClassName(getStorageClass())
+                .withNewResources()
+                    .withRequests(
+                            Collections.singletonMap("storage", new Quantity(getStorageRequest()))
+                    )
+                .endResources()
+            .endSpec()
+            .build();
+    }
+
+    public Volume buildVolume(String volumeName) {
+        return new VolumeBuilder()
+                .withName(volumeName)
+                .withNewPersistentVolumeClaim(getClaimName() + "-" + volumeName + "-pvc", false)
+                .build();
+    }
+
+    @Extension
+    @Symbol("pvcTemplate")
+    public static class DescriptorImpl extends Descriptor<PvcTemplate> {
+        @Override
+        public String getDisplayName() {
+            return "Persistent Volume Claim Template";
+        }
+    }
+}

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
@@ -36,6 +36,16 @@
                                     deleteCaption="${%Delete Environment Variable}" />
   </f:entry>
 
+  <f:entry
+      title="${%Dynamic PVC}"
+      description="${%PVC that will be created for an agent and teardown with it}">
+      <f:repeatableHeteroProperty
+        field="pvcTemplates"
+        hasHeader="true"
+        addCaption="${%Add Dynamic PVC}"
+        deleteCaption="${%Delete Dynamic PVC}" />
+  </f:entry>
+
   <f:entry title="${%Volumes}" description="${%List of volumes to mount in agent pod}">
     <f:repeatableHeteroProperty field="volumes" hasHeader="true" addCaption="${%Add Volume}"
                                 deleteCaption="${%Delete Volume}" />

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PvcTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PvcTemplate/config.jelly
@@ -1,0 +1,33 @@
+<?jelly escape-by-default='true'?>
+<j:jelly
+        xmlns:j="jelly:core"
+        xmlns:st="jelly:stapler"
+        xmlns:d="jelly:define"
+        xmlns:l="/lib/layout"
+        xmlns:t="/lib/hudson"
+        xmlns:f="/lib/form">
+
+  <f:entry title="${%Base claim Name}" field="claimName">
+    <f:textbox />
+  </f:entry>
+
+  <f:entry title="${%Storage Class}" field="storageClass">
+    <f:textbox />
+  </f:entry>
+
+  <f:entry field="accessMode" title="${%Access mode}">
+     <f:enum default="ReadWriteOnce">${it.name}</f:enum>
+  </f:entry>
+  <f:entry title="${%Capacity}" field="storageCapacity">
+    <f:number clazz="required number" min="0" step="1" default="50"/>
+  </f:entry>
+
+  <f:entry title="${%Unit}" field="storageUnit">
+    <f:enum default="Gi">${it.name}</f:enum>
+  </f:entry>
+
+  <f:entry title="${%Mount path}" field="mountPath">
+    <f:textbox />
+  </f:entry>
+
+</j:jelly>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PvcTemplate/config_zh_CN.properties
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PvcTemplate/config_zh_CN.properties
@@ -1,0 +1,25 @@
+# The MIT License
+#
+# Copyright (c) 2018, Alauda
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Claim\ Name=\u7533\u660E\u503C
+Read\ Only=\u53EA\u8BFB
+Mount\ path=\u6302\u8F7D\u8DEF\u5F84

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PvcTemplate/help-accessMode.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PvcTemplate/help-accessMode.html
@@ -1,0 +1,1 @@
+Access mode for the persistent volume

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PvcTemplate/help-claimName.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PvcTemplate/help-claimName.html
@@ -1,0 +1,1 @@
+Base for the claimName generation

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PvcTemplate/help-mountPath.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PvcTemplate/help-mountPath.html
@@ -1,0 +1,1 @@
+Path to mount this volume inside the pod.

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PvcTemplate/help-storageCapacity.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PvcTemplate/help-storageCapacity.html
@@ -1,0 +1,1 @@
+The claim storage capacity.

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PvcTemplate/help-storageClass.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PvcTemplate/help-storageClass.html
@@ -1,0 +1,1 @@
+The claim storage class.


### PR DESCRIPTION
This PR add the feature to dynamically create pvc for the agents.

This is useful for example when using [dind](https://blog.argoproj.io/storage-considerations-for-docker-in-docker-on-kubernetes-ed928a83331c), as this allows to create a pod with a dynamically managed pvc (and thus volumes) that will be deleted afterwards.

When having to run a job that requires a lot of storage for example.