### PR TITLE
Try to address ContainerExecDecoratorTest#testCommandExecution flakiness

### DIFF
--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorTest.java
@@ -81,7 +81,7 @@ public class ContainerExecDecoratorTest {
 
     private KubernetesCloud cloud;
     private static KubernetesClient client;
-    private static final Pattern PID_PATTERN = Pattern.compile("^(pid is \\d+)$", Pattern.MULTILINE);
+    private static final Pattern PID_PATTERN = Pattern.compile("^(\\[\\d+\\] pid is \\d+)$", Pattern.MULTILINE);
 
     private ContainerExecDecorator decorator;
     private Pod pod;
@@ -130,7 +130,7 @@ public class ContainerExecDecoratorTest {
 
     @After
     public void after() throws Exception {
-        deletePods(client, getLabels(this, name), false);
+        deletePods(client, getLabels(this, name), true);
     }
 
     /**
@@ -175,7 +175,7 @@ public class ContainerExecDecoratorTest {
     private void command(List<ProcReturn> results, int i) {
         ProcReturn r;
         try {
-            r = execCommand(false, "sh", "-c", "cd /tmp; echo pid is $$$$ > test; cat /tmp/test");
+            r = execCommand(false, "sh", "-c", "cd /tmp; echo ["+i+"] pid is $$$$ > test; cat /tmp/test");
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorTest.java
@@ -81,7 +81,7 @@ public class ContainerExecDecoratorTest {
 
     private KubernetesCloud cloud;
     private static KubernetesClient client;
-    private static final Pattern PID_PATTERN = Pattern.compile("^(\\[\\d+\\] pid is \\d+)$", Pattern.MULTILINE);
+    private static final Pattern PID_PATTERN = Pattern.compile("^((?:\\[\\d+\\] )?pid is \\d+)$", Pattern.MULTILINE);
 
     private ContainerExecDecorator decorator;
     private Pod pod;
@@ -130,6 +130,7 @@ public class ContainerExecDecoratorTest {
 
     @After
     public void after() throws Exception {
+        client.pods().delete(pod);
         deletePods(client, getLabels(this, name), true);
     }
 


### PR DESCRIPTION
Observed in another PR. There is one failed execution, maybe because the pod clean up is too aggressive.

```
Error Message
Output should contain pid: Executing shell script inside container [busybox] of pod [test-command-execution-w9ddq]
Executing command: "sh" "-c" "cd /tmp; echo pid is \$\$ > test; cat /tmp/test" 
exit
Stacktrace
java.lang.AssertionError: 
Output should contain pid: Executing shell script inside container [busybox] of pod [test-command-execution-w9ddq]
Executing command: "sh" "-c" "cd /tmp; echo pid is \$\$ > test; cat /tmp/test" 
exit

	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.assertTrue(Assert.java:41)
	at org.csanchez.jenkins.plugins.kubernetes.pipeline.ContainerExecDecoratorTest.testCommandExecution(ContainerExecDecoratorTest.java:156)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:298)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:292)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.lang.Thread.run(Thread.java:748)
Standard Output
Created pod: test-command-execution-w9ddq
Executing shell script inside container [busybox] of pod [test-command-execution-w9ddq]
Executing shell script inside container [busybox] of pod [test-command-execution-w9ddq]
Executing shell script inside container [busybox] of pod [test-command-execution-w9ddq]
Executing shell script inside container [busybox] of pod [test-command-execution-w9ddq]
Executing shell script inside container [busybox] of pod [test-command-execution-w9ddq]
Executing shell script inside container [busybox] of pod [test-command-execution-w9ddq]
Executing shell script inside container [busybox] of pod [test-command-execution-w9ddq]
Executing shell script inside container [busybox] of pod [test-command-execution-w9ddq]
Executing shell script inside container [busybox] of pod [test-command-execution-w9ddq]
Executing shell script inside container [busybox] of pod [test-command-execution-w9ddq]
Executing command: "sh" "-c" "cd /tmp; echo pid is \$\$ > test; cat /tmp/test" 
exit
Executing command: "sh" "-c" "cd /tmp; echo pid is \$\$ > test; cat /tmp/test" 
exit
Executing command: "sh" "-c" "cd /tmp; echo pid is \$\$ > test; cat /tmp/test" 
exit
Executing command: "sh" "-c" "cd /tmp; echo pid is \$\$ > test; cat /tmp/test" 
exit
Executing command: "sh" "-c" "cd /tmp; echo pid is \$\$ > test; cat /tmp/test" 
exit
Executing command: "sh" "-c" "cd /tmp; echo pid is \$\$ > test; cat /tmp/test" 
exit
pid is 15
Executing command: "sh" Executing command: "-c" "sh" "cd /tmp; echo pid is \$\$ > test; cat /tmp/test" "-c" 
"cd /tmp; echo pid is \$\$ > test; cat /tmp/test" exit

exit
Executing command: "sh" "-c" "cd /tmp; echo pid is \$\$ > test; cat /tmp/test" 
exit
pid is 23
Executing command: "sh" "-c" "cd /tmp; echo pid is \$\$ > test; cat /tmp/test" 
exit
Thread 9 finished
pid is 31
Thread 8 finished
pid is 39
pid is 47
Thread 6 finished
pid is 55
pid is 63
Thread 1 finished
pid is 78
pid is 85
Thread 0 finished
Thread 3 finished
Thread 2 finished
Thread 7 finished
Thread 4 finished
Thread 5 finished
Standard Error
   0.008 [id=1]	INFO	o.c.j.p.k.KubernetesTestUtil#setupCloud: Using namespace kubernetes-plugin-test for branch PR-552
   0.009 [id=641]	WARNING	i.f.k.c.d.i.WatchConnectionManager$1#onFailure: Exec Failure
java.lang.IllegalStateException: Jenkins.instance is missing. Read the documentation of Jenkins.getInstanceOrNull to see what you are doing wrong.
	at jenkins.model.Jenkins.get(Jenkins.java:769)
	at org.csanchez.jenkins.plugins.kubernetes.pod.retention.Reaper.eventReceived(Reaper.java:114)
	at org.csanchez.jenkins.plugins.kubernetes.pod.retention.Reaper.eventReceived(Reaper.java:48)
	at io.fabric8.kubernetes.client.utils.WatcherToggle.eventReceived(WatcherToggle.java:49)
	at io.fabric8.kubernetes.client.dsl.internal.WatchConnectionManager$1.onMessage(WatchConnectionManager.java:232)
	at okhttp3.internal.ws.RealWebSocket.onReadMessage(RealWebSocket.java:323)
	at okhttp3.internal.ws.WebSocketReader.readMessageFrame(WebSocketReader.java:219)
	at okhttp3.internal.ws.WebSocketReader.processNextFrame(WebSocketReader.java:105)
	at okhttp3.internal.ws.RealWebSocket.loopReader(RealWebSocket.java:274)
	at okhttp3.internal.ws.RealWebSocket$2.onResponse(RealWebSocket.java:214)
	at okhttp3.RealCall$AsyncCall.execute(RealCall.java:206)
	at okhttp3.internal.NamedRunnable.run(NamedRunnable.java:32)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
   0.011 [id=722]	WARNING	i.f.k.c.d.i.WatchConnectionManager$1#onFailure: Exec Failure
java.lang.IllegalStateException: Jenkins.instance is missing. Read the documentation of Jenkins.getInstanceOrNull to see what you are doing wrong.
	at jenkins.model.Jenkins.get(Jenkins.java:769)
	at org.csanchez.jenkins.plugins.kubernetes.pod.retention.Reaper.eventReceived(Reaper.java:114)
	at org.csanchez.jenkins.plugins.kubernetes.pod.retention.Reaper.eventReceived(Reaper.java:48)
	at io.fabric8.kubernetes.client.utils.WatcherToggle.eventReceived(WatcherToggle.java:49)
	at io.fabric8.kubernetes.client.dsl.internal.WatchConnectionManager$1.onMessage(WatchConnectionManager.java:232)
	at okhttp3.internal.ws.RealWebSocket.onReadMessage(RealWebSocket.java:323)
	at okhttp3.internal.ws.WebSocketReader.readMessageFrame(WebSocketReader.java:219)
	at okhttp3.internal.ws.WebSocketReader.processNextFrame(WebSocketReader.java:105)
	at okhttp3.internal.ws.RealWebSocket.loopReader(RealWebSocket.java:274)
	at okhttp3.internal.ws.RealWebSocket$2.onResponse(RealWebSocket.java:214)
	at okhttp3.RealCall$AsyncCall.execute(RealCall.java:206)
	at okhttp3.internal.NamedRunnable.run(NamedRunnable.java:32)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
   0.013 [id=560]	WARNING	i.f.k.c.d.i.WatchConnectionManager$1#onFailure: Exec Failure
java.lang.IllegalStateException: Jenkins.instance is missing. Read the documentation of Jenkins.getInstanceOrNull to see what you are doing wrong.
	at jenkins.model.Jenkins.get(Jenkins.java:769)
	at org.csanchez.jenkins.plugins.kubernetes.pod.retention.Reaper.eventReceived(Reaper.java:114)
	at org.csanchez.jenkins.plugins.kubernetes.pod.retention.Reaper.eventReceived(Reaper.java:48)
	at io.fabric8.kubernetes.client.utils.WatcherToggle.eventReceived(WatcherToggle.java:49)
	at io.fabric8.kubernetes.client.dsl.internal.WatchConnectionManager$1.onMessage(WatchConnectionManager.java:232)
	at okhttp3.internal.ws.RealWebSocket.onReadMessage(RealWebSocket.java:323)
	at okhttp3.internal.ws.WebSocketReader.readMessageFrame(WebSocketReader.java:219)
	at okhttp3.internal.ws.WebSocketReader.processNextFrame(WebSocketReader.java:105)
	at okhttp3.internal.ws.RealWebSocket.loopReader(RealWebSocket.java:274)
	at okhttp3.internal.ws.RealWebSocket$2.onResponse(RealWebSocket.java:214)
	at okhttp3.RealCall$AsyncCall.execute(RealCall.java:206)
	at okhttp3.internal.NamedRunnable.run(NamedRunnable.java:32)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
   0.051 [id=897]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#launch: Launch proc with environment: [aaaaaaaa31=bbbbbbbb, aaaaaaaa32=bbbbbbbb, aaaaaaaa30=bbbbbbbb, aaaaaaaa24=bbbbbbbb, aaaaaaaa25=bbbbbbbb, aaaaaaaa22=bbbbbbbb, aaaaaaaa23=bbbbbbbb, aaaaaaaa28=bbbbbbbb, aaaaaaaa29=bbbbbbbb, aaaaaaaa26=bbbbbbbb, aaaaaaaa27=bbbbbbbb, aaaaaaaa42=bbbbbbbb, aaaaaaaa43=bbbbbbbb, aaaaaaaa40=bbbbbbbb, aaaaaaaa41=bbbbbbbb, aaaaaaaa7=bbbbbbbb, aaaaaaaa6=bbbbbbbb, aaaaaaaa5=bbbbbbbb, aaaaaaaa4=bbbbbbbb, aaaaaaaa3=bbbbbbbb, aaaaaaaa2=bbbbbbbb, aaaaaaaa1=bbbbbbbb, aaaaaaaa0=bbbbbbbb, aaaaaaaa35=bbbbbbbb, aaaaaaaa36=bbbbbbbb, aaaaaaaa33=bbbbbbbb, aaaaaaaa34=bbbbbbbb, aaaaaaaa39=bbbbbbbb, aaaaaaaa9=bbbbbbbb, aaaaaaaa37=bbbbbbbb, aaaaaaaa8=bbbbbbbb, aaaaaaaa38=bbbbbbbb, aaaaaaaa10=bbbbbbbb, aaaaaaaa46=bbbbbbbb, aaaaaaaa47=bbbbbbbb, aaaaaaaa44=bbbbbbbb, aaaaaaaa45=bbbbbbbb, aaaaaaaa48=bbbbbbbb, aaaaaaaa49=bbbbbbbb, aaaaaaaa20=bbbbbbbb, aaaaaaaa21=bbbbbbbb, aaaaaaaa19=bbbbbbbb, aaaaaaaa13=bbbbbbbb, aaaaaaaa14=bbbbbbbb, aaaaaaaa11=bbbbbbbb, aaaaaaaa12=bbbbbbbb, aaaaaaaa17=bbbbbbbb, aaaaaaaa18=bbbbbbbb, aaaaaaaa15=bbbbbbbb, aaaaaaaa16=bbbbbbbb]
   0.052 [id=897]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#waitUntilPodContainersAreReady: Waiting until pod containers are ready: kubernetes-plugin-test/test-command-execution-w9ddq
   0.052 [id=906]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#launch: Launch proc with environment: [aaaaaaaa31=bbbbbbbb, aaaaaaaa32=bbbbbbbb, aaaaaaaa30=bbbbbbbb, aaaaaaaa24=bbbbbbbb, aaaaaaaa25=bbbbbbbb, aaaaaaaa22=bbbbbbbb, aaaaaaaa23=bbbbbbbb, aaaaaaaa28=bbbbbbbb, aaaaaaaa29=bbbbbbbb, aaaaaaaa26=bbbbbbbb, aaaaaaaa27=bbbbbbbb, aaaaaaaa42=bbbbbbbb, aaaaaaaa43=bbbbbbbb, aaaaaaaa40=bbbbbbbb, aaaaaaaa41=bbbbbbbb, aaaaaaaa7=bbbbbbbb, aaaaaaaa6=bbbbbbbb, aaaaaaaa5=bbbbbbbb, aaaaaaaa4=bbbbbbbb, aaaaaaaa3=bbbbbbbb, aaaaaaaa2=bbbbbbbb, aaaaaaaa1=bbbbbbbb, aaaaaaaa0=bbbbbbbb, aaaaaaaa35=bbbbbbbb, aaaaaaaa36=bbbbbbbb, aaaaaaaa33=bbbbbbbb, aaaaaaaa34=bbbbbbbb, aaaaaaaa39=bbbbbbbb, aaaaaaaa9=bbbbbbbb, aaaaaaaa37=bbbbbbbb, aaaaaaaa8=bbbbbbbb, aaaaaaaa38=bbbbbbbb, aaaaaaaa10=bbbbbbbb, aaaaaaaa46=bbbbbbbb, aaaaaaaa47=bbbbbbbb, aaaaaaaa44=bbbbbbbb, aaaaaaaa45=bbbbbbbb, aaaaaaaa48=bbbbbbbb, aaaaaaaa49=bbbbbbbb, aaaaaaaa20=bbbbbbbb, aaaaaaaa21=bbbbbbbb, aaaaaaaa19=bbbbbbbb, aaaaaaaa13=bbbbbbbb, aaaaaaaa14=bbbbbbbb, aaaaaaaa11=bbbbbbbb, aaaaaaaa12=bbbbbbbb, aaaaaaaa17=bbbbbbbb, aaaaaaaa18=bbbbbbbb, aaaaaaaa15=bbbbbbbb, aaaaaaaa16=bbbbbbbb]
   0.053 [id=906]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#waitUntilPodContainersAreReady: Waiting until pod containers are ready: kubernetes-plugin-test/test-command-execution-w9ddq
   0.054 [id=905]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#launch: Launch proc with environment: [aaaaaaaa31=bbbbbbbb, aaaaaaaa32=bbbbbbbb, aaaaaaaa30=bbbbbbbb, aaaaaaaa24=bbbbbbbb, aaaaaaaa25=bbbbbbbb, aaaaaaaa22=bbbbbbbb, aaaaaaaa23=bbbbbbbb, aaaaaaaa28=bbbbbbbb, aaaaaaaa29=bbbbbbbb, aaaaaaaa26=bbbbbbbb, aaaaaaaa27=bbbbbbbb, aaaaaaaa42=bbbbbbbb, aaaaaaaa43=bbbbbbbb, aaaaaaaa40=bbbbbbbb, aaaaaaaa41=bbbbbbbb, aaaaaaaa7=bbbbbbbb, aaaaaaaa6=bbbbbbbb, aaaaaaaa5=bbbbbbbb, aaaaaaaa4=bbbbbbbb, aaaaaaaa3=bbbbbbbb, aaaaaaaa2=bbbbbbbb, aaaaaaaa1=bbbbbbbb, aaaaaaaa0=bbbbbbbb, aaaaaaaa35=bbbbbbbb, aaaaaaaa36=bbbbbbbb, aaaaaaaa33=bbbbbbbb, aaaaaaaa34=bbbbbbbb, aaaaaaaa39=bbbbbbbb, aaaaaaaa9=bbbbbbbb, aaaaaaaa37=bbbbbbbb, aaaaaaaa8=bbbbbbbb, aaaaaaaa38=bbbbbbbb, aaaaaaaa10=bbbbbbbb, aaaaaaaa46=bbbbbbbb, aaaaaaaa47=bbbbbbbb, aaaaaaaa44=bbbbbbbb, aaaaaaaa45=bbbbbbbb, aaaaaaaa48=bbbbbbbb, aaaaaaaa49=bbbbbbbb, aaaaaaaa20=bbbbbbbb, aaaaaaaa21=bbbbbbbb, aaaaaaaa19=bbbbbbbb, aaaaaaaa13=bbbbbbbb, aaaaaaaa14=bbbbbbbb, aaaaaaaa11=bbbbbbbb, aaaaaaaa12=bbbbbbbb, aaaaaaaa17=bbbbbbbb, aaaaaaaa18=bbbbbbbb, aaaaaaaa15=bbbbbbbb, aaaaaaaa16=bbbbbbbb]
   0.054 [id=903]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#launch: Launch proc with environment: [aaaaaaaa31=bbbbbbbb, aaaaaaaa32=bbbbbbbb, aaaaaaaa30=bbbbbbbb, aaaaaaaa24=bbbbbbbb, aaaaaaaa25=bbbbbbbb, aaaaaaaa22=bbbbbbbb, aaaaaaaa23=bbbbbbbb, aaaaaaaa28=bbbbbbbb, aaaaaaaa29=bbbbbbbb, aaaaaaaa26=bbbbbbbb, aaaaaaaa27=bbbbbbbb, aaaaaaaa42=bbbbbbbb, aaaaaaaa43=bbbbbbbb, aaaaaaaa40=bbbbbbbb, aaaaaaaa41=bbbbbbbb, aaaaaaaa7=bbbbbbbb, aaaaaaaa6=bbbbbbbb, aaaaaaaa5=bbbbbbbb, aaaaaaaa4=bbbbbbbb, aaaaaaaa3=bbbbbbbb, aaaaaaaa2=bbbbbbbb, aaaaaaaa1=bbbbbbbb, aaaaaaaa0=bbbbbbbb, aaaaaaaa35=bbbbbbbb, aaaaaaaa36=bbbbbbbb, aaaaaaaa33=bbbbbbbb, aaaaaaaa34=bbbbbbbb, aaaaaaaa39=bbbbbbbb, aaaaaaaa9=bbbbbbbb, aaaaaaaa37=bbbbbbbb, aaaaaaaa8=bbbbbbbb, aaaaaaaa38=bbbbbbbb, aaaaaaaa10=bbbbbbbb, aaaaaaaa46=bbbbbbbb, aaaaaaaa47=bbbbbbbb, aaaaaaaa44=bbbbbbbb, aaaaaaaa45=bbbbbbbb, aaaaaaaa48=bbbbbbbb, aaaaaaaa49=bbbbbbbb, aaaaaaaa20=bbbbbbbb, aaaaaaaa21=bbbbbbbb, aaaaaaaa19=bbbbbbbb, aaaaaaaa13=bbbbbbbb, aaaaaaaa14=bbbbbbbb, aaaaaaaa11=bbbbbbbb, aaaaaaaa12=bbbbbbbb, aaaaaaaa17=bbbbbbbb, aaaaaaaa18=bbbbbbbb, aaaaaaaa15=bbbbbbbb, aaaaaaaa16=bbbbbbbb]
   0.054 [id=903]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#waitUntilPodContainersAreReady: Waiting until pod containers are ready: kubernetes-plugin-test/test-command-execution-w9ddq
   0.055 [id=904]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#launch: Launch proc with environment: [aaaaaaaa31=bbbbbbbb, aaaaaaaa32=bbbbbbbb, aaaaaaaa30=bbbbbbbb, aaaaaaaa24=bbbbbbbb, aaaaaaaa25=bbbbbbbb, aaaaaaaa22=bbbbbbbb, aaaaaaaa23=bbbbbbbb, aaaaaaaa28=bbbbbbbb, aaaaaaaa29=bbbbbbbb, aaaaaaaa26=bbbbbbbb, aaaaaaaa27=bbbbbbbb, aaaaaaaa42=bbbbbbbb, aaaaaaaa43=bbbbbbbb, aaaaaaaa40=bbbbbbbb, aaaaaaaa41=bbbbbbbb, aaaaaaaa7=bbbbbbbb, aaaaaaaa6=bbbbbbbb, aaaaaaaa5=bbbbbbbb, aaaaaaaa4=bbbbbbbb, aaaaaaaa3=bbbbbbbb, aaaaaaaa2=bbbbbbbb, aaaaaaaa1=bbbbbbbb, aaaaaaaa0=bbbbbbbb, aaaaaaaa35=bbbbbbbb, aaaaaaaa36=bbbbbbbb, aaaaaaaa33=bbbbbbbb, aaaaaaaa34=bbbbbbbb, aaaaaaaa39=bbbbbbbb, aaaaaaaa9=bbbbbbbb, aaaaaaaa37=bbbbbbbb, aaaaaaaa8=bbbbbbbb, aaaaaaaa38=bbbbbbbb, aaaaaaaa10=bbbbbbbb, aaaaaaaa46=bbbbbbbb, aaaaaaaa47=bbbbbbbb, aaaaaaaa44=bbbbbbbb, aaaaaaaa45=bbbbbbbb, aaaaaaaa48=bbbbbbbb, aaaaaaaa49=bbbbbbbb, aaaaaaaa20=bbbbbbbb, aaaaaaaa21=bbbbbbbb, aaaaaaaa19=bbbbbbbb, aaaaaaaa13=bbbbbbbb, aaaaaaaa14=bbbbbbbb, aaaaaaaa11=bbbbbbbb, aaaaaaaa12=bbbbbbbb, aaaaaaaa17=bbbbbbbb, aaaaaaaa18=bbbbbbbb, aaaaaaaa15=bbbbbbbb, aaaaaaaa16=bbbbbbbb]
   0.055 [id=901]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#launch: Launch proc with environment: [aaaaaaaa31=bbbbbbbb, aaaaaaaa32=bbbbbbbb, aaaaaaaa30=bbbbbbbb, aaaaaaaa24=bbbbbbbb, aaaaaaaa25=bbbbbbbb, aaaaaaaa22=bbbbbbbb, aaaaaaaa23=bbbbbbbb, aaaaaaaa28=bbbbbbbb, aaaaaaaa29=bbbbbbbb, aaaaaaaa26=bbbbbbbb, aaaaaaaa27=bbbbbbbb, aaaaaaaa42=bbbbbbbb, aaaaaaaa43=bbbbbbbb, aaaaaaaa40=bbbbbbbb, aaaaaaaa41=bbbbbbbb, aaaaaaaa7=bbbbbbbb, aaaaaaaa6=bbbbbbbb, aaaaaaaa5=bbbbbbbb, aaaaaaaa4=bbbbbbbb, aaaaaaaa3=bbbbbbbb, aaaaaaaa2=bbbbbbbb, aaaaaaaa1=bbbbbbbb, aaaaaaaa0=bbbbbbbb, aaaaaaaa35=bbbbbbbb, aaaaaaaa36=bbbbbbbb, aaaaaaaa33=bbbbbbbb, aaaaaaaa34=bbbbbbbb, aaaaaaaa39=bbbbbbbb, aaaaaaaa9=bbbbbbbb, aaaaaaaa37=bbbbbbbb, aaaaaaaa8=bbbbbbbb, aaaaaaaa38=bbbbbbbb, aaaaaaaa10=bbbbbbbb, aaaaaaaa46=bbbbbbbb, aaaaaaaa47=bbbbbbbb, aaaaaaaa44=bbbbbbbb, aaaaaaaa45=bbbbbbbb, aaaaaaaa48=bbbbbbbb, aaaaaaaa49=bbbbbbbb, aaaaaaaa20=bbbbbbbb, aaaaaaaa21=bbbbbbbb, aaaaaaaa19=bbbbbbbb, aaaaaaaa13=bbbbbbbb, aaaaaaaa14=bbbbbbbb, aaaaaaaa11=bbbbbbbb, aaaaaaaa12=bbbbbbbb, aaaaaaaa17=bbbbbbbb, aaaaaaaa18=bbbbbbbb, aaaaaaaa15=bbbbbbbb, aaaaaaaa16=bbbbbbbb]
   0.055 [id=901]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#waitUntilPodContainersAreReady: Waiting until pod containers are ready: kubernetes-plugin-test/test-command-execution-w9ddq
   0.055 [id=902]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#launch: Launch proc with environment: [aaaaaaaa31=bbbbbbbb, aaaaaaaa32=bbbbbbbb, aaaaaaaa30=bbbbbbbb, aaaaaaaa24=bbbbbbbb, aaaaaaaa25=bbbbbbbb, aaaaaaaa22=bbbbbbbb, aaaaaaaa23=bbbbbbbb, aaaaaaaa28=bbbbbbbb, aaaaaaaa29=bbbbbbbb, aaaaaaaa26=bbbbbbbb, aaaaaaaa27=bbbbbbbb, aaaaaaaa42=bbbbbbbb, aaaaaaaa43=bbbbbbbb, aaaaaaaa40=bbbbbbbb, aaaaaaaa41=bbbbbbbb, aaaaaaaa7=bbbbbbbb, aaaaaaaa6=bbbbbbbb, aaaaaaaa5=bbbbbbbb, aaaaaaaa4=bbbbbbbb, aaaaaaaa3=bbbbbbbb, aaaaaaaa2=bbbbbbbb, aaaaaaaa1=bbbbbbbb, aaaaaaaa0=bbbbbbbb, aaaaaaaa35=bbbbbbbb, aaaaaaaa36=bbbbbbbb, aaaaaaaa33=bbbbbbbb, aaaaaaaa34=bbbbbbbb, aaaaaaaa39=bbbbbbbb, aaaaaaaa9=bbbbbbbb, aaaaaaaa37=bbbbbbbb, aaaaaaaa8=bbbbbbbb, aaaaaaaa38=bbbbbbbb, aaaaaaaa10=bbbbbbbb, aaaaaaaa46=bbbbbbbb, aaaaaaaa47=bbbbbbbb, aaaaaaaa44=bbbbbbbb, aaaaaaaa45=bbbbbbbb, aaaaaaaa48=bbbbbbbb, aaaaaaaa49=bbbbbbbb, aaaaaaaa20=bbbbbbbb, aaaaaaaa21=bbbbbbbb, aaaaaaaa19=bbbbbbbb, aaaaaaaa13=bbbbbbbb, aaaaaaaa14=bbbbbbbb, aaaaaaaa11=bbbbbbbb, aaaaaaaa12=bbbbbbbb, aaaaaaaa17=bbbbbbbb, aaaaaaaa18=bbbbbbbb, aaaaaaaa15=bbbbbbbb, aaaaaaaa16=bbbbbbbb]
   0.055 [id=902]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#waitUntilPodContainersAreReady: Waiting until pod containers are ready: kubernetes-plugin-test/test-command-execution-w9ddq
   0.055 [id=900]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#launch: Launch proc with environment: [aaaaaaaa31=bbbbbbbb, aaaaaaaa32=bbbbbbbb, aaaaaaaa30=bbbbbbbb, aaaaaaaa24=bbbbbbbb, aaaaaaaa25=bbbbbbbb, aaaaaaaa22=bbbbbbbb, aaaaaaaa23=bbbbbbbb, aaaaaaaa28=bbbbbbbb, aaaaaaaa29=bbbbbbbb, aaaaaaaa26=bbbbbbbb, aaaaaaaa27=bbbbbbbb, aaaaaaaa42=bbbbbbbb, aaaaaaaa43=bbbbbbbb, aaaaaaaa40=bbbbbbbb, aaaaaaaa41=bbbbbbbb, aaaaaaaa7=bbbbbbbb, aaaaaaaa6=bbbbbbbb, aaaaaaaa5=bbbbbbbb, aaaaaaaa4=bbbbbbbb, aaaaaaaa3=bbbbbbbb, aaaaaaaa2=bbbbbbbb, aaaaaaaa1=bbbbbbbb, aaaaaaaa0=bbbbbbbb, aaaaaaaa35=bbbbbbbb, aaaaaaaa36=bbbbbbbb, aaaaaaaa33=bbbbbbbb, aaaaaaaa34=bbbbbbbb, aaaaaaaa39=bbbbbbbb, aaaaaaaa9=bbbbbbbb, aaaaaaaa37=bbbbbbbb, aaaaaaaa8=bbbbbbbb, aaaaaaaa38=bbbbbbbb, aaaaaaaa10=bbbbbbbb, aaaaaaaa46=bbbbbbbb, aaaaaaaa47=bbbbbbbb, aaaaaaaa44=bbbbbbbb, aaaaaaaa45=bbbbbbbb, aaaaaaaa48=bbbbbbbb, aaaaaaaa49=bbbbbbbb, aaaaaaaa20=bbbbbbbb, aaaaaaaa21=bbbbbbbb, aaaaaaaa19=bbbbbbbb, aaaaaaaa13=bbbbbbbb, aaaaaaaa14=bbbbbbbb, aaaaaaaa11=bbbbbbbb, aaaaaaaa12=bbbbbbbb, aaaaaaaa17=bbbbbbbb, aaaaaaaa18=bbbbbbbb, aaaaaaaa15=bbbbbbbb, aaaaaaaa16=bbbbbbbb]
   0.056 [id=900]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#waitUntilPodContainersAreReady: Waiting until pod containers are ready: kubernetes-plugin-test/test-command-execution-w9ddq
   0.056 [id=904]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#waitUntilPodContainersAreReady: Waiting until pod containers are ready: kubernetes-plugin-test/test-command-execution-w9ddq
   0.056 [id=905]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#waitUntilPodContainersAreReady: Waiting until pod containers are ready: kubernetes-plugin-test/test-command-execution-w9ddq
   0.056 [id=899]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#launch: Launch proc with environment: [aaaaaaaa31=bbbbbbbb, aaaaaaaa32=bbbbbbbb, aaaaaaaa30=bbbbbbbb, aaaaaaaa24=bbbbbbbb, aaaaaaaa25=bbbbbbbb, aaaaaaaa22=bbbbbbbb, aaaaaaaa23=bbbbbbbb, aaaaaaaa28=bbbbbbbb, aaaaaaaa29=bbbbbbbb, aaaaaaaa26=bbbbbbbb, aaaaaaaa27=bbbbbbbb, aaaaaaaa42=bbbbbbbb, aaaaaaaa43=bbbbbbbb, aaaaaaaa40=bbbbbbbb, aaaaaaaa41=bbbbbbbb, aaaaaaaa7=bbbbbbbb, aaaaaaaa6=bbbbbbbb, aaaaaaaa5=bbbbbbbb, aaaaaaaa4=bbbbbbbb, aaaaaaaa3=bbbbbbbb, aaaaaaaa2=bbbbbbbb, aaaaaaaa1=bbbbbbbb, aaaaaaaa0=bbbbbbbb, aaaaaaaa35=bbbbbbbb, aaaaaaaa36=bbbbbbbb, aaaaaaaa33=bbbbbbbb, aaaaaaaa34=bbbbbbbb, aaaaaaaa39=bbbbbbbb, aaaaaaaa9=bbbbbbbb, aaaaaaaa37=bbbbbbbb, aaaaaaaa8=bbbbbbbb, aaaaaaaa38=bbbbbbbb, aaaaaaaa10=bbbbbbbb, aaaaaaaa46=bbbbbbbb, aaaaaaaa47=bbbbbbbb, aaaaaaaa44=bbbbbbbb, aaaaaaaa45=bbbbbbbb, aaaaaaaa48=bbbbbbbb, aaaaaaaa49=bbbbbbbb, aaaaaaaa20=bbbbbbbb, aaaaaaaa21=bbbbbbbb, aaaaaaaa19=bbbbbbbb, aaaaaaaa13=bbbbbbbb, aaaaaaaa14=bbbbbbbb, aaaaaaaa11=bbbbbbbb, aaaaaaaa12=bbbbbbbb, aaaaaaaa17=bbbbbbbb, aaaaaaaa18=bbbbbbbb, aaaaaaaa15=bbbbbbbb, aaaaaaaa16=bbbbbbbb]
   0.056 [id=899]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#waitUntilPodContainersAreReady: Waiting until pod containers are ready: kubernetes-plugin-test/test-command-execution-w9ddq
   0.057 [id=898]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#launch: Launch proc with environment: [aaaaaaaa31=bbbbbbbb, aaaaaaaa32=bbbbbbbb, aaaaaaaa30=bbbbbbbb, aaaaaaaa24=bbbbbbbb, aaaaaaaa25=bbbbbbbb, aaaaaaaa22=bbbbbbbb, aaaaaaaa23=bbbbbbbb, aaaaaaaa28=bbbbbbbb, aaaaaaaa29=bbbbbbbb, aaaaaaaa26=bbbbbbbb, aaaaaaaa27=bbbbbbbb, aaaaaaaa42=bbbbbbbb, aaaaaaaa43=bbbbbbbb, aaaaaaaa40=bbbbbbbb, aaaaaaaa41=bbbbbbbb, aaaaaaaa7=bbbbbbbb, aaaaaaaa6=bbbbbbbb, aaaaaaaa5=bbbbbbbb, aaaaaaaa4=bbbbbbbb, aaaaaaaa3=bbbbbbbb, aaaaaaaa2=bbbbbbbb, aaaaaaaa1=bbbbbbbb, aaaaaaaa0=bbbbbbbb, aaaaaaaa35=bbbbbbbb, aaaaaaaa36=bbbbbbbb, aaaaaaaa33=bbbbbbbb, aaaaaaaa34=bbbbbbbb, aaaaaaaa39=bbbbbbbb, aaaaaaaa9=bbbbbbbb, aaaaaaaa37=bbbbbbbb, aaaaaaaa8=bbbbbbbb, aaaaaaaa38=bbbbbbbb, aaaaaaaa10=bbbbbbbb, aaaaaaaa46=bbbbbbbb, aaaaaaaa47=bbbbbbbb, aaaaaaaa44=bbbbbbbb, aaaaaaaa45=bbbbbbbb, aaaaaaaa48=bbbbbbbb, aaaaaaaa49=bbbbbbbb, aaaaaaaa20=bbbbbbbb, aaaaaaaa21=bbbbbbbb, aaaaaaaa19=bbbbbbbb, aaaaaaaa13=bbbbbbbb, aaaaaaaa14=bbbbbbbb, aaaaaaaa11=bbbbbbbb, aaaaaaaa12=bbbbbbbb, aaaaaaaa17=bbbbbbbb, aaaaaaaa18=bbbbbbbb, aaaaaaaa15=bbbbbbbb, aaaaaaaa16=bbbbbbbb]
   0.057 [id=898]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#waitUntilPodContainersAreReady: Waiting until pod containers are ready: kubernetes-plugin-test/test-command-execution-w9ddq
   1.307 [id=905]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#waitUntilPodContainersAreReady: Pod is ready: kubernetes-plugin-test/test-command-execution-w9ddq
   1.307 [id=905]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#doLaunch: Executing shell script inside container [busybox] of pod [test-command-execution-w9ddq]
   1.308 [id=899]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#waitUntilPodContainersAreReady: Pod is ready: kubernetes-plugin-test/test-command-execution-w9ddq
   1.308 [id=899]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#doLaunch: Executing shell script inside container [busybox] of pod [test-command-execution-w9ddq]
   1.308 [id=906]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#waitUntilPodContainersAreReady: Pod is ready: kubernetes-plugin-test/test-command-execution-w9ddq
   1.308 [id=906]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#doLaunch: Executing shell script inside container [busybox] of pod [test-command-execution-w9ddq]
   1.311 [id=904]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#waitUntilPodContainersAreReady: Pod is ready: kubernetes-plugin-test/test-command-execution-w9ddq
   1.311 [id=904]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#doLaunch: Executing shell script inside container [busybox] of pod [test-command-execution-w9ddq]
   1.311 [id=898]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#waitUntilPodContainersAreReady: Pod is ready: kubernetes-plugin-test/test-command-execution-w9ddq
   1.311 [id=898]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#doLaunch: Executing shell script inside container [busybox] of pod [test-command-execution-w9ddq]
   1.313 [id=902]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#waitUntilPodContainersAreReady: Pod is ready: kubernetes-plugin-test/test-command-execution-w9ddq
   1.313 [id=902]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#doLaunch: Executing shell script inside container [busybox] of pod [test-command-execution-w9ddq]
   1.314 [id=900]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#waitUntilPodContainersAreReady: Pod is ready: kubernetes-plugin-test/test-command-execution-w9ddq
   1.314 [id=897]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#waitUntilPodContainersAreReady: Pod is ready: kubernetes-plugin-test/test-command-execution-w9ddq
   1.314 [id=897]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#doLaunch: Executing shell script inside container [busybox] of pod [test-command-execution-w9ddq]
   1.314 [id=900]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#doLaunch: Executing shell script inside container [busybox] of pod [test-command-execution-w9ddq]
   1.315 [id=901]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#waitUntilPodContainersAreReady: Pod is ready: kubernetes-plugin-test/test-command-execution-w9ddq
   1.315 [id=901]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#doLaunch: Executing shell script inside container [busybox] of pod [test-command-execution-w9ddq]
   1.316 [id=903]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#waitUntilPodContainersAreReady: Pod is ready: kubernetes-plugin-test/test-command-execution-w9ddq
   1.316 [id=903]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#doLaunch: Executing shell script inside container [busybox] of pod [test-command-execution-w9ddq]
   1.489 [id=906]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#doLaunch: Launching with env vars: {aaaaaaaa0=bbbbbbbb, aaaaaaaa1=bbbbbbbb, aaaaaaaa10=bbbbbbbb, aaaaaaaa11=bbbbbbbb, aaaaaaaa12=bbbbbbbb, aaaaaaaa13=bbbbbbbb, aaaaaaaa14=bbbbbbbb, aaaaaaaa15=bbbbbbbb, aaaaaaaa16=bbbbbbbb, aaaaaaaa17=bbbbbbbb, aaaaaaaa18=bbbbbbbb, aaaaaaaa19=bbbbbbbb, aaaaaaaa2=bbbbbbbb, aaaaaaaa20=bbbbbbbb, aaaaaaaa21=bbbbbbbb, aaaaaaaa22=bbbbbbbb, aaaaaaaa23=bbbbbbbb, aaaaaaaa24=bbbbbbbb, aaaaaaaa25=bbbbbbbb, aaaaaaaa26=bbbbbbbb, aaaaaaaa27=bbbbbbbb, aaaaaaaa28=bbbbbbbb, aaaaaaaa29=bbbbbbbb, aaaaaaaa3=bbbbbbbb, aaaaaaaa30=bbbbbbbb, aaaaaaaa31=bbbbbbbb, aaaaaaaa32=bbbbbbbb, aaaaaaaa33=bbbbbbbb, aaaaaaaa34=bbbbbbbb, aaaaaaaa35=bbbbbbbb, aaaaaaaa36=bbbbbbbb, aaaaaaaa37=bbbbbbbb, aaaaaaaa38=bbbbbbbb, aaaaaaaa39=bbbbbbbb, aaaaaaaa4=bbbbbbbb, aaaaaaaa40=bbbbbbbb, aaaaaaaa41=bbbbbbbb, aaaaaaaa42=bbbbbbbb, aaaaaaaa43=bbbbbbbb, aaaaaaaa44=bbbbbbbb, aaaaaaaa45=bbbbbbbb, aaaaaaaa46=bbbbbbbb, aaaaaaaa47=bbbbbbbb, aaaaaaaa48=bbbbbbbb, aaaaaaaa49=bbbbbbbb, aaaaaaaa5=bbbbbbbb, aaaaaaaa6=bbbbbbbb, aaaaaaaa7=bbbbbbbb, aaaaaaaa8=bbbbbbbb, aaaaaaaa9=bbbbbbbb}
   1.490 [id=906]	FINEST	o.c.j.p.k.p.ContainerExecDecorator#doExec: Executing command: "sh" "-c" "cd /tmp; echo pid is \$\$ > test; cat /tmp/test" 
exit

   1.490 [id=906]	INFO	o.c.j.p.k.p.ContainerExecDecorator$1#doLaunch: Created process inside pod: [test-command-execution-w9ddq], container: [busybox]
   1.490 [id=906]	INFO	o.c.j.p.k.p.ContainerExecDecorator$1#doLaunch: Created process inside pod: [test-command-execution-w9ddq], container: [busybox]
   1.490 [id=920]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1$1#onOpen: onOpen : java.util.concurrent.CountDownLatch@55952730[Count = 1]
   1.491 [id=827]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1$1#onOpen: onOpen : java.util.concurrent.CountDownLatch@7aa2f90d[Count = 1]
   1.491 [id=903]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#doLaunch: Launching with env vars: {aaaaaaaa0=bbbbbbbb, aaaaaaaa1=bbbbbbbb, aaaaaaaa10=bbbbbbbb, aaaaaaaa11=bbbbbbbb, aaaaaaaa12=bbbbbbbb, aaaaaaaa13=bbbbbbbb, aaaaaaaa14=bbbbbbbb, aaaaaaaa15=bbbbbbbb, aaaaaaaa16=bbbbbbbb, aaaaaaaa17=bbbbbbbb, aaaaaaaa18=bbbbbbbb, aaaaaaaa19=bbbbbbbb, aaaaaaaa2=bbbbbbbb, aaaaaaaa20=bbbbbbbb, aaaaaaaa21=bbbbbbbb, aaaaaaaa22=bbbbbbbb, aaaaaaaa23=bbbbbbbb, aaaaaaaa24=bbbbbbbb, aaaaaaaa25=bbbbbbbb, aaaaaaaa26=bbbbbbbb, aaaaaaaa27=bbbbbbbb, aaaaaaaa28=bbbbbbbb, aaaaaaaa29=bbbbbbbb, aaaaaaaa3=bbbbbbbb, aaaaaaaa30=bbbbbbbb, aaaaaaaa31=bbbbbbbb, aaaaaaaa32=bbbbbbbb, aaaaaaaa33=bbbbbbbb, aaaaaaaa34=bbbbbbbb, aaaaaaaa35=bbbbbbbb, aaaaaaaa36=bbbbbbbb, aaaaaaaa37=bbbbbbbb, aaaaaaaa38=bbbbbbbb, aaaaaaaa39=bbbbbbbb, aaaaaaaa4=bbbbbbbb, aaaaaaaa40=bbbbbbbb, aaaaaaaa41=bbbbbbbb, aaaaaaaa42=bbbbbbbb, aaaaaaaa43=bbbbbbbb, aaaaaaaa44=bbbbbbbb, aaaaaaaa45=bbbbbbbb, aaaaaaaa46=bbbbbbbb, aaaaaaaa47=bbbbbbbb, aaaaaaaa48=bbbbbbbb, aaaaaaaa49=bbbbbbbb, aaaaaaaa5=bbbbbbbb, aaaaaaaa6=bbbbbbbb, aaaaaaaa7=bbbbbbbb, aaaaaaaa8=bbbbbbbb, aaaaaaaa9=bbbbbbbb}
   1.492 [id=903]	FINEST	o.c.j.p.k.p.ContainerExecDecorator#doExec: Executing command: "sh" "-c" "cd /tmp; echo pid is \$\$ > test; cat /tmp/test" 
exit

   1.492 [id=903]	INFO	o.c.j.p.k.p.ContainerExecDecorator$1#doLaunch: Created process inside pod: [test-command-execution-w9ddq], container: [busybox]
   1.492 [id=903]	INFO	o.c.j.p.k.p.ContainerExecDecorator$1#doLaunch: Created process inside pod: [test-command-execution-w9ddq], container: [busybox]
   1.498 [id=814]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1$1#onOpen: onOpen : java.util.concurrent.CountDownLatch@6b0ea605[Count = 1]
   1.505 [id=905]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#doLaunch: Launching with env vars: {aaaaaaaa0=bbbbbbbb, aaaaaaaa1=bbbbbbbb, aaaaaaaa10=bbbbbbbb, aaaaaaaa11=bbbbbbbb, aaaaaaaa12=bbbbbbbb, aaaaaaaa13=bbbbbbbb, aaaaaaaa14=bbbbbbbb, aaaaaaaa15=bbbbbbbb, aaaaaaaa16=bbbbbbbb, aaaaaaaa17=bbbbbbbb, aaaaaaaa18=bbbbbbbb, aaaaaaaa19=bbbbbbbb, aaaaaaaa2=bbbbbbbb, aaaaaaaa20=bbbbbbbb, aaaaaaaa21=bbbbbbbb, aaaaaaaa22=bbbbbbbb, aaaaaaaa23=bbbbbbbb, aaaaaaaa24=bbbbbbbb, aaaaaaaa25=bbbbbbbb, aaaaaaaa26=bbbbbbbb, aaaaaaaa27=bbbbbbbb, aaaaaaaa28=bbbbbbbb, aaaaaaaa29=bbbbbbbb, aaaaaaaa3=bbbbbbbb, aaaaaaaa30=bbbbbbbb, aaaaaaaa31=bbbbbbbb, aaaaaaaa32=bbbbbbbb, aaaaaaaa33=bbbbbbbb, aaaaaaaa34=bbbbbbbb, aaaaaaaa35=bbbbbbbb, aaaaaaaa36=bbbbbbbb, aaaaaaaa37=bbbbbbbb, aaaaaaaa38=bbbbbbbb, aaaaaaaa39=bbbbbbbb, aaaaaaaa4=bbbbbbbb, aaaaaaaa40=bbbbbbbb, aaaaaaaa41=bbbbbbbb, aaaaaaaa42=bbbbbbbb, aaaaaaaa43=bbbbbbbb, aaaaaaaa44=bbbbbbbb, aaaaaaaa45=bbbbbbbb, aaaaaaaa46=bbbbbbbb, aaaaaaaa47=bbbbbbbb, aaaaaaaa48=bbbbbbbb, aaaaaaaa49=bbbbbbbb, aaaaaaaa5=bbbbbbbb, aaaaaaaa6=bbbbbbbb, aaaaaaaa7=bbbbbbbb, aaaaaaaa8=bbbbbbbb, aaaaaaaa9=bbbbbbbb}
   1.506 [id=905]	FINEST	o.c.j.p.k.p.ContainerExecDecorator#doExec: Executing command: "sh" "-c" "cd /tmp; echo pid is \$\$ > test; cat /tmp/test" 
exit

   1.506 [id=905]	INFO	o.c.j.p.k.p.ContainerExecDecorator$1#doLaunch: Created process inside pod: [test-command-execution-w9ddq], container: [busybox]
   1.506 [id=905]	INFO	o.c.j.p.k.p.ContainerExecDecorator$1#doLaunch: Created process inside pod: [test-command-execution-w9ddq], container: [busybox]
   1.508 [id=921]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1$1#onOpen: onOpen : java.util.concurrent.CountDownLatch@6460a2e4[Count = 1]
   1.509 [id=904]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#doLaunch: Launching with env vars: {aaaaaaaa0=bbbbbbbb, aaaaaaaa1=bbbbbbbb, aaaaaaaa10=bbbbbbbb, aaaaaaaa11=bbbbbbbb, aaaaaaaa12=bbbbbbbb, aaaaaaaa13=bbbbbbbb, aaaaaaaa14=bbbbbbbb, aaaaaaaa15=bbbbbbbb, aaaaaaaa16=bbbbbbbb, aaaaaaaa17=bbbbbbbb, aaaaaaaa18=bbbbbbbb, aaaaaaaa19=bbbbbbbb, aaaaaaaa2=bbbbbbbb, aaaaaaaa20=bbbbbbbb, aaaaaaaa21=bbbbbbbb, aaaaaaaa22=bbbbbbbb, aaaaaaaa23=bbbbbbbb, aaaaaaaa24=bbbbbbbb, aaaaaaaa25=bbbbbbbb, aaaaaaaa26=bbbbbbbb, aaaaaaaa27=bbbbbbbb, aaaaaaaa28=bbbbbbbb, aaaaaaaa29=bbbbbbbb, aaaaaaaa3=bbbbbbbb, aaaaaaaa30=bbbbbbbb, aaaaaaaa31=bbbbbbbb, aaaaaaaa32=bbbbbbbb, aaaaaaaa33=bbbbbbbb, aaaaaaaa34=bbbbbbbb, aaaaaaaa35=bbbbbbbb, aaaaaaaa36=bbbbbbbb, aaaaaaaa37=bbbbbbbb, aaaaaaaa38=bbbbbbbb, aaaaaaaa39=bbbbbbbb, aaaaaaaa4=bbbbbbbb, aaaaaaaa40=bbbbbbbb, aaaaaaaa41=bbbbbbbb, aaaaaaaa42=bbbbbbbb, aaaaaaaa43=bbbbbbbb, aaaaaaaa44=bbbbbbbb, aaaaaaaa45=bbbbbbbb, aaaaaaaa46=bbbbbbbb, aaaaaaaa47=bbbbbbbb, aaaaaaaa48=bbbbbbbb, aaaaaaaa49=bbbbbbbb, aaaaaaaa5=bbbbbbbb, aaaaaaaa6=bbbbbbbb, aaaaaaaa7=bbbbbbbb, aaaaaaaa8=bbbbbbbb, aaaaaaaa9=bbbbbbbb}
   1.509 [id=904]	FINEST	o.c.j.p.k.p.ContainerExecDecorator#doExec: Executing command: "sh" "-c" "cd /tmp; echo pid is \$\$ > test; cat /tmp/test" 
exit

   1.510 [id=904]	INFO	o.c.j.p.k.p.ContainerExecDecorator$1#doLaunch: Created process inside pod: [test-command-execution-w9ddq], container: [busybox]
   1.510 [id=904]	INFO	o.c.j.p.k.p.ContainerExecDecorator$1#doLaunch: Created process inside pod: [test-command-execution-w9ddq], container: [busybox]
   1.510 [id=922]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1$1#onOpen: onOpen : java.util.concurrent.CountDownLatch@1d9e3b5e[Count = 1]
   1.510 [id=898]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#doLaunch: Launching with env vars: {aaaaaaaa0=bbbbbbbb, aaaaaaaa1=bbbbbbbb, aaaaaaaa10=bbbbbbbb, aaaaaaaa11=bbbbbbbb, aaaaaaaa12=bbbbbbbb, aaaaaaaa13=bbbbbbbb, aaaaaaaa14=bbbbbbbb, aaaaaaaa15=bbbbbbbb, aaaaaaaa16=bbbbbbbb, aaaaaaaa17=bbbbbbbb, aaaaaaaa18=bbbbbbbb, aaaaaaaa19=bbbbbbbb, aaaaaaaa2=bbbbbbbb, aaaaaaaa20=bbbbbbbb, aaaaaaaa21=bbbbbbbb, aaaaaaaa22=bbbbbbbb, aaaaaaaa23=bbbbbbbb, aaaaaaaa24=bbbbbbbb, aaaaaaaa25=bbbbbbbb, aaaaaaaa26=bbbbbbbb, aaaaaaaa27=bbbbbbbb, aaaaaaaa28=bbbbbbbb, aaaaaaaa29=bbbbbbbb, aaaaaaaa3=bbbbbbbb, aaaaaaaa30=bbbbbbbb, aaaaaaaa31=bbbbbbbb, aaaaaaaa32=bbbbbbbb, aaaaaaaa33=bbbbbbbb, aaaaaaaa34=bbbbbbbb, aaaaaaaa35=bbbbbbbb, aaaaaaaa36=bbbbbbbb, aaaaaaaa37=bbbbbbbb, aaaaaaaa38=bbbbbbbb, aaaaaaaa39=bbbbbbbb, aaaaaaaa4=bbbbbbbb, aaaaaaaa40=bbbbbbbb, aaaaaaaa41=bbbbbbbb, aaaaaaaa42=bbbbbbbb, aaaaaaaa43=bbbbbbbb, aaaaaaaa44=bbbbbbbb, aaaaaaaa45=bbbbbbbb, aaaaaaaa46=bbbbbbbb, aaaaaaaa47=bbbbbbbb, aaaaaaaa48=bbbbbbbb, aaaaaaaa49=bbbbbbbb, aaaaaaaa5=bbbbbbbb, aaaaaaaa6=bbbbbbbb, aaaaaaaa7=bbbbbbbb, aaaaaaaa8=bbbbbbbb, aaaaaaaa9=bbbbbbbb}
   1.510 [id=898]	FINEST	o.c.j.p.k.p.ContainerExecDecorator#doExec: Executing command: "sh" "-c" "cd /tmp; echo pid is \$\$ > test; cat /tmp/test" 
exit

   1.510 [id=898]	INFO	o.c.j.p.k.p.ContainerExecDecorator$1#doLaunch: Created process inside pod: [test-command-execution-w9ddq], container: [busybox]
   1.510 [id=898]	INFO	o.c.j.p.k.p.ContainerExecDecorator$1#doLaunch: Created process inside pod: [test-command-execution-w9ddq], container: [busybox]
   1.516 [id=807]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1$1#onOpen: onOpen : java.util.concurrent.CountDownLatch@5c16a8dd[Count = 1]
   1.517 [id=901]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#doLaunch: Launching with env vars: {aaaaaaaa0=bbbbbbbb, aaaaaaaa1=bbbbbbbb, aaaaaaaa10=bbbbbbbb, aaaaaaaa11=bbbbbbbb, aaaaaaaa12=bbbbbbbb, aaaaaaaa13=bbbbbbbb, aaaaaaaa14=bbbbbbbb, aaaaaaaa15=bbbbbbbb, aaaaaaaa16=bbbbbbbb, aaaaaaaa17=bbbbbbbb, aaaaaaaa18=bbbbbbbb, aaaaaaaa19=bbbbbbbb, aaaaaaaa2=bbbbbbbb, aaaaaaaa20=bbbbbbbb, aaaaaaaa21=bbbbbbbb, aaaaaaaa22=bbbbbbbb, aaaaaaaa23=bbbbbbbb, aaaaaaaa24=bbbbbbbb, aaaaaaaa25=bbbbbbbb, aaaaaaaa26=bbbbbbbb, aaaaaaaa27=bbbbbbbb, aaaaaaaa28=bbbbbbbb, aaaaaaaa29=bbbbbbbb, aaaaaaaa3=bbbbbbbb, aaaaaaaa30=bbbbbbbb, aaaaaaaa31=bbbbbbbb, aaaaaaaa32=bbbbbbbb, aaaaaaaa33=bbbbbbbb, aaaaaaaa34=bbbbbbbb, aaaaaaaa35=bbbbbbbb, aaaaaaaa36=bbbbbbbb, aaaaaaaa37=bbbbbbbb, aaaaaaaa38=bbbbbbbb, aaaaaaaa39=bbbbbbbb, aaaaaaaa4=bbbbbbbb, aaaaaaaa40=bbbbbbbb, aaaaaaaa41=bbbbbbbb, aaaaaaaa42=bbbbbbbb, aaaaaaaa43=bbbbbbbb, aaaaaaaa44=bbbbbbbb, aaaaaaaa45=bbbbbbbb, aaaaaaaa46=bbbbbbbb, aaaaaaaa47=bbbbbbbb, aaaaaaaa48=bbbbbbbb, aaaaaaaa49=bbbbbbbb, aaaaaaaa5=bbbbbbbb, aaaaaaaa6=bbbbbbbb, aaaaaaaa7=bbbbbbbb, aaaaaaaa8=bbbbbbbb, aaaaaaaa9=bbbbbbbb}
   1.517 [id=901]	FINEST	o.c.j.p.k.p.ContainerExecDecorator#doExec: Executing command: "sh" "-c" "cd /tmp; echo pid is \$\$ > test; cat /tmp/test" 
exit

   1.517 [id=901]	INFO	o.c.j.p.k.p.ContainerExecDecorator$1#doLaunch: Created process inside pod: [test-command-execution-w9ddq], container: [busybox]
   1.517 [id=901]	INFO	o.c.j.p.k.p.ContainerExecDecorator$1#doLaunch: Created process inside pod: [test-command-execution-w9ddq], container: [busybox]
   1.579 [id=925]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1$1#onOpen: onOpen : java.util.concurrent.CountDownLatch@189d49da[Count = 1]
   1.579 [id=924]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1$1#onOpen: onOpen : java.util.concurrent.CountDownLatch@139c79ce[Count = 1]
   1.580 [id=899]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#doLaunch: Launching with env vars: {aaaaaaaa0=bbbbbbbb, aaaaaaaa1=bbbbbbbb, aaaaaaaa10=bbbbbbbb, aaaaaaaa11=bbbbbbbb, aaaaaaaa12=bbbbbbbb, aaaaaaaa13=bbbbbbbb, aaaaaaaa14=bbbbbbbb, aaaaaaaa15=bbbbbbbb, aaaaaaaa16=bbbbbbbb, aaaaaaaa17=bbbbbbbb, aaaaaaaa18=bbbbbbbb, aaaaaaaa19=bbbbbbbb, aaaaaaaa2=bbbbbbbb, aaaaaaaa20=bbbbbbbb, aaaaaaaa21=bbbbbbbb, aaaaaaaa22=bbbbbbbb, aaaaaaaa23=bbbbbbbb, aaaaaaaa24=bbbbbbbb, aaaaaaaa25=bbbbbbbb, aaaaaaaa26=bbbbbbbb, aaaaaaaa27=bbbbbbbb, aaaaaaaa28=bbbbbbbb, aaaaaaaa29=bbbbbbbb, aaaaaaaa3=bbbbbbbb, aaaaaaaa30=bbbbbbbb, aaaaaaaa31=bbbbbbbb, aaaaaaaa32=bbbbbbbb, aaaaaaaa33=bbbbbbbb, aaaaaaaa34=bbbbbbbb, aaaaaaaa35=bbbbbbbb, aaaaaaaa36=bbbbbbbb, aaaaaaaa37=bbbbbbbb, aaaaaaaa38=bbbbbbbb, aaaaaaaa39=bbbbbbbb, aaaaaaaa4=bbbbbbbb, aaaaaaaa40=bbbbbbbb, aaaaaaaa41=bbbbbbbb, aaaaaaaa42=bbbbbbbb, aaaaaaaa43=bbbbbbbb, aaaaaaaa44=bbbbbbbb, aaaaaaaa45=bbbbbbbb, aaaaaaaa46=bbbbbbbb, aaaaaaaa47=bbbbbbbb, aaaaaaaa48=bbbbbbbb, aaaaaaaa49=bbbbbbbb, aaaaaaaa5=bbbbbbbb, aaaaaaaa6=bbbbbbbb, aaaaaaaa7=bbbbbbbb, aaaaaaaa8=bbbbbbbb, aaaaaaaa9=bbbbbbbb}
   1.580 [id=900]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#doLaunch: Launching with env vars: {aaaaaaaa0=bbbbbbbb, aaaaaaaa1=bbbbbbbb, aaaaaaaa10=bbbbbbbb, aaaaaaaa11=bbbbbbbb, aaaaaaaa12=bbbbbbbb, aaaaaaaa13=bbbbbbbb, aaaaaaaa14=bbbbbbbb, aaaaaaaa15=bbbbbbbb, aaaaaaaa16=bbbbbbbb, aaaaaaaa17=bbbbbbbb, aaaaaaaa18=bbbbbbbb, aaaaaaaa19=bbbbbbbb, aaaaaaaa2=bbbbbbbb, aaaaaaaa20=bbbbbbbb, aaaaaaaa21=bbbbbbbb, aaaaaaaa22=bbbbbbbb, aaaaaaaa23=bbbbbbbb, aaaaaaaa24=bbbbbbbb, aaaaaaaa25=bbbbbbbb, aaaaaaaa26=bbbbbbbb, aaaaaaaa27=bbbbbbbb, aaaaaaaa28=bbbbbbbb, aaaaaaaa29=bbbbbbbb, aaaaaaaa3=bbbbbbbb, aaaaaaaa30=bbbbbbbb, aaaaaaaa31=bbbbbbbb, aaaaaaaa32=bbbbbbbb, aaaaaaaa33=bbbbbbbb, aaaaaaaa34=bbbbbbbb, aaaaaaaa35=bbbbbbbb, aaaaaaaa36=bbbbbbbb, aaaaaaaa37=bbbbbbbb, aaaaaaaa38=bbbbbbbb, aaaaaaaa39=bbbbbbbb, aaaaaaaa4=bbbbbbbb, aaaaaaaa40=bbbbbbbb, aaaaaaaa41=bbbbbbbb, aaaaaaaa42=bbbbbbbb, aaaaaaaa43=bbbbbbbb, aaaaaaaa44=bbbbbbbb, aaaaaaaa45=bbbbbbbb, aaaaaaaa46=bbbbbbbb, aaaaaaaa47=bbbbbbbb, aaaaaaaa48=bbbbbbbb, aaaaaaaa49=bbbbbbbb, aaaaaaaa5=bbbbbbbb, aaaaaaaa6=bbbbbbbb, aaaaaaaa7=bbbbbbbb, aaaaaaaa8=bbbbbbbb, aaaaaaaa9=bbbbbbbb}
   1.580 [id=897]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#doLaunch: Launching with env vars: {aaaaaaaa0=bbbbbbbb, aaaaaaaa1=bbbbbbbb, aaaaaaaa10=bbbbbbbb, aaaaaaaa11=bbbbbbbb, aaaaaaaa12=bbbbbbbb, aaaaaaaa13=bbbbbbbb, aaaaaaaa14=bbbbbbbb, aaaaaaaa15=bbbbbbbb, aaaaaaaa16=bbbbbbbb, aaaaaaaa17=bbbbbbbb, aaaaaaaa18=bbbbbbbb, aaaaaaaa19=bbbbbbbb, aaaaaaaa2=bbbbbbbb, aaaaaaaa20=bbbbbbbb, aaaaaaaa21=bbbbbbbb, aaaaaaaa22=bbbbbbbb, aaaaaaaa23=bbbbbbbb, aaaaaaaa24=bbbbbbbb, aaaaaaaa25=bbbbbbbb, aaaaaaaa26=bbbbbbbb, aaaaaaaa27=bbbbbbbb, aaaaaaaa28=bbbbbbbb, aaaaaaaa29=bbbbbbbb, aaaaaaaa3=bbbbbbbb, aaaaaaaa30=bbbbbbbb, aaaaaaaa31=bbbbbbbb, aaaaaaaa32=bbbbbbbb, aaaaaaaa33=bbbbbbbb, aaaaaaaa34=bbbbbbbb, aaaaaaaa35=bbbbbbbb, aaaaaaaa36=bbbbbbbb, aaaaaaaa37=bbbbbbbb, aaaaaaaa38=bbbbbbbb, aaaaaaaa39=bbbbbbbb, aaaaaaaa4=bbbbbbbb, aaaaaaaa40=bbbbbbbb, aaaaaaaa41=bbbbbbbb, aaaaaaaa42=bbbbbbbb, aaaaaaaa43=bbbbbbbb, aaaaaaaa44=bbbbbbbb, aaaaaaaa45=bbbbbbbb, aaaaaaaa46=bbbbbbbb, aaaaaaaa47=bbbbbbbb, aaaaaaaa48=bbbbbbbb, aaaaaaaa49=bbbbbbbb, aaaaaaaa5=bbbbbbbb, aaaaaaaa6=bbbbbbbb, aaaaaaaa7=bbbbbbbb, aaaaaaaa8=bbbbbbbb, aaaaaaaa9=bbbbbbbb}
   1.581 [id=899]	FINEST	o.c.j.p.k.p.ContainerExecDecorator#doExec: Executing command: "sh" "-c" "cd /tmp; echo pid is \$\$ > test; cat /tmp/test" 
exit

   1.581 [id=899]	INFO	o.c.j.p.k.p.ContainerExecDecorator$1#doLaunch: Created process inside pod: [test-command-execution-w9ddq], container: [busybox]
   1.581 [id=899]	INFO	o.c.j.p.k.p.ContainerExecDecorator$1#doLaunch: Created process inside pod: [test-command-execution-w9ddq], container: [busybox]
   1.581 [id=897]	FINEST	o.c.j.p.k.p.ContainerExecDecorator#doExec: Executing command: "sh" "-c" "cd /tmp; echo pid is \$\$ > test; cat /tmp/test" 
exit

   1.581 [id=897]	INFO	o.c.j.p.k.p.ContainerExecDecorator$1#doLaunch: Created process inside pod: [test-command-execution-w9ddq], container: [busybox]
   1.581 [id=897]	INFO	o.c.j.p.k.p.ContainerExecDecorator$1#doLaunch: Created process inside pod: [test-command-execution-w9ddq], container: [busybox]
   1.581 [id=804]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1$1#onOpen: onOpen : java.util.concurrent.CountDownLatch@493f6d93[Count = 1]
   1.581 [id=900]	FINEST	o.c.j.p.k.p.ContainerExecDecorator#doExec: Executing command: "sh" "-c" "cd /tmp; echo pid is \$\$ > test; cat /tmp/test" 
exit

   1.581 [id=900]	INFO	o.c.j.p.k.p.ContainerExecDecorator$1#doLaunch: Created process inside pod: [test-command-execution-w9ddq], container: [busybox]
   1.581 [id=900]	INFO	o.c.j.p.k.p.ContainerExecDecorator$1#doLaunch: Created process inside pod: [test-command-execution-w9ddq], container: [busybox]
   1.636 [id=923]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1$1#onOpen: onOpen : java.util.concurrent.CountDownLatch@f846294[Count = 1]
   1.637 [id=902]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1#doLaunch: Launching with env vars: {aaaaaaaa0=bbbbbbbb, aaaaaaaa1=bbbbbbbb, aaaaaaaa10=bbbbbbbb, aaaaaaaa11=bbbbbbbb, aaaaaaaa12=bbbbbbbb, aaaaaaaa13=bbbbbbbb, aaaaaaaa14=bbbbbbbb, aaaaaaaa15=bbbbbbbb, aaaaaaaa16=bbbbbbbb, aaaaaaaa17=bbbbbbbb, aaaaaaaa18=bbbbbbbb, aaaaaaaa19=bbbbbbbb, aaaaaaaa2=bbbbbbbb, aaaaaaaa20=bbbbbbbb, aaaaaaaa21=bbbbbbbb, aaaaaaaa22=bbbbbbbb, aaaaaaaa23=bbbbbbbb, aaaaaaaa24=bbbbbbbb, aaaaaaaa25=bbbbbbbb, aaaaaaaa26=bbbbbbbb, aaaaaaaa27=bbbbbbbb, aaaaaaaa28=bbbbbbbb, aaaaaaaa29=bbbbbbbb, aaaaaaaa3=bbbbbbbb, aaaaaaaa30=bbbbbbbb, aaaaaaaa31=bbbbbbbb, aaaaaaaa32=bbbbbbbb, aaaaaaaa33=bbbbbbbb, aaaaaaaa34=bbbbbbbb, aaaaaaaa35=bbbbbbbb, aaaaaaaa36=bbbbbbbb, aaaaaaaa37=bbbbbbbb, aaaaaaaa38=bbbbbbbb, aaaaaaaa39=bbbbbbbb, aaaaaaaa4=bbbbbbbb, aaaaaaaa40=bbbbbbbb, aaaaaaaa41=bbbbbbbb, aaaaaaaa42=bbbbbbbb, aaaaaaaa43=bbbbbbbb, aaaaaaaa44=bbbbbbbb, aaaaaaaa45=bbbbbbbb, aaaaaaaa46=bbbbbbbb, aaaaaaaa47=bbbbbbbb, aaaaaaaa48=bbbbbbbb, aaaaaaaa49=bbbbbbbb, aaaaaaaa5=bbbbbbbb, aaaaaaaa6=bbbbbbbb, aaaaaaaa7=bbbbbbbb, aaaaaaaa8=bbbbbbbb, aaaaaaaa9=bbbbbbbb}
   1.638 [id=920]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1$1#onClose: onClose : java.util.concurrent.CountDownLatch@55952730[Count = 1]
   1.639 [id=902]	FINEST	o.c.j.p.k.p.ContainerExecDecorator#doExec: Executing command: "sh" "-c" "cd /tmp; echo pid is \$\$ > test; cat /tmp/test" 
exit

   1.639 [id=902]	INFO	o.c.j.p.k.p.ContainerExecDecorator$1#doLaunch: Created process inside pod: [test-command-execution-w9ddq], container: [busybox]
   1.639 [id=902]	INFO	o.c.j.p.k.p.ContainerExecDecorator$1#doLaunch: Created process inside pod: [test-command-execution-w9ddq], container: [busybox]
   1.739 [id=814]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1$1#onClose: onClose : java.util.concurrent.CountDownLatch@6b0ea605[Count = 1]
   1.819 [id=827]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1$1#onClose: onClose : java.util.concurrent.CountDownLatch@7aa2f90d[Count = 1]
   2.025 [id=922]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1$1#onClose: onClose : java.util.concurrent.CountDownLatch@1d9e3b5e[Count = 1]
   2.376 [id=925]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1$1#onClose: onClose : java.util.concurrent.CountDownLatch@189d49da[Count = 1]
   2.424 [id=807]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1$1#onClose: onClose : java.util.concurrent.CountDownLatch@5c16a8dd[Count = 1]
   2.453 [id=924]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1$1#onClose: onClose : java.util.concurrent.CountDownLatch@139c79ce[Count = 1]
   2.484 [id=804]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1$1#onClose: onClose : java.util.concurrent.CountDownLatch@493f6d93[Count = 1]
   2.508 [id=921]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1$1#onClose: onClose : java.util.concurrent.CountDownLatch@6460a2e4[Count = 1]
   2.540 [id=923]	FINEST	o.c.j.p.k.p.ContainerExecDecorator$1$1#onClose: onClose : java.util.concurrent.CountDownLatch@f846294[Count = 1]
   2.556 [id=1]	WARNING	o.c.j.p.k.KubernetesTestUtil#deletePods: Deleting leftover pods: [test-command-execution-w9ddq (Running)]
   2.575 [id=641]	WARNING	i.f.k.c.d.i.WatchConnectionManager$1#onFailure: Exec Failure
java.lang.IllegalStateException: Jenkins.instance is missing. Read the documentation of Jenkins.getInstanceOrNull to see what you are doing wrong.
	at jenkins.model.Jenkins.get(Jenkins.java:769)
	at org.csanchez.jenkins.plugins.kubernetes.pod.retention.Reaper.eventReceived(Reaper.java:114)
	at org.csanchez.jenkins.plugins.kubernetes.pod.retention.Reaper.eventReceived(Reaper.java:48)
	at io.fabric8.kubernetes.client.utils.WatcherToggle.eventReceived(WatcherToggle.java:49)
	at io.fabric8.kubernetes.client.dsl.internal.WatchConnectionManager$1.onMessage(WatchConnectionManager.java:232)
	at okhttp3.internal.ws.RealWebSocket.onReadMessage(RealWebSocket.java:323)
	at okhttp3.internal.ws.WebSocketReader.readMessageFrame(WebSocketReader.java:219)
	at okhttp3.internal.ws.WebSocketReader.processNextFrame(WebSocketReader.java:105)
	at okhttp3.internal.ws.RealWebSocket.loopReader(RealWebSocket.java:274)
	at okhttp3.internal.ws.RealWebSocket$2.onResponse(RealWebSocket.java:214)
	at okhttp3.RealCall$AsyncCall.execute(RealCall.java:206)
	at okhttp3.internal.NamedRunnable.run(NamedRunnable.java:32)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
   2.575 [id=722]	WARNING	i.f.k.c.d.i.WatchConnectionManager$1#onFailure: Exec Failure
java.lang.IllegalStateException: Jenkins.instance is missing. Read the documentation of Jenkins.getInstanceOrNull to see what you are doing wrong.
	at jenkins.model.Jenkins.get(Jenkins.java:769)
	at org.csanchez.jenkins.plugins.kubernetes.pod.retention.Reaper.eventReceived(Reaper.java:114)
	at org.csanchez.jenkins.plugins.kubernetes.pod.retention.Reaper.eventReceived(Reaper.java:48)
	at io.fabric8.kubernetes.client.utils.WatcherToggle.eventReceived(WatcherToggle.java:49)
	at io.fabric8.kubernetes.client.dsl.internal.WatchConnectionManager$1.onMessage(WatchConnectionManager.java:232)
	at okhttp3.internal.ws.RealWebSocket.onReadMessage(RealWebSocket.java:323)
	at okhttp3.internal.ws.WebSocketReader.readMessageFrame(WebSocketReader.java:219)
	at okhttp3.internal.ws.WebSocketReader.processNextFrame(WebSocketReader.java:105)
	at okhttp3.internal.ws.RealWebSocket.loopReader(RealWebSocket.java:274)
	at okhttp3.internal.ws.RealWebSocket$2.onResponse(RealWebSocket.java:214)
	at okhttp3.RealCall$AsyncCall.execute(RealCall.java:206)
	at okhttp3.internal.NamedRunnable.run(NamedRunnable.java:32)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
   2.579 [id=560]	WARNING	i.f.k.c.d.i.WatchConnectionManager$1#onFailure: Exec Failure
java.lang.IllegalStateException: Jenkins.instance is missing. Read the documentation of Jenkins.getInstanceOrNull to see what you are doing wrong.
	at jenkins.model.Jenkins.get(Jenkins.java:769)
	at org.csanchez.jenkins.plugins.kubernetes.pod.retention.Reaper.eventReceived(Reaper.java:114)
	at org.csanchez.jenkins.plugins.kubernetes.pod.retention.Reaper.eventReceived(Reaper.java:48)
	at io.fabric8.kubernetes.client.utils.WatcherToggle.eventReceived(WatcherToggle.java:49)
	at io.fabric8.kubernetes.client.dsl.internal.WatchConnectionManager$1.onMessage(WatchConnectionManager.java:232)
	at okhttp3.internal.ws.RealWebSocket.onReadMessage(RealWebSocket.java:323)
	at okhttp3.internal.ws.WebSocketReader.readMessageFrame(WebSocketReader.java:219)
	at okhttp3.internal.ws.WebSocketReader.processNextFrame(WebSocketReader.java:105)
	at okhttp3.internal.ws.RealWebSocket.loopReader(RealWebSocket.java:274)
	at okhttp3.internal.ws.RealWebSocket$2.onResponse(RealWebSocket.java:214)
	at okhttp3.RealCall$AsyncCall.execute(RealCall.java:206)
	at okhttp3.internal.NamedRunnable.run(NamedRunnable.java:32)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```