### PR TITLE
Fix scope for some git plugin transitive dependencies getting pulled as 'compile' instead of 'test'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -225,6 +225,20 @@
         <artifactId>jackson-dataformat-yaml</artifactId>
         <version>2.9.9</version>
       </dependency>
+      <dependency>
+        <!-- Transitive dependency of test-scoped git-plugin, should not be packaged -->
+        <groupId>joda-time</groupId>
+        <artifactId>joda-time</artifactId>
+        <version>2.9.5</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <!-- Transitive dependency of test-scoped git-plugin, should not be packaged -->
+        <groupId>io.jenkins.temp.jelly</groupId>
+        <artifactId>multiline-secrets-ui</artifactId>
+        <version>1.0</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -154,12 +154,34 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <!-- Already included through pipeline-model-extensions and causing them to be packaged -->
+        <exclusion>
+          <groupId>org.jenkins-ci.plugins</groupId>
+          <artifactId>ssh-credentials</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>joda-time</groupId>
+          <artifactId>joda-time</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
       <classifier>tests</classifier>
       <scope>test</scope>
+      <exclusions>
+        <!-- Already included through pipeline-model-extensions and causing them to be packaged -->
+        <exclusion>
+          <groupId>org.jenkins-ci.plugins</groupId>
+          <artifactId>ssh-credentials</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>joda-time</groupId>
+          <artifactId>joda-time</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -174,9 +196,9 @@
       <version>1.17</version>
       <scope>test</scope>
       <exclusions>
-        <exclusion> <!-- pluginFirstClassLoader, and anyway kroniak/ssh-client includes /usr/bin/ssh-agent so JVM client is unused -->
-          <groupId>org.apache.sshd</groupId>
-          <artifactId>sshd-core</artifactId>
+        <exclusion>
+          <groupId>org.jenkins-ci.plugins</groupId>
+          <artifactId>ssh-credentials</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -225,20 +247,6 @@
         <artifactId>jackson-dataformat-yaml</artifactId>
         <version>2.9.9</version>
       </dependency>
-      <dependency>
-        <!-- Transitive dependency of test-scoped git-plugin, should not be packaged -->
-        <groupId>joda-time</groupId>
-        <artifactId>joda-time</artifactId>
-        <version>2.9.5</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <!-- Transitive dependency of test-scoped git-plugin, should not be packaged -->
-        <groupId>io.jenkins.temp.jelly</groupId>
-        <artifactId>multiline-secrets-ui</artifactId>
-        <version>1.0</version>
-        <scope>test</scope>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -262,13 +270,6 @@
         <groupId>org.jenkins-ci.tools</groupId>
         <artifactId>maven-hpi-plugin</artifactId>
         <configuration>
-          <!-- with the default setting seems that an older version of jackson from core is used
-            java.lang.NoSuchMethodError: com.fasterxml.jackson.core.JsonFactory.requiresPropertyOrdering()Z
-            at com.fasterxml.jackson.databind.ObjectMapper.<init>(ObjectMapper.java:549)
-            at com.fasterxml.jackson.databind.ObjectMapper.<init>(ObjectMapper.java:460)
-            at io.fabric8.kubernetes.client.utils.Serialization.<clinit>(Serialization.java:37)
-          -->
-          <pluginFirstClassLoader>true</pluginFirstClassLoader>
           <systemProperties>
             <hudson.slaves.NodeProvisioner.initialDelay>0</hudson.slaves.NodeProvisioner.initialDelay>
             <hudson.slaves.NodeProvisioner.MARGIN>50</hudson.slaves.NodeProvisioner.MARGIN>

--- a/pom.xml
+++ b/pom.xml
@@ -197,6 +197,10 @@
       <scope>test</scope>
       <exclusions>
         <exclusion>
+          <groupId>org.apache.sshd</groupId>
+          <artifactId>sshd-core</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.jenkins-ci.plugins</groupId>
           <artifactId>ssh-credentials</artifactId>
         </exclusion>


### PR DESCRIPTION
hpi plugin bug?