### PR TITLE
Do not mount the full /root dir from secret with Kaniko

### DIFF
--- a/examples/kaniko-declarative.groovy
+++ b/examples/kaniko-declarative.groovy
@@ -29,7 +29,7 @@ spec:
     tty: true
     volumeMounts:
       - name: jenkins-docker-cfg
-        mountPath: /root
+        mountPath: /kaniko/.docker
   volumes:
   - name: jenkins-docker-cfg
     projected:
@@ -38,7 +38,7 @@ spec:
           name: regcred
           items:
             - key: .dockerconfigjson
-              path: .docker/config.json
+              path: config.json
 """
     }
   }

--- a/examples/kaniko.groovy
+++ b/examples/kaniko.groovy
@@ -22,7 +22,7 @@ spec:
     tty: true
     volumeMounts:
       - name: jenkins-docker-cfg
-        mountPath: /root
+        mountPath: /kaniko/.docker
   volumes:
   - name: jenkins-docker-cfg
     projected:
@@ -31,7 +31,7 @@ spec:
           name: regcred
           items:
             - key: .dockerconfigjson
-              path: .docker/config.json
+              path: config.json
 """
   ) {
 


### PR DESCRIPTION
It will cause the full dir to be read only and some builds will fail

```
failed to initialize build cache at /root/.cache/go-build: mkdir /root/.cache: read-only file system
```