### PR TITLE
No need for timestamps step any more

### DIFF
--- a/Jenkinsfile-kubernetes
+++ b/Jenkinsfile-kubernetes
@@ -11,8 +11,6 @@
 
 def label = UUID.randomUUID().toString()
 
-timestamps {
-
   podTemplate(label: label, yaml: """
 apiVersion: v1
 kind: Pod
@@ -64,5 +62,3 @@ spec:
       }
     }
   }
-
-}


### PR DESCRIPTION
Like in https://github.com/jenkins-infra/pipeline-library/pull/90. I have enabled the global setting on the server running this. But as usual, I have no write access to the repo so this PR build will not verify my change.