### PR TITLE
Release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,3 @@
+_extends: .github
+tag-template: kubernetes-$NEXT_PATCH_VERSION
+version-template: $MAJOR.$MINOR.$PATCH

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ Known issues
 
 See the full list of issues at [JIRA](https://issues.jenkins-ci.org/issues/?filter=15575)
 
-Unreleased
-----------
+1.16.5 and newer
+------
+
+No longer tracked in this file. See [GitHub releases](https://github.com/jenkinsci/kubernetes-plugin/releases) instead.
 
 1.16.4
 ------


### PR DESCRIPTION
See [usage](https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc#usage). I have enabled the app on the repo. If you merge this, we then need to

* apply appropriate labels (like `bug`) to all PRs merged since 1.16.4
* do the 1.16.5 release
* start using it (first release will need more cleanup, to delete the old entries)