### PR TITLE
[JENKINS-42763] Only override HOME if OpenShift

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,13 +52,14 @@
     <pipeline-model-definition.version>1.3.7</pipeline-model-definition.version>
     <workflow-step-api-plugin.version>2.20</workflow-step-api-plugin.version>
     <slf4jVersion>1.7.26</slf4jVersion>
+    <kubernetes-client.version>4.3.0</kubernetes-client.version>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-client</artifactId>
-      <version>4.3.0</version>
+      <version>${kubernetes-client.version}</version>
       <exclusions>
         <!-- Jackson logic comes from plugins -->
         <exclusion>
@@ -70,6 +71,11 @@
           <artifactId>jackson-databind</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>openshift-client</artifactId>
+      <version>${kubernetes-client.version}</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -26,6 +26,7 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.servlet.ServletException;
 
+import io.fabric8.openshift.client.OpenShiftClient;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
 import org.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateMap;
@@ -202,6 +203,17 @@ public class KubernetesCloud extends Cloud {
     @DataBoundSetter
     public void setDefaultsProviderTemplate(String defaultsProviderTemplate) {
         this.defaultsProviderTemplate = defaultsProviderTemplate;
+    }
+
+    public boolean isOpenShift() {
+        try {
+            if (connect().isAdaptable(OpenShiftClient.class)) {
+                return true;
+            }
+        } catch (Exception e) {
+            // ignore
+        }
+        return false;
     }
 
     @Nonnull
@@ -780,7 +792,6 @@ public class KubernetesCloud extends Cloud {
         if (waitForPodSec == null) {
             waitForPodSec = DEFAULT_WAIT_FOR_POD_SEC;
         }
-
         return this;
     }
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -792,6 +792,7 @@ public class KubernetesCloud extends Cloud {
         if (waitForPodSec == null) {
             waitForPodSec = DEFAULT_WAIT_FOR_POD_SEC;
         }
+
         return this;
     }
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
@@ -338,6 +338,7 @@ public class KubernetesSlave extends AbstractCloudSlave {
 
     @Override
     public Launcher createLauncher(TaskListener listener) {
+        Launcher launcher = super.createLauncher(listener);
         if (template != null) {
             Executor executor = Executor.currentExecutor();
             if (executor != null) {
@@ -348,10 +349,27 @@ public class KubernetesSlave extends AbstractCloudSlave {
                             getTemplate().getDisplayName())
                     );
                     listener.getLogger().println(getTemplate().getDescriptionForLogging());
+                    checkHomeAndWarnIfNeeded(listener);
                 }
             }
         }
-        return super.createLauncher(listener);
+        return launcher;
+    }
+
+    private void checkHomeAndWarnIfNeeded(TaskListener listener) {
+        try {
+            Computer computer = toComputer();
+            if (computer != null) {
+                String home = computer.getEnvironment().get("HOME");
+                if ("/".equals(home)) {
+                    listener.getLogger().println(Messages.KubernetesSlave_HomeWarning());
+                }
+            }
+        } catch (IOException e) {
+            e.printStackTrace(listener.error("[WARNING] Unable to retrieve HOME environment variable"));
+        } catch (InterruptedException e) {
+            e.printStackTrace(listener.error("[WARNING] Interrupted while retrieving HOME environment variable"));
+        }
     }
 
     protected Object readResolve() {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
@@ -365,10 +365,8 @@ public class KubernetesSlave extends AbstractCloudSlave {
                     listener.getLogger().println(Messages.KubernetesSlave_HomeWarning());
                 }
             }
-        } catch (IOException e) {
+        } catch (IOException|InterruptedException e) {
             e.printStackTrace(listener.error("[WARNING] Unable to retrieve HOME environment variable"));
-        } catch (InterruptedException e) {
-            e.printStackTrace(listener.error("[WARNING] Interrupted while retrieving HOME environment variable"));
         }
     }
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -286,12 +286,14 @@ public class PodTemplateBuilder {
                 	env.put("http_proxy", httpProxy);
                 }
             }
-        }
 
-        // Running on OpenShift Enterprise, security concerns force use of arbitrary user ID
-        // As a result, container is running without a home set for user, resulting into using `/` for some tools,
-        // and `?` for java build tools. So we force HOME to a safe location.
-        env.put("HOME", workingDir);
+            if (cloud.isOpenShift()) {
+                // Running on OpenShift Enterprise, security concerns force use of arbitrary user ID
+                // As a result, container is running without a home set for user, resulting into using `/` for some tools,
+                // and `?` for java build tools. So we force HOME to a safe location.
+                env.put("HOME", workingDir);
+            }
+        }
 
         Map<String, EnvVar> envVarsMap = new HashMap<>();
 

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/Messages.properties
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/Messages.properties
@@ -4,3 +4,7 @@ KubernetesSlave.AgentIsProvisionedFromTemplate=Agent {0} is provisioned from tem
 RFC1123.error=Container Names MUST match RFC 1123 - They can only contain lowercase letters, numbers or dashes: {0}
 label.error=Labels must follow required specs - https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set: {0}
 KubernetesFolderProperty.displayName=Kubernetes
+KubernetesSlave.HomeWarning=[WARNING] HOME is set to / in the jnlp container. You may encounter \
+    troubles when using tools or ssh client. This usually happens if the uid doesn't have any \
+    entry in /etc/passwd. Please add a user to your Dockerfile or set the HOME environment \
+    variable to a valid directory in the pod template definition.


### PR DESCRIPTION
Alternative to #508

* Only override HOME for OpenShift
* Warn in the build if HOME is set to `/` to allow user to fix either docker image or pod template configuration.