### PR TITLE
Adding a DinD example

### DIFF
--- a/examples/dind.groovy
+++ b/examples/dind.groovy
@@ -1,0 +1,37 @@
+/*
+“Docker-in-Docker”: runs a Docker-based build where the Docker daemon and client are both defined in the pod.
+This allows you to control the exact version of Docker used.
+(For example, try DOCKER_BUILDKIT=1 to access advanced Dockerfile syntaxes.)
+There is no interaction with the container system used by Kubernetes:
+docker.sock does not need to be mounted as in dood.groovy.
+May or may not work depending on cluster policy: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
+*/
+podTemplate(yaml: '''
+apiVersion: v1
+kind: Pod
+spec:
+  containers:
+  - name: docker
+    image: docker:19.03.1
+    command:
+    - sleep
+    args:
+    - 99d
+    env:
+      - name: DOCKER_HOST
+        value: tcp://localhost:2375
+  - name: docker-daemon
+    image: docker:19.03.1-dind
+    securityContext:
+      privileged: true
+    env:
+      - name: DOCKER_TLS_CERTDIR
+        value: ""
+''') {
+    node(POD_LABEL) {
+        git 'https://github.com/jenkinsci/docker-jnlp-slave.git'
+        container('docker') {
+            sh 'docker version && DOCKER_BUILDKIT=1 docker build --progress plain -t testing .'
+        }
+    }
+}

--- a/examples/dood.groovy
+++ b/examples/dood.groovy
@@ -1,7 +1,6 @@
-/**
- * This pipeline will run a Docker image build
- */
-
+/*
+“Docker-outside-of-Docker”: runs a Docker-based build by connecting a Docker client inside the pod to the host daemon.
+*/
 podTemplate(yaml: """
 apiVersion: v1
 kind: Pod


### PR DESCRIPTION
Tested on GKE, and saw something similar running with a Kops cluster on AWS.

Could also experiment with [rootless Docker](https://medium.com/@tonistiigi/experimenting-with-rootless-docker-416c9ad8c0d6).

Note that every build gets a fresh Docker daemon, so there is no local layer cache between builds. This could make builds slower, though it also means builds are more deterministic and there is no need for a GC system. I have not experimented with using a `PersistentVolumeClaim` to retain the daemon storage across builds. Probably better to set up a local registry in the cluster as a proxy, just like we would advise for Maven dependencies and the like.