### PR TITLE
[JENKINS-56121] Add option to (not) show raw yaml in console

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -124,6 +124,8 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
 
     private String yaml;
 
+    private boolean showRawYaml;
+
     @CheckForNull
     private PodRetention podRetention = PodRetention.getPodTemplateDefault();
 
@@ -148,6 +150,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
         this.setVolumes(from.getVolumes());
         this.setWorkspaceVolume(from.getWorkspaceVolume());
         this.setYaml(from.getYaml());
+        this.setShowRawYaml(from.isShowRawYaml());
         this.setNodeProperties(from.getNodeProperties());
         this.setPodRetention(from.getPodRetention());
     }
@@ -680,6 +683,15 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
                 getContainersDescriptionForLogging());
     }
 
+    public boolean isShowRawYaml() {
+        return showRawYaml;
+    }
+
+    @DataBoundSetter
+    public void setShowRawYaml(boolean showRawYaml) {
+        this.showRawYaml = showRawYaml;
+    }
+
     private String getContainersDescriptionForLogging() {
         List<ContainerTemplate> containers = getContainers();
         StringBuilder sb = new StringBuilder();
@@ -695,10 +707,10 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
             }
             sb.append("\n");
         }
-        if (StringUtils.isNotBlank(getYaml())) {
+        if (StringUtils.isNotBlank(getYaml()) && isShowRawYaml()) {
             sb.append("yaml:\n")
-                    .append(getYaml())
-                    .append("\n");
+              .append(getYaml())
+              .append("\n");
         }
         return sb.toString();
     }

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
@@ -71,6 +71,10 @@
     <f:textarea/>
   </f:entry>
 
+  <f:entry field="showRawYaml" title="${%Show raw yaml in console}" >
+    <f:checkbox default="true"/>
+  </f:entry>
+
   <f:advanced>
 
     <f:entry title="${%ImagePullSecrets}" description="${%List of image pull secrets}"


### PR DESCRIPTION
[JENKINS-56121](https://issues.jenkins-ci.org/browse/JENKINS-56121)

Since the raw yaml can add quite some noise to the console log, an
option was added to disable it. Default is ShowRawYaml=true, so the
default behavior does not change.