### PR TITLE
Fix KubernetesSlave NPE on getting Workspace after Jenkins Master Restart

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
@@ -326,14 +326,14 @@ public class KubernetesSlave extends AbstractCloudSlave {
         KubernetesSlave that = (KubernetesSlave) o;
 
         if (cloudName != null ? !cloudName.equals(that.cloudName) : that.cloudName != null) return false;
-        return template != null ? template.equals(that.template) : that.template == null;
+        return name != null ? name.equals(that.name) : that.name == null;
     }
 
     @Override
     public int hashCode() {
         int result = super.hashCode();
         result = 31 * result + (cloudName != null ? cloudName.hashCode() : 0);
-        result = 31 * result + (template != null ? template.hashCode() : 0);
+        result = 31 * result + (name != null ? name.hashCode() : 0);
         return result;
     }
 


### PR DESCRIPTION
@carlossg Thanks a lot for your work on the kubernetes-plugin, it is greatly appreciated! 🙂 Could you please let me know your thoughts on this? 

How to reproduce the issue

Kubernetes-plugin 1.14.9
Jenkins LTS 2.164.1

* Configure a Kubernetes PodTemplate in the way it stays up after the job finishes (idleMinutes setting)
* Run a Job that uses such Kubernetes PodTemplate to provision an Agent (that should work good)
* Restart Jenkins Master (for instance killing the Jenkins process inside the pod)
* When the Jenkins Master comes back online, the Agent should be able to connect back to it and it is reported as being on-line both from the Agent logs and in the Jenkins master /computer/<agent_name>/
* When running Job that tries to use that agent you should get an error saying:
```
ERROR: Issue with creating launcher for agent <agent name>. Computer has been disconnected
Building remotely on <agent name> (k8s)ERROR: <agent name> seems to be offline
Finished: FAILURE
```
Root cause

[When fetching a Workspace for a Job](https://github.com/jenkinsci/jenkins/blob/jenkins-2.164.1/core/src/main/java/hudson/model/AbstractBuild.java#L447) we get a null value that triggers the aforementioned error. If we go deep on [how Jenkins fetch the Workspace root path for Slaves](https://github.com/jenkinsci/jenkins/blob/jenkins-2.164.1/core/src/main/java/hudson/model/Slave.java#L341), Jenkins [queries a Map with Computers](https://github.com/jenkinsci/jenkins/blob/jenkins-2.164.1/core/src/main/java/hudson/model/AbstractCIBase.java#L176) and KubernetesSlave (Node) is a key for such Map.

When Jenkins restarts and the agent gets reconnected that Map is re-instantiated, the KubernetesSlave instance is one of the keys but it is not equals() and has a different hashCode(). They differ on the template private field given that PodTemplate does not implements an equals()/hashCode().

Proposed Fix

Perhaps it is reasonable to assume that if agents have the same name they are the same independently of the PodTemplate definition. I have changed both equals() and hasCode() for KubernetesSlave in tune with that.

An alternative would be to implement equals()/hashCode() on the PodTemplate, let me know if you would like me to do it that way instead.
