### PR TITLE
[JENKINS-49717] Hide deprecated credentials type

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/OpenShiftTokenCredentialImpl.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/OpenShiftTokenCredentialImpl.java
@@ -1,5 +1,6 @@
 package org.csanchez.jenkins.plugins.kubernetes;
 
+import com.cloudbees.plugins.credentials.CredentialsProvider;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -38,7 +39,12 @@ public class OpenShiftTokenCredentialImpl extends BaseStandardCredentials implem
 
         @Override
         public String getDisplayName() {
-            return "OpenShift OAuth token";
+            return "OpenShift OAuth token (Deprecated)";
+        }
+
+        @Override
+        public boolean isApplicable(CredentialsProvider provider) {
+            return false;
         }
     }
 


### PR DESCRIPTION
[JENKINS-49717](https://issues.jenkins-ci.org/browse/JENKINS-49717) The "OpenShift OAuth token" is still available when creating new credentials but actually unusable. This fix will hide it from the dropdown when creating new credentials. Existing credentials are still selectable in the Kubernetes Cloud configuration, I believe thanks to the [aliases](https://github.com/jenkinsci/kubernetes-plugin/blob/kubernetes-1.16.3/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java#L671-L678).