### PR TITLE
Ensure adding dynamic pod template is thread-safe

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateMap.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateMap.java
@@ -54,13 +54,17 @@ public class PodTemplateMap {
      * @param podTemplate The pod template to add.
      */
     public void addTemplate(@Nonnull KubernetesCloud cloud, @Nonnull PodTemplate podTemplate) {
-        List<PodTemplate> list = getOrCreateTemplateList(cloud);
-        list.add(podTemplate);
-        map.put(cloud.name, list);
+        synchronized (this.map) {
+            List<PodTemplate> list = getOrCreateTemplateList(cloud);
+            list.add(podTemplate);
+            map.put(cloud.name, list);
+        }
     }
 
     public void removeTemplate(@Nonnull KubernetesCloud cloud, @Nonnull PodTemplate podTemplate) {
-        getOrCreateTemplateList(cloud).remove(podTemplate);
+        synchronized (this.map) {
+            getOrCreateTemplateList(cloud).remove(podTemplate);
+        }
     }
 
     @Extension

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateMapTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateMapTest.java
@@ -1,0 +1,57 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import org.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateMap;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+public class PodTemplateMapTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    private PodTemplateMap instance;
+    private KubernetesCloud cloud;
+
+    @Before
+    public void setUp() throws IOException {
+        this.instance = PodTemplateMap.get();
+        this.cloud = new KubernetesCloud("kubernetes");
+        j.jenkins.clouds.add(cloud);
+        j.jenkins.save();
+    }
+
+    @Test
+    public void concurrentAdds() throws Exception {
+        assertEquals(0, this.instance.getTemplates(cloud).size());
+        int n = 10;
+        Thread[] t = new Thread[n];
+        for (int i = 0; i < t.length; i++) {
+            t[i] = newThread(i);
+        }
+        for (int i = 0; i < t.length; i++) {
+            t[i].start();
+        }
+        for (int i = 0; i < t.length; i++) {
+            t[i].join();
+        }
+        assertEquals(n, this.instance.getTemplates(cloud).size());
+    }
+
+    private Thread newThread(int i) {
+        String name = "test-" + i;
+        return new Thread(() -> {
+            instance.addTemplate(cloud, buildPodTemplate(name));
+        }, name);
+    }
+
+    private PodTemplate buildPodTemplate(String label) {
+        PodTemplate podTemplate = new PodTemplate();
+        podTemplate.setLabel(label);
+        return podTemplate;
+    }
+}


### PR DESCRIPTION
- In some situations in a high-load environment where many builds are being triggered, it is possible for 2 templates to be added at same time.
-  The consequence is that only 1 podTemplate is added and the other build is left in a neverending state whereby the console log says:

"Waiting for podABC ..."

- One workaround was to rebuild the build that was hung (which essentially re-adds the podTemplate). This enabled the hung build to become unstuck.