### PR TITLE
fix examples link

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -2,5 +2,5 @@
 
 In this dir you can find several pipeline examples.
 
-For more examples that are continuously tested, check the [`src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline`](src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline)
+For more examples that are continuously tested, check the [`/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline`](/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline)
 resources directory.


### PR DESCRIPTION
The original path does not exist relative to `kubernetes-plugin/examples`.

Absolute path works as expected.

