### PR TITLE
[JENKINS-57827] Fix databinding of ContainerTemplate so DescribableModel.uninstantiate2 works

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
@@ -101,7 +101,6 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
         this.setLivenessProbe(from.getLivenessProbe());
     }
 
-    @DataBoundSetter
     public void setName(String name) {
         this.name = name;
     }
@@ -110,7 +109,6 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
         return name;
     }
 
-    @DataBoundSetter
     public void setImage(String image) {
         this.image = image;
     }


### PR DESCRIPTION
[JENKINS-57827](https://issues.jenkins-ci.org/browse/JENKINS-57827)

You cannot define a property in _both_ `@DataBoundConstructor` _and_ `@DataBoundSetter`.