### PR TITLE
[JENKINS-47827 ] adding support Support passing a user/uid into containerTemplate

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
@@ -52,6 +52,8 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
 
     private String resourceRequestCpu;
 
+    private Long runAsUser;
+
     private String resourceRequestMemory;
 
     private String resourceLimitCpu;
@@ -94,6 +96,7 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
         this.setArgs(from.getArgs());
         this.setTtyEnabled(from.isTtyEnabled());
         this.setResourceRequestCpu(from.getResourceRequestCpu());
+        this.setRunAsUser(from.getRunAsUser());
         this.setResourceRequestMemory(from.getResourceRequestMemory());
         this.setResourceLimitCpu(from.getResourceLimitCpu());
         this.setResourceLimitMemory(from.getResourceLimitMemory());
@@ -167,6 +170,10 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
     public boolean isPrivileged() {
         return privileged;
     }
+    public Long isRunAsUser() {
+        return runAsUser;
+    }
+
 
     @DataBoundSetter
     public void setAlwaysPullImage(boolean alwaysPullImage) {
@@ -234,9 +241,18 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
         return resourceRequestCpu;
     }
 
+    public Long getRunAsUser(){
+        return runAsUser;
+    }
+
     @DataBoundSetter
     public void setResourceRequestCpu(String resourceRequestCpu) {
         this.resourceRequestCpu = resourceRequestCpu;
+    }
+
+    @DataBoundSetter
+    public void setRunAsUser(Long runAsUser) {
+        this.runAsUser = runAsUser;
     }
 
     public String getShell() {
@@ -300,6 +316,7 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
                 (args == null ? "" : ", args='" + args + '\'') +
                 (!ttyEnabled ? "" : ", ttyEnabled=" + ttyEnabled) +
                 (resourceRequestCpu == null ? "" : ", resourceRequestCpu='" + resourceRequestCpu + '\'') +
+                (runAsUser == null ? "" : ", runAsUser='" + runAsUser + '\'') +
                 (resourceRequestMemory == null ? "" : ", resourceRequestMemory='" + resourceRequestMemory + '\'') +
                 (resourceLimitCpu == null ? "" : ", resourceLimitCpu='" + resourceLimitCpu + '\'') +
                 (resourceLimitMemory == null ? "" : ", resourceLimitMemory='" + resourceLimitMemory + '\'') +
@@ -347,6 +364,9 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
         if (resourceRequestCpu != null ? !resourceRequestCpu.equals(that.resourceRequestCpu) : that.resourceRequestCpu != null) {
             return false;
         }
+        if (runAsUser != null ? !runAsUser.equals(that.runAsUser) : that.runAsUser != null) {
+            return false;
+        }
         if (resourceRequestMemory != null ? !resourceRequestMemory.equals(that.resourceRequestMemory) : that.resourceRequestMemory != null) {
             return false;
         }
@@ -379,6 +399,7 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
         result = 31 * result + (args != null ? args.hashCode() : 0);
         result = 31 * result + (ttyEnabled ? 1 : 0);
         result = 31 * result + (resourceRequestCpu != null ? resourceRequestCpu.hashCode() : 0);
+        result = 31 * result + (runAsUser != null ? runAsUser.hashCode() : 0);
         result = 31 * result + (resourceRequestMemory != null ? resourceRequestMemory.hashCode() : 0);
         result = 31 * result + (resourceLimitCpu != null ? resourceLimitCpu.hashCode() : 0);
         result = 31 * result + (resourceLimitMemory != null ? resourceLimitMemory.hashCode() : 0);

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -102,6 +102,8 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
 
     private String resourceRequestCpu;
 
+    private Long runAsUser;
+
     private String resourceRequestMemory;
 
     private String resourceLimitCpu;
@@ -440,6 +442,9 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
         return getFirstContainer().map(ContainerTemplate::isPrivileged).orElse(false);
     }
 
+    public Long isRunAsUser() { return getFirstContainer().map(ContainerTemplate::isRunAsUser).orElse(Integer.toUnsignedLong(0)); }
+
+
     public String getServiceAccount() {
         return serviceAccount;
     }
@@ -581,9 +586,21 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
     }
 
     @Deprecated
+    public Long getRunAsUser() {
+        return getFirstContainer().map(ContainerTemplate::getRunAsUser).orElse(Integer.toUnsignedLong(0));
+    }
+
+    @Deprecated
     @DataBoundSetter
     public void setResourceRequestCpu(String resourceRequestCpu) {
         getFirstContainer().ifPresent((i) -> i.setResourceRequestCpu(resourceRequestCpu));
+    }
+
+
+    @Deprecated
+    @DataBoundSetter
+    public void setRunAsUser(Long runAsUser) {
+        getFirstContainer().ifPresent((i) -> i.setRunAsUser(runAsUser));
     }
 
     @DataBoundSetter
@@ -708,6 +725,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
             containerTemplate.setResourceLimitCpu(resourceLimitCpu);
             containerTemplate.setResourceLimitMemory(resourceLimitMemory);
             containerTemplate.setResourceRequestCpu(resourceRequestCpu);
+            containerTemplate.setRunAsUser(runAsUser);
             containerTemplate.setWorkingDir(remoteFs);
             containers.add(containerTemplate);
         }
@@ -796,6 +814,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
             sb.append("* [").append(ct.getName()).append("] ").append(ct.getImage());
             StringBuilder optional = new StringBuilder();
             optionalField(optional, "resourceRequestCpu", ct.getResourceRequestCpu());
+            optionalField(optional, "runAsUser", ct.getRunAsUser().toString());
             optionalField(optional, "resourceRequestMemory", ct.getResourceRequestMemory());
             optionalField(optional, "resourceLimitCpu", ct.getResourceLimitCpu());
             optionalField(optional, "resourceLimitMemory", ct.getResourceLimitMemory());
@@ -881,6 +900,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
                 (nodeSelector == null ? "" : ", nodeSelector='" + nodeSelector + '\'') +
                 (nodeUsageMode == null ? "" : ", nodeUsageMode=" + nodeUsageMode) +
                 (resourceRequestCpu == null ? "" : ", resourceRequestCpu='" + resourceRequestCpu + '\'') +
+                (runAsUser == null ? "" : ", runAsUser='" + runAsUser + '\'') +
                 (resourceRequestMemory == null ? "" : ", resourceRequestMemory='" + resourceRequestMemory + '\'') +
                 (resourceLimitCpu == null ? "" : ", resourceLimitCpu='" + resourceLimitCpu + '\'') +
                 (resourceLimitMemory == null ? "" : ", resourceLimitMemory='" + resourceLimitMemory + '\'') +

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -359,6 +359,7 @@ public class PodTemplateBuilder {
                 .withImagePullPolicy(containerTemplate.isAlwaysPullImage() ? "Always" : "IfNotPresent")
                 .withNewSecurityContext()
                 .withPrivileged(containerTemplate.isPrivileged())
+                .withRunAsUser(containerTemplate.isRunAsUser())
                 .endSecurityContext()
                 .withWorkingDir(workingDir)
                 .withVolumeMounts(containerMounts.toArray(new VolumeMount[containerMounts.size()]))

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
@@ -58,6 +58,7 @@ import io.fabric8.kubernetes.api.model.PodFluent.SpecNested;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.SecurityContext;
 import io.fabric8.kubernetes.api.model.Toleration;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
@@ -92,6 +93,7 @@ public class PodTemplateUtils {
         String args = Strings.isNullOrEmpty(template.getArgs()) ? parent.getArgs() : template.getArgs();
         boolean ttyEnabled = template.isTtyEnabled() ? template.isTtyEnabled() : (parent.isTtyEnabled() ? parent.isTtyEnabled() : false);
         String resourceRequestCpu = Strings.isNullOrEmpty(template.getResourceRequestCpu()) ? parent.getResourceRequestCpu() : template.getResourceRequestCpu();
+        Long runAsUser = parent.getRunAsUser()  ==  Integer.toUnsignedLong(0) ? parent.getRunAsUser() : template.getRunAsUser();
         String resourceRequestMemory = Strings.isNullOrEmpty(template.getResourceRequestMemory()) ? parent.getResourceRequestMemory() : template.getResourceRequestMemory();
         String resourceLimitCpu = Strings.isNullOrEmpty(template.getResourceLimitCpu()) ? parent.getResourceLimitCpu() : template.getResourceLimitCpu();
         String resourceLimitMemory = Strings.isNullOrEmpty(template.getResourceLimitMemory()) ? parent.getResourceLimitMemory() : template.getResourceLimitMemory();
@@ -108,6 +110,7 @@ public class PodTemplateUtils {
         combined.setTtyEnabled(ttyEnabled);
         combined.setResourceLimitCpu(resourceLimitCpu);
         combined.setResourceLimitMemory(resourceLimitMemory);
+        combined.setRunAsUser(runAsUser);
         combined.setResourceRequestCpu(resourceRequestCpu);
         combined.setResourceRequestMemory(resourceRequestMemory);
         combined.setWorkingDir(workingDir);
@@ -139,6 +142,8 @@ public class PodTemplateUtils {
                 : (parent.getSecurityContext() != null ? parent.getSecurityContext().getPrivileged() : Boolean.FALSE);
         String imagePullPolicy = Strings.isNullOrEmpty(template.getImagePullPolicy()) ? parent.getImagePullPolicy()
                 : template.getImagePullPolicy();
+        Long runAsUser = template.getSecurityContext().getRunAsUser()  ==  Integer.toUnsignedLong(0) ? parent.getSecurityContext().getRunAsUser() : template.getSecurityContext().getRunAsUser();
+
         String workingDir = Strings.isNullOrEmpty(template.getWorkingDir())
                 ? (Strings.isNullOrEmpty(parent.getWorkingDir()) ? DEFAULT_WORKING_DIR : parent.getWorkingDir())
                 : template.getWorkingDir();
@@ -167,6 +172,7 @@ public class PodTemplateUtils {
                 .withEnv(combineEnvVars(parent, template)) //
                 .withEnvFrom(combinedEnvFromSources(parent, template))
                 .withNewSecurityContext().withPrivileged(privileged).endSecurityContext() //
+                .withNewSecurityContext().withRunAsUser(runAsUser).endSecurityContext() //
                 .withVolumeMounts(new ArrayList<>(volumeMounts.values())) //
                 .build();
 


### PR DESCRIPTION
Signed-off-by: eefrat <elhay.efrat@intel.com>

https://issues.jenkins-ci.org/browse/JENKINS-47827?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aall-tabpanel


Currently, the kubernetes plugin can't run jobs in containers that have unpriveleged users baked into their image metadata. 

Supporting jobs running as unpriveleged users is a more difficult task. Maybe a minimal solution to this is to allow the user to override the user. Kubernetes supports this, so it should be reasonably straight forward to add a "user" field to the containerTemplate() call.


adding runAsUser option for adding userID 