### PR TITLE
[JENKINS-58740] add missing pod label field attribute to config.jelly

### DIFF
--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/config.jelly
@@ -48,7 +48,7 @@
     </f:entry>
 
     <f:entry title="${%Pod Labels}" field="podLabels">
-        <f:repeatableHeteroProperty hasHeader="true" addCaption="${%Add Pod Label}"
+        <f:repeatableHeteroProperty field="podLabels" hasHeader="true" addCaption="${%Add Pod Label}"
                                     deleteCaption="${%Delete Pod Label}" />
     </f:entry>
 


### PR DESCRIPTION
The `repeatableHeteroProperty` does not get the field from the `entry` parent tag and results in a NPE when rendering the configure page. The `field` attribute is on both the `entry` and `repeatableHeteroProperty` to render the help correctly. This follows precedent set by other fields like `annotations` on PodTemplate.

fixes JENKINS-58740