### PR TITLE
update jackson from 2.9.8 to 2.9.9 CVE-2019-12086

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jackson2-api</artifactId>
-      <version>2.9.8</version>
+      <version>2.9.9</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.9