### PR TITLE
Switch /project/url from Confluence to GitHub

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <name>Kubernetes plugin</name>
   <description>Jenkins plugin to run dynamic agents in a Kubernetes cluster</description>
   <packaging>hpi</packaging>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/Kubernetes+Plugin</url>
+  <url>https://github.com/jenkinsci/kubernetes-plugin</url>
 
   <scm>
     <connection>scm:git:https://github.com/jenkinsci/kubernetes-plugin.git</connection>


### PR DESCRIPTION
See announcement from @oleg-nenashev on the dev list. If merged, we should also delete all real content from Confluence and just say point to GitHub.