### PR TITLE
[JENKINS-59000] Upgrade kubernetes-client to 4.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <surefire.rerunFailingTestsCount>0</surefire.rerunFailingTestsCount>
     <pipeline-model-definition.version>1.3.7</pipeline-model-definition.version>
     <slf4jVersion>1.7.26</slf4jVersion>
-    <kubernetes-client.version>4.3.0</kubernetes-client.version>
+    <kubernetes-client.version>4.4.2</kubernetes-client.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
To get the fix in https://github.com/fabric8io/kubernetes-client/pull/1669

Origin header is set with port -1 when no port is present in the Kubernetes API url

Causing an error on exec

```
java.net.ProtocolException: Expected HTTP 101 response but was '403 Forbidden'
```