### PR TITLE
[JENKINS-56121] Add option to (not) show raw yaml in console

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Either way it provides access to the following fields:
 * **podRetention** Controls the behavior of keeping slave pods. Can be 'never()', 'onFailure()', 'always()', or 'default()' - if empty will default to deleting the pod after `activeDeadlineSeconds` has passed.
 * **activeDeadlineSeconds** If `podRetention` is set to 'never()' or 'onFailure()', pod is deleted after this deadline is passed.
 * **idleMinutes** Allows the Pod to remain active for reuse until the configured number of minutes has passed since the last step was executed on it.
-* **ShowRawYaml** Enable or disable the output of the raw Yaml file. Defaults to `true`
+* **showRawYaml** Enable or disable the output of the raw Yaml file. Defaults to `true`
 
 The `containerTemplate` is a template of container that will be added to the pod. Again, its configurable via the user interface or via pipeline and allows you to set the following fields:
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Either way it provides access to the following fields:
 * **podRetention** Controls the behavior of keeping slave pods. Can be 'never()', 'onFailure()', 'always()', or 'default()' - if empty will default to deleting the pod after `activeDeadlineSeconds` has passed.
 * **activeDeadlineSeconds** If `podRetention` is set to 'never()' or 'onFailure()', pod is deleted after this deadline is passed.
 * **idleMinutes** Allows the Pod to remain active for reuse until the configured number of minutes has passed since the last step was executed on it.
+* **ShowRawYaml** Enable or disable the output of the raw Yaml file. Defaults to `true`
 
 The `containerTemplate` is a template of container that will be added to the pod. Again, its configurable via the user interface or via pipeline and allows you to set the following fields:
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -124,6 +124,8 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
 
     private String yaml;
 
+    private boolean showRawYaml;
+
     @CheckForNull
     private PodRetention podRetention = PodRetention.getPodTemplateDefault();
 
@@ -148,6 +150,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
         this.setVolumes(from.getVolumes());
         this.setWorkspaceVolume(from.getWorkspaceVolume());
         this.setYaml(from.getYaml());
+        this.setShowRawYaml(from.isShowRawYaml());
         this.setNodeProperties(from.getNodeProperties());
         this.setPodRetention(from.getPodRetention());
     }
@@ -680,6 +683,15 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
                 getContainersDescriptionForLogging());
     }
 
+    public boolean isShowRawYaml() {
+        return showRawYaml;
+    }
+
+    @DataBoundSetter
+    public void setShowRawYaml(boolean showRawYaml) {
+        this.showRawYaml = showRawYaml;
+    }
+
     private String getContainersDescriptionForLogging() {
         List<ContainerTemplate> containers = getContainers();
         StringBuilder sb = new StringBuilder();
@@ -695,10 +707,10 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
             }
             sb.append("\n");
         }
-        if (StringUtils.isNotBlank(getYaml())) {
+        if (StringUtils.isNotBlank(getYaml()) && isShowRawYaml()) {
             sb.append("yaml:\n")
-                    .append(getYaml())
-                    .append("\n");
+              .append(getYaml())
+              .append("\n");
         }
         return sb.toString();
     }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -130,7 +130,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
 
     private List<String> yamls;
 
-    private boolean showRawYaml;
+    private Boolean showRawYaml;
 
     @CheckForNull
     private PodRetention podRetention = PodRetention.getPodTemplateDefault();
@@ -708,6 +708,10 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
             yamls.add(yaml);
             yaml = null;
         }
+
+        if (showRawYaml == null) {
+            showRawYaml = Boolean.TRUE;
+        }
         return this;
     }
 
@@ -729,12 +733,12 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
     }
 
     public boolean isShowRawYaml() {
-        return showRawYaml;
+        return showRawYaml == null ? true : showRawYaml.booleanValue();
     }
 
     @DataBoundSetter
     public void setShowRawYaml(boolean showRawYaml) {
-        this.showRawYaml = showRawYaml;
+        this.showRawYaml = Boolean.valueOf(showRawYaml);
     }
 
     private String getContainersDescriptionForLogging() {

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
@@ -71,6 +71,10 @@
     <f:textarea/>
   </f:entry>
 
+  <f:entry field="showRawYaml" title="${%Show raw yaml in console}" >
+    <f:checkbox default="true"/>
+  </f:entry>
+
   <f:advanced>
 
     <f:entry title="${%ImagePullSecrets}" description="${%List of image pull secrets}"

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest.java
@@ -83,6 +83,7 @@ public class KubernetesTest {
         PodTemplate template = templates.get(0);
         assertEquals(new Default(), template.getPodRetention());
         assertEquals(cloud.DEFAULT_WAIT_FOR_POD_SEC, cloud.getWaitForPodSec());
+        assertTrue(template.isShowRawYaml());
     }
 
     @Test


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-56121

Based on https://github.com/jenkinsci/kubernetes-plugin/pull/451 @fredg02

Since the raw yaml can add quite some noise to the console log, an
option was added to disable it. Default is ShowRawYaml=true, so the
default behavior does not change.

