### PR TITLE
JENKINS-42763: Make override of HOME configurable

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -101,6 +101,7 @@ public class KubernetesCloud extends Cloud {
 
     private boolean skipTlsVerify;
     private boolean addMasterProxyEnvVars;
+    private Boolean ensureHomeIsValid;
 
     private boolean capOnlyOnAlivePods;
 
@@ -145,6 +146,7 @@ public class KubernetesCloud extends Cloud {
         this.serverUrl = source.serverUrl;
         this.skipTlsVerify = source.skipTlsVerify;
         this.addMasterProxyEnvVars = source.addMasterProxyEnvVars;
+        this.ensureHomeIsValid = source.ensureHomeIsValid;
         this.namespace = source.namespace;
         this.jenkinsUrl = source.jenkinsUrl;
         this.jenkinsTunnel = source.jenkinsTunnel;
@@ -256,6 +258,15 @@ public class KubernetesCloud extends Cloud {
     @DataBoundSetter
     public void setAddMasterProxyEnvVars(boolean addMasterProxyEnvVars) {
     	this.addMasterProxyEnvVars = addMasterProxyEnvVars;
+    }
+
+    public boolean isEnsureHomeIsValid() {
+        return ensureHomeIsValid == null || ensureHomeIsValid;
+    }
+
+    @DataBoundSetter
+    public void setEnsureHomeIsValid(Boolean ensureHomeIsValid) {
+        this.ensureHomeIsValid = ensureHomeIsValid;
     }
 
     public String getNamespace() {
@@ -624,6 +635,7 @@ public class KubernetesCloud extends Cloud {
         KubernetesCloud that = (KubernetesCloud) o;
         return skipTlsVerify == that.skipTlsVerify &&
                 addMasterProxyEnvVars == that.addMasterProxyEnvVars &&
+                ensureHomeIsValid == that.ensureHomeIsValid &&
                 capOnlyOnAlivePods == that.capOnlyOnAlivePods &&
                 containerCap == that.containerCap &&
                 retentionTimeout == that.retentionTimeout &&
@@ -646,7 +658,7 @@ public class KubernetesCloud extends Cloud {
 
     @Override
     public int hashCode() {
-        return Objects.hash(defaultsProviderTemplate, templates, serverUrl, serverCertificate, skipTlsVerify, addMasterProxyEnvVars, capOnlyOnAlivePods, namespace, jenkinsUrl, jenkinsTunnel, credentialsId, containerCap, retentionTimeout, connectTimeout, readTimeout, labels, usageRestricted, maxRequestsPerHost, podRetention);
+        return Objects.hash(defaultsProviderTemplate, templates, serverUrl, serverCertificate, skipTlsVerify, addMasterProxyEnvVars, ensureHomeIsValid, capOnlyOnAlivePods, namespace, jenkinsUrl, jenkinsTunnel, credentialsId, containerCap, retentionTimeout, connectTimeout, readTimeout, labels, usageRestricted, maxRequestsPerHost, podRetention);
     }
 
     public Integer getWaitForPodSec() {
@@ -777,6 +789,10 @@ public class KubernetesCloud extends Cloud {
         }
         if (waitForPodSec == null) {
             waitForPodSec = DEFAULT_WAIT_FOR_POD_SEC;
+        }
+        if (ensureHomeIsValid == null) {
+            // Legacy compatibility (1.16 or older)
+            ensureHomeIsValid = true;
         }
 
         return this;

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -286,12 +286,14 @@ public class PodTemplateBuilder {
                 	env.put("http_proxy", httpProxy);
                 }
             }
-        }
 
-        // Running on OpenShift Enterprise, security concerns force use of arbitrary user ID
-        // As a result, container is running without a home set for user, resulting into using `/` for some tools,
-        // and `?` for java build tools. So we force HOME to a safe location.
-        env.put("HOME", workingDir);
+            if (slave.getKubernetesCloud().isEnsureHomeIsValid()) {
+                // Running on OpenShift Enterprise, security concerns force use of arbitrary user ID
+                // As a result, container is running without a home set for user, resulting into using `/` for some tools,
+                // and `?` for java build tools. So we force HOME to a safe location.
+                env.put("HOME", workingDir);
+            }
+        }
 
         Map<String, EnvVar> envVarsMap = new HashMap<>();
 

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/config.jelly
@@ -67,6 +67,10 @@
         <f:checkbox />
       </f:entry>
 
+      <f:entry title="${%Ensure HOME is valid}" field="ensureHomeIsValid">
+        <f:checkbox />
+      </f:entry>
+
       <f:entry title="${%Restrict pipeline support to authorized folders}" field="usageRestricted">
         <f:checkbox />
       </f:entry>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/help-ensureHomeIsValid.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/help-ensureHomeIsValid.html
@@ -1,0 +1,8 @@
+With this option enabled, the <code>HOME</code> environment variable is set to
+the Jenkins working directory. This is useful for Kubernetes environments,
+where pods are run with arbritary user IDs (for security reasons) which don't
+have an entry in the passwd file of the pod (this seems to be the case in
+OpenShift Enterprise).
+<p>
+For compatibility reasons, this is enabled for systems updated from
+kubernetes-plugin 1.16 or older. It is disabled by default.

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest.java
@@ -87,11 +87,12 @@ public class KubernetesTest {
     }
 
     @Test
-    @LocalData()
+    @LocalData
     public void upgradeFrom_1_10() throws Exception {
         List<PodTemplate> templates = cloud.getTemplates();
         assertPodTemplates(templates);
         assertEquals(new Never(), cloud.getPodRetention());
+        assertTrue(cloud.isEnsureHomeIsValid());
         PodTemplate template = templates.get(0);
         assertEquals(new Default(), template.getPodRetention());
         assertEquals(cloud.DEFAULT_WAIT_FOR_POD_SEC, cloud.getWaitForPodSec());

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
@@ -231,11 +231,10 @@ public class PodTemplateBuilderTest {
 
     private void validateJnlpContainer(Container jnlp, KubernetesSlave slave) {
         assertThat(jnlp.getCommand(), empty());
-        List<EnvVar> envVars = Lists.newArrayList( //
-                new EnvVar("HOME", "/home/jenkins", null) //
-        );
+        List<EnvVar> envVars = Lists.newArrayList();
         if (slave != null) {
             assertThat(jnlp.getArgs(), empty());
+            envVars.add(new EnvVar("HOME", "/home/jenkins", null));
             envVars.add(new EnvVar("JENKINS_URL", JENKINS_URL, null));
             envVars.add(new EnvVar("JENKINS_SECRET", AGENT_SECRET, null));
             envVars.add(new EnvVar("JENKINS_NAME", AGENT_NAME, null));


### PR DESCRIPTION
This is basically a "I'm so annoyed by this, I actually wrote a fix" PR :smiling_imp:

This should fix [JENKINS-42763](https://issues.jenkins-ci.org/browse/JENKINS-42763) by making that
"feature" configurable. Since I consider NOT overwriting the HOME environment variable the correct behaviour, I tried to implement the following features:

- New clouds are created with the option disabled
- When updating old data, the option is enabled, so behaviour is unchanged for existing clouds...

There seems to be one minor behaviour change in a corner case, see test cases.