### PR TITLE
Allow Setting Default Mode In Secret Volumes

### DIFF
--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/volumes/SecretVolume/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/volumes/SecretVolume/config.jelly
@@ -10,4 +10,8 @@
     <f:textbox />
   </f:entry>
 
+  <f:entry title="${%Default mode}" field="defaultMode">
+    <f:textbox />
+  </f:entry>
+
 </j:jelly>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/volumes/SecretVolume/help-defaultMode.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/volumes/SecretVolume/help-defaultMode.html
@@ -1,0 +1,1 @@
+The file permissions for the secret volume. Does not support Octal notation.


### PR DESCRIPTION
Addressing [JENKINS-49641](https://issues.jenkins-ci.org/browse/JENKINS-49641)

This change allows you to specify defaultMode for a secretVolume in the podtemplate.

Currently when using SSH private keys in a secret volume, you must specify using YAML in the podTemplate in order to get the correct permissions on the files.

I have tested this it works with and without the defaultMode specified to maintain backwards compatibility.

