### PR TITLE
Update ReadME with `POD_LABEL` disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ use this cloud configuration you will need to add it in the jobs folder's config
 
 Nodes can be defined in a pipeline and then used, however, default execution always goes to the jnlp container.  You will need to specify the container you want to execute your task in.
 
+*Please note the `Pod_LABEL` is a new feature to automatically label the generated pod in versions `1.17.0` or higher, older versions of the Kubernetes Plugin will need to manually label the podTemplate*
+
 This will run in jnlp container
 ```groovy
 podTemplate {


### PR DESCRIPTION
Support has received complaints from users that the Scripts using `POD_LABEL` are not valid, as their instance was not on the newest Kubernetes Plugin version, and received the error:

`No such property: POD_LABEL for class: groovy.lang.Binding`