### PR TITLE
[JENKINS-56544] Don't set build result in Declarative agent blocks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
     <jenkins.version>2.138.4</jenkins.version>
     <no-test-jar>false</no-test-jar>
     <surefire.rerunFailingTestsCount>1</surefire.rerunFailingTestsCount>
+    <pipeline-model-definition.version>1.3.7</pipeline-model-definition.version>
   </properties>
 
   <dependencies>
@@ -107,7 +108,7 @@
     <dependency> <!-- DeclarativeAgent -->
       <groupId>org.jenkinsci.plugins</groupId>
       <artifactId>pipeline-model-extensions</artifactId>
-      <version>1.3.4.1</version>
+      <version>${pipeline-model-definition.version}</version>
       <optional>true</optional>
     </dependency>
 
@@ -165,7 +166,7 @@
     <dependency>
       <groupId>org.jenkinsci.plugins</groupId>
       <artifactId>pipeline-model-definition</artifactId>
-      <version>1.3.4.1</version>
+      <version>${pipeline-model-definition.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgentScript.groovy
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgentScript.groovy
@@ -36,37 +36,32 @@ public class KubernetesDeclarativeAgentScript extends DeclarativeAgentScript<Kub
     @Override
     public Closure run(Closure body) {
         return {
-            try {
-                if ((describable.getYamlFile() != null) && (describable.hasScmContext(script))) {
-                    describable.setYaml(script.readTrusted(describable.getYamlFile()))
-                }
-                script.podTemplate(describable.asArgs) {
-                    script.node(describable.label) {
-                        CheckoutScript.doCheckout(script, describable, describable.customWorkspace) {
-                            // what container to use for the main body
-                            def container = describable.defaultContainer ?: 'jnlp'
+            if ((describable.getYamlFile() != null) && (describable.hasScmContext(script))) {
+                describable.setYaml(script.readTrusted(describable.getYamlFile()))
+            }
+            script.podTemplate(describable.asArgs) {
+                script.node(describable.label) {
+                    CheckoutScript.doCheckout(script, describable, describable.customWorkspace) {
+                        // what container to use for the main body
+                        def container = describable.defaultContainer ?: 'jnlp'
 
-                            if (describable.containerTemplate != null) {
-                                // run inside the container declared for backwards compatibility
-                                container = describable.containerTemplate.asArgs
-                            }
+                        if (describable.containerTemplate != null) {
+                            // run inside the container declared for backwards compatibility
+                            container = describable.containerTemplate.asArgs
+                        }
 
-                            // call the main body
-                            if (container == 'jnlp') {
-                                // If default container is not changed by the pipeline user,
-                                // do not enclose the body with a `container` statement.
+                        // call the main body
+                        if (container == 'jnlp') {
+                            // If default container is not changed by the pipeline user,
+                            // do not enclose the body with a `container` statement.
+                            body.call()
+                        } else {
+                            script.container(container) {
                                 body.call()
-                            } else {
-                                script.container(container) {
-                                    body.call()
-                                }
                             }
-                        }.call()
-                    }
+                        }
+                    }.call()
                 }
-            } catch (Exception e) {
-                script.getProperty("currentBuild").result = Result.FAILURE
-                throw e
             }
         }
     }


### PR DESCRIPTION
Analogous to the fixes in https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/322 ([JENKINS-56544](https://issues.jenkins-ci.org/browse/JENKINS-56544)), since this `DeclarativeAgentScript` has the same problem.

Fixes issues where parallel stages with failFast would cause the build result to be aborted instead of failure in some cases. Easiest to review the [whitespace-reduced diff](https://github.com/jenkinsci/kubernetes-plugin/pull/445/files?w=1) since this just removes a try/catch and de-indents the block. Happy to re-indent to avoid touching the lines if desired.

CC @abayer