### PR TITLE
[JENKINS-58766] Fix migration compatibility for working dir

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
@@ -34,6 +34,8 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
 
     public static final String DEFAULT_WORKING_DIR = "/home/jenkins/agent";
 
+    private static final String OLD_DEFAULT_WORKING_DIR = "/home/jenkins";
+
     private String name;
 
     private String image;
@@ -391,6 +393,9 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
 
     private Object readResolve() {
         this.workingDir = Util.fixEmpty(workingDir);
+        if (OLD_DEFAULT_WORKING_DIR.equals(workingDir)) {
+            this.workingDir = DEFAULT_WORKING_DIR;
+        }
         return this;
     }
 }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 
+import hudson.model.Label;
 import org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar;
 import org.csanchez.jenkins.plugins.kubernetes.pod.retention.Default;
 import org.csanchez.jenkins.plugins.kubernetes.pod.retention.Never;
@@ -88,6 +89,11 @@ public class KubernetesTest {
         assertEquals(2, labels.size());
         assertThat(cloud.getPodLabelsMap(), hasEntry("jenkins", "slave"));
         assertThat(cloud.getPodLabelsMap(), hasEntry("biff", "johnson"));
+        PodTemplate pt = cloud.getTemplate(Label.get("java"));
+        assertNotNull(pt);
+        for (ContainerTemplate ct : pt.getContainers()) {
+            assertEquals(ContainerTemplate.DEFAULT_WORKING_DIR, ct.getWorkingDir());
+        }
     }
 
     @Test

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest/upgradeFrom_1_17_2/config.xml
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest/upgradeFrom_1_17_2/config.xml
@@ -82,6 +82,30 @@
                 <successThreshold>0</successThreshold>
               </livenessProbe>
             </org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
+            <org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
+              <name>busybox</name>
+              <image>busybox</image>
+              <privileged>false</privileged>
+              <alwaysPullImage>false</alwaysPullImage>
+              <workingDir>/home/jenkins</workingDir>
+              <command>cat</command>
+              <args></args>
+              <ttyEnabled>false</ttyEnabled>
+              <resourceRequestCpu>500m</resourceRequestCpu>
+              <resourceRequestMemory>250Mi</resourceRequestMemory>
+              <resourceLimitCpu>500m</resourceLimitCpu>
+              <resourceLimitMemory>250Mi</resourceLimitMemory>
+              <envVars/>
+              <ports/>
+              <livenessProbe>
+                <execArgs></execArgs>
+                <timeoutSeconds>0</timeoutSeconds>
+                <initialDelaySeconds>0</initialDelaySeconds>
+                <failureThreshold>0</failureThreshold>
+                <periodSeconds>0</periodSeconds>
+                <successThreshold>0</successThreshold>
+              </livenessProbe>
+            </org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
           </containers>
           <envVars>
             <org.csanchez.jenkins.plugins.kubernetes.PodEnvVar>


### PR DESCRIPTION
[JENKINS-58766](https://issues.jenkins-ci.org/browse/JENKINS-58766)

Existing static container templates using workingDir = '/home/jenkins' are migrated automatically to '/home/jenkins/agent'.