### PR TITLE
support Docker Host Certificate Authentication type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,6 +234,11 @@
       <version>1.18</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>docker-commons</artifactId>
+      <version>1.14</version>
+    </dependency>
   </dependencies>
 
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -31,6 +31,7 @@ import org.apache.commons.lang.StringUtils;
 import org.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateMap;
 import org.csanchez.jenkins.plugins.kubernetes.pod.retention.Default;
 import org.csanchez.jenkins.plugins.kubernetes.pod.retention.PodRetention;
+import org.jenkinsci.plugins.docker.commons.credentials.DockerServerCredentials;
 import org.jenkinsci.plugins.plaincredentials.FileCredentials;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
@@ -718,7 +719,8 @@ public class KubernetesCloud extends Cloud {
                                     CredentialsMatchers.instanceOf(
                                             org.jenkinsci.plugins.kubernetes.credentials.TokenProducer.class),
                                     CredentialsMatchers.instanceOf(StandardCertificateCredentials.class),
-                                    CredentialsMatchers.instanceOf(StringCredentials.class)), //
+                                    CredentialsMatchers.instanceOf(StringCredentials.class),//
+                                    CredentialsMatchers.instanceOf(DockerServerCredentials.class)),
                             CredentialsProvider.lookupCredentials(StandardCredentials.class, //
                                     Jenkins.getInstance(), //
                                     ACL.SYSTEM, //

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFactoryAdapter.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFactoryAdapter.java
@@ -39,6 +39,7 @@ import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.docker.commons.credentials.DockerServerCredentials;
 import org.jenkinsci.plugins.kubernetes.credentials.TokenProducer;
 import org.jenkinsci.plugins.plaincredentials.FileCredentials;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
@@ -152,6 +153,10 @@ public class KubernetesFactoryAdapter {
             builder.withClientCertData(Base64.encodeBase64String(certificate.getEncoded()))
                     .withClientKeyData(pemEncodeKey(key))
                     .withClientKeyPassphrase(Secret.toString(certificateCredentials.getPassword()));
+        } else if (credentials instanceof DockerServerCredentials) {
+            DockerServerCredentials certificateCredentials = (DockerServerCredentials) credentials;
+            builder.withClientCertData(certificateCredentials.getClientCertificate())
+                    .withClientKeyData(certificateCredentials.getClientKey());
         }
 
         if (skipTlsVerify) {


### PR DESCRIPTION
Currently the kubernetes plugin does not support to list and use a credential type of Docker Host Certificate Authentication.This PR will enable this . Please help check that if it is allowed to be merged. Thanks

Signed-off-by: Shuwei Hao <haoshuwei24@gmail.com>