### PR TITLE
[JENKINS-58405] Backward compatibility for yaml field merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Either way it provides access to the following fields:
 * **namespace** The namespace of the pod.
 * **label** The label of the pod. Set a unique value to avoid conflicts across builds
 * **yaml** [yaml representation of the Pod](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#pod-v1-core), to allow setting any values not supported as fields
+* **yamlMergeStrategy** `merge()` or `override()`. Controls whether the yaml definition overrides or is merged with the yaml definition inherited from pod templates declared with `inheritFrom`. Defaults to `override()`.
 * **containers** The container templates that are use to create the containers of the pod *(see below)*.
 * **serviceAccount** The service account of the pod.
 * **nodeSelector** The node selector of the pod.

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -833,15 +833,9 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
 
         @SuppressWarnings("unused") // Used by jelly
         @Restricted(DoNotUse.class) // Used by jelly
-        public Descriptor getDefaultYamlMergeStrategy() {
-            Jenkins jenkins = Jenkins.getInstanceOrNull();
-            if (jenkins == null) {
-                return null;
-            }
-            return jenkins.getDescriptor(YamlMergeStrategy.defaultStrategy().getClass());
+        public YamlMergeStrategy getDefaultYamlMergeStrategy() {
+            return YamlMergeStrategy.defaultStrategy();
         }
-
-
     }
 
     @Override

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -16,6 +16,7 @@ import javax.annotation.Nonnull;
 import org.apache.commons.lang.StringUtils;
 import org.csanchez.jenkins.plugins.kubernetes.model.TemplateEnvVar;
 import org.csanchez.jenkins.plugins.kubernetes.pod.retention.PodRetention;
+import org.csanchez.jenkins.plugins.kubernetes.pod.yaml.YamlMergeStrategy;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.PodVolume;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.workspace.WorkspaceVolume;
 import org.kohsuke.accmod.Restricted;
@@ -128,6 +129,21 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
     private transient String yaml;
 
     private List<String> yamls = new ArrayList<>();
+
+    public YamlMergeStrategy getYamlMergeStrategy() {
+        return yamlMergeStrategy;
+    }
+
+    @DataBoundSetter
+    public void setYamlMergeStrategy(YamlMergeStrategy yamlMergeStrategy) {
+        this.yamlMergeStrategy = yamlMergeStrategy;
+    }
+
+    private YamlMergeStrategy yamlMergeStrategy = YamlMergeStrategy.defaultStrategy();
+
+    public Pod getYamlsPod() {
+        return yamlMergeStrategy.merge(getYamls());
+    }
 
     private Boolean showRawYaml;
 
@@ -718,6 +734,10 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
             showRawYaml = Boolean.TRUE;
         }
 
+        if (yamlMergeStrategy == null) {
+            yamlMergeStrategy = YamlMergeStrategy.defaultStrategy();
+        }
+
         return this;
     }
 
@@ -801,7 +821,8 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
             return DescriptorVisibilityFilter.apply(null, Jenkins.getInstance().getDescriptorList(TemplateEnvVar.class));
         }
 
-        @SuppressWarnings("rawtypes")
+        @SuppressWarnings("unused") // Used by jelly
+        @Restricted(DoNotUse.class) // Used by jelly
         public Descriptor getDefaultPodRetention() {
             Jenkins jenkins = Jenkins.getInstanceOrNull();
             if (jenkins == null) {
@@ -809,6 +830,17 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
             }
             return jenkins.getDescriptor(PodRetention.getPodTemplateDefault().getClass());
         }
+
+        @SuppressWarnings("unused") // Used by jelly
+        @Restricted(DoNotUse.class) // Used by jelly
+        public Descriptor getDefaultYamlMergeStrategy() {
+            Jenkins jenkins = Jenkins.getInstanceOrNull();
+            if (jenkins == null) {
+                return null;
+            }
+            return jenkins.getDescriptor(YamlMergeStrategy.defaultStrategy().getClass());
+        }
+
 
     }
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -198,8 +198,7 @@ public class PodTemplateBuilder {
         builder.withContainers(containers.values().toArray(new Container[containers.size()]));
 
         // merge with the yaml fragments
-        Pod yamlPods = combine(template.getYamls().stream().map(PodTemplateUtils::parseFromYaml).collect(Collectors.toList()));
-        Pod pod = combine(yamlPods, builder.endSpec().build());
+        Pod pod = combine(template.getYamlsPod(), builder.endSpec().build());
 
         // Apply defaults
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
@@ -351,6 +351,7 @@ public class PodTemplateUtils {
         podTemplate.setAnnotations(new ArrayList<>(podAnnotations));
         podTemplate.setNodeProperties(toolLocationNodeProperties);
         podTemplate.setNodeUsageMode(nodeUsageMode);
+        podTemplate.setYamlMergeStrategy(template.getYamlMergeStrategy());
         podTemplate.setInheritFrom(!Strings.isNullOrEmpty(template.getInheritFrom()) ?
                                    template.getInheritFrom() : parent.getInheritFrom());
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep.java
@@ -13,6 +13,7 @@ import org.csanchez.jenkins.plugins.kubernetes.PodAnnotation;
 import org.csanchez.jenkins.plugins.kubernetes.PodTemplate;
 import org.csanchez.jenkins.plugins.kubernetes.model.TemplateEnvVar;
 import org.csanchez.jenkins.plugins.kubernetes.pod.retention.PodRetention;
+import org.csanchez.jenkins.plugins.kubernetes.pod.yaml.YamlMergeStrategy;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.PodVolume;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.workspace.WorkspaceVolume;
 import org.jenkinsci.plugins.workflow.steps.Step;
@@ -58,6 +59,7 @@ public class PodTemplateStep extends Step implements Serializable {
     private String workingDir = ContainerTemplate.DEFAULT_WORKING_DIR;
 
     private String yaml;
+    private YamlMergeStrategy yamlMergeStrategy = YamlMergeStrategy.defaultStrategy();
     private PodRetention podRetention;
 
     @DataBoundConstructor
@@ -120,6 +122,15 @@ public class PodTemplateStep extends Step implements Serializable {
             this.envVars.clear();
             this.envVars.addAll(envVars);
         }
+    }
+
+    public YamlMergeStrategy getYamlMergeStrategy() {
+        return yamlMergeStrategy;
+    }
+
+    @DataBoundSetter
+    public void setYamlMergeStrategy(YamlMergeStrategy yamlMergeStrategy) {
+        this.yamlMergeStrategy = yamlMergeStrategy;
     }
 
     public List<PodVolume> getVolumes() {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
@@ -101,6 +101,7 @@ public class PodTemplateStepExecution extends AbstractStepExecutionImpl {
         newTemplate.setNodeUsageMode(step.getNodeUsageMode());
         newTemplate.setServiceAccount(step.getServiceAccount());
         newTemplate.setAnnotations(step.getAnnotations());
+        newTemplate.setYamlMergeStrategy(step.getYamlMergeStrategy());
         if(run!=null) {
             newTemplate.getAnnotations().add(new PodAnnotation("buildUrl", ((KubernetesCloud)cloud).getJenkinsUrlOrDie()+run.getUrl()));
         }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/yaml/Merge.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/yaml/Merge.java
@@ -1,0 +1,38 @@
+package org.csanchez.jenkins.plugins.kubernetes.pod.yaml;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import io.fabric8.kubernetes.api.model.Pod;
+import org.csanchez.jenkins.plugins.kubernetes.PodTemplateUtils;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
+import java.io.Serializable;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.csanchez.jenkins.plugins.kubernetes.PodTemplateUtils.combine;
+
+public class Merge extends YamlMergeStrategy implements Serializable {
+    private static final long serialVersionUID = 6562610892063268131L;
+
+    @DataBoundConstructor
+    public Merge() {
+    }
+
+    @Override
+    public Pod merge(List<String> yamls) {
+        return combine(yamls.stream().map(PodTemplateUtils::parseFromYaml).collect(Collectors.toList()));
+    }
+
+    @Extension
+    @Symbol("merge")
+    public static class DescriptorImpl extends Descriptor<YamlMergeStrategy> {
+        @Nonnull
+        @Override
+        public String getDisplayName() {
+            return "Merge";
+        }
+    }
+}

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/yaml/Merge.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/yaml/Merge.java
@@ -14,7 +14,7 @@ import java.util.stream.Collectors;
 
 import static org.csanchez.jenkins.plugins.kubernetes.PodTemplateUtils.combine;
 
-public class Merge extends YamlMergeStrategy implements Serializable {
+public class Merge extends YamlMergeStrategy {
     private static final long serialVersionUID = 6562610892063268131L;
 
     @DataBoundConstructor

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/yaml/Merge.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/yaml/Merge.java
@@ -8,7 +8,6 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import javax.annotation.Nonnull;
-import java.io.Serializable;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/yaml/Overrides.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/yaml/Overrides.java
@@ -7,7 +7,6 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import javax.annotation.Nonnull;
-import java.io.Serializable;
 import java.util.List;
 
 import static org.csanchez.jenkins.plugins.kubernetes.PodTemplateUtils.parseFromYaml;

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/yaml/Overrides.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/yaml/Overrides.java
@@ -1,0 +1,40 @@
+package org.csanchez.jenkins.plugins.kubernetes.pod.yaml;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import io.fabric8.kubernetes.api.model.Pod;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
+import java.io.Serializable;
+import java.util.List;
+
+import static org.csanchez.jenkins.plugins.kubernetes.PodTemplateUtils.parseFromYaml;
+
+public class Overrides extends YamlMergeStrategy implements Serializable {
+    private static final long serialVersionUID = 4510341864619338164L;
+
+    @DataBoundConstructor
+    public Overrides() {
+    }
+
+    @Override
+    public Pod merge(List<String> yamls) {
+        if (yamls.isEmpty()) {
+            return null;
+        } else {
+            return parseFromYaml(yamls.get(yamls.size()-1));
+        }
+    }
+
+    @Extension
+    @Symbol("override")
+    public static class DescriptorImpl extends Descriptor<YamlMergeStrategy> {
+        @Nonnull
+        @Override
+        public String getDisplayName() {
+            return "Override";
+        }
+    }
+}

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/yaml/Overrides.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/yaml/Overrides.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 import static org.csanchez.jenkins.plugins.kubernetes.PodTemplateUtils.parseFromYaml;
 
-public class Overrides extends YamlMergeStrategy implements Serializable {
+public class Overrides extends YamlMergeStrategy {
     private static final long serialVersionUID = 4510341864619338164L;
 
     @DataBoundConstructor

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/yaml/YamlMergeStrategy.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/yaml/YamlMergeStrategy.java
@@ -1,0 +1,16 @@
+package org.csanchez.jenkins.plugins.kubernetes.pod.yaml;
+
+import hudson.ExtensionPoint;
+import hudson.model.AbstractDescribableImpl;
+import io.fabric8.kubernetes.api.model.Pod;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+
+public abstract class YamlMergeStrategy extends AbstractDescribableImpl<YamlMergeStrategy> implements ExtensionPoint {
+    public static YamlMergeStrategy defaultStrategy() {
+        return new Overrides();
+    }
+
+    public abstract Pod merge(@Nonnull List<String> yamls);
+}

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/yaml/YamlMergeStrategy.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/yaml/YamlMergeStrategy.java
@@ -5,9 +5,10 @@ import hudson.model.AbstractDescribableImpl;
 import io.fabric8.kubernetes.api.model.Pod;
 
 import javax.annotation.Nonnull;
+import java.io.Serializable;
 import java.util.List;
 
-public abstract class YamlMergeStrategy extends AbstractDescribableImpl<YamlMergeStrategy> implements ExtensionPoint {
+public abstract class YamlMergeStrategy extends AbstractDescribableImpl<YamlMergeStrategy> implements ExtensionPoint, Serializable {
     public static YamlMergeStrategy defaultStrategy() {
         return new Overrides();
     }

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
@@ -71,6 +71,8 @@
     <f:textarea/>
   </f:entry>
 
+  <f:dropdownDescriptorSelector title="${%Yaml merge strategy}" field="yamlMergeStrategy" default="${descriptor.defaultYamlMergeStrategy}" />
+
   <f:entry field="showRawYaml" title="${%Show raw yaml in console}" >
     <f:checkbox default="true"/>
   </f:entry>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/help-yamlMergeStrategy.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/help-yamlMergeStrategy.html
@@ -1,6 +1,1 @@
 Defines how the raw yaml field gets merged with yaml definitions from inherited pod templates.
-
-<ul>
-    <li>Override: The yaml definitions from inherited pod templates are completely overridden by the current yaml field.</li>
-    <li>Merge: The yaml definitions from inherited pod templates are merged with the current template yaml fragment.</li>
-</ul>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/help-yamlMergeStrategy.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/help-yamlMergeStrategy.html
@@ -1,0 +1,6 @@
+Defines how the raw yaml field gets merged with yaml definitions from inherited pod templates.
+
+<ul>
+    <li>Override: The yaml definitions from inherited pod templates are completely overridden by the current yaml field.</li>
+    <li>Merge: The yaml definitions from inherited pod templates are merged with the current template yaml fragment.</li>
+</ul>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pod/yaml/Merge/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pod/yaml/Merge/config.jelly
@@ -1,0 +1,5 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:description>The yaml definitions from inherited pod templates are merged with the current template yaml fragment.</f:description>
+</j:jelly>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pod/yaml/Overrides/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pod/yaml/Overrides/config.jelly
@@ -1,0 +1,5 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:description>The yaml definitions from inherited pod templates are completely overridden by the current yaml field.</f:description>
+</j:jelly>

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
@@ -20,6 +20,8 @@ import java.util.stream.Collectors;
 import org.apache.commons.compress.utils.IOUtils;
 import org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar;
 import org.csanchez.jenkins.plugins.kubernetes.model.TemplateEnvVar;
+import org.csanchez.jenkins.plugins.kubernetes.pod.yaml.Merge;
+import org.csanchez.jenkins.plugins.kubernetes.pod.yaml.YamlMergeStrategy;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.EmptyDirVolume;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.HostPathVolume;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.PodVolume;
@@ -331,6 +333,7 @@ public class PodTemplateBuilderTest {
                 "    - cat\n" +
                 "    tty: true\n"
         );
+        child.setYamlMergeStrategy(merge());
         child.setInheritFrom("parent");
         setupStubs();
         PodTemplate result = combine(parent, child);
@@ -372,6 +375,7 @@ public class PodTemplateBuilderTest {
                 "    tty: true\n"
         );
         child.setInheritFrom("parent");
+        child.setYamlMergeStrategy(merge());
         setupStubs();
         PodTemplate result = combine(parent, child);
         Pod pod = new PodTemplateBuilder(result).withSlave(slave).build();
@@ -380,6 +384,10 @@ public class PodTemplateBuilderTest {
         Optional<Container> container = pod.getSpec().getContainers().stream().filter(c -> "container".equals(c.getName())).findFirst();
         assertTrue(container.isPresent());
         assertEquals("busybox2", container.get().getImage());
+    }
+
+    public YamlMergeStrategy merge() {
+        return new Merge();
     }
 
     @Issue("JENKINS-58374")
@@ -396,6 +404,7 @@ public class PodTemplateBuilderTest {
                 "    - name: VAR2\n" +
                 "      value: \"1\"\n");
         PodTemplate child = new PodTemplate();
+        child.setYamlMergeStrategy(new Merge());
         child.setYaml("kind: Pod\n" +
                 "spec:\n" +
                 "  containers:\n" +
@@ -439,6 +448,7 @@ public class PodTemplateBuilderTest {
                 "      path: /host/data2\n"
         );
         child.setInheritFrom("parent");
+        child.setYamlMergeStrategy(merge());
         setupStubs();
         PodTemplate result = combine(parent, child);
         Pod pod = new PodTemplateBuilder(result).withSlave(slave).build();
@@ -474,6 +484,7 @@ public class PodTemplateBuilderTest {
                 "      path: /host/data2\n"
         );
         child.setInheritFrom("parent");
+        child.setYamlMergeStrategy(merge());
         setupStubs();
         PodTemplate result = combine(parent, child);
         Pod pod = new PodTemplateBuilder(result).withSlave(slave).build();

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
@@ -386,10 +386,6 @@ public class PodTemplateBuilderTest {
         assertEquals("busybox2", container.get().getImage());
     }
 
-    public YamlMergeStrategy merge() {
-        return new Merge();
-    }
-
     @Issue("JENKINS-58374")
     @Test
     public void yamlOverrideContainerEnvvar() throws Exception {
@@ -404,7 +400,7 @@ public class PodTemplateBuilderTest {
                 "    - name: VAR2\n" +
                 "      value: \"1\"\n");
         PodTemplate child = new PodTemplate();
-        child.setYamlMergeStrategy(new Merge());
+        child.setYamlMergeStrategy(merge());
         child.setYaml("kind: Pod\n" +
                 "spec:\n" +
                 "  containers:\n" +
@@ -521,5 +517,9 @@ public class PodTemplateBuilderTest {
 
     private String loadYamlFile(String s) throws IOException {
         return new String(IOUtils.toByteArray(getClass().getResourceAsStream(s)));
+    }
+
+    private YamlMergeStrategy merge() {
+        return new Merge();
     }
 }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
@@ -345,4 +345,16 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
         r.assertBuildStatusSuccess(r.waitForCompletion(b));
         assertTrue(deletePods(cloud.connect(), getLabels(this, name), true));
     }
+
+    @Test
+    @Issue("JENKINS-58405")
+    public void overrideYaml() throws Exception {
+        r.assertBuildStatusSuccess(r.waitForCompletion(b));
+    }
+
+    @Test
+    @Issue("JENKINS-58405")
+    public void mergeYaml() throws Exception {
+        r.assertBuildStatusSuccess(r.waitForCompletion(b));
+    }
 }

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/mergeYaml.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/mergeYaml.groovy
@@ -1,0 +1,22 @@
+podTemplate(label: 'mergeYaml-parent', yaml: """
+spec:
+    containers:
+    - name: jnlp
+    env:
+    - name: VAR1
+      value: 1
+""") {
+    podTemplate(label: 'mergeYaml-child',
+            yamlMergeStrategy: merge(),
+            yaml: """
+    containers:
+    - name: jnlp
+    env:
+    - name: VAR2
+      value: 1
+""") {
+        node('mergeYaml-child'){
+            sh '["$VAR1" == "$VAR2"]'
+        }
+    }
+}

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/overrideYaml.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/overrideYaml.groovy
@@ -1,0 +1,21 @@
+podTemplate(label: 'mergeYaml-parent', yaml: """
+spec:
+    containers:
+    - name: jnlp
+    env:
+    - name: VAR1
+      value: 1
+""") {
+    podTemplate(label: 'mergeYaml-child',
+            yaml: """
+    containers:
+    - name: jnlp
+    env:
+    - name: VAR2
+      value: 1
+""") {
+        node('mergeYaml-child'){
+            sh '["$VAR1" != "$VAR2"]'
+        }
+    }
+}


### PR DESCRIPTION
Added a yamlMergeStrategy field to PodTemplate/PodTemplateStep in order
to control how yaml field is handled across inheritance of pod
templates. Defaults to "override" in order to be backward compatible.