### PR TITLE
Align working dirs

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
@@ -44,7 +44,7 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
 
     private boolean alwaysPullImage;
 
-    private String workingDir = DEFAULT_WORKING_DIR;
+    private String workingDir;
 
     private String command;
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -217,11 +217,12 @@ public class PodTemplateBuilder {
         if (!jnlpOpt.isPresent()) {
             pod.getSpec().getContainers().add(jnlp);
         }
+        pod.getSpec().getContainers().stream().filter(c -> c.getWorkingDir() == null).forEach(c -> c.setWorkingDir(jnlp.getWorkingDir()));
         if (StringUtils.isBlank(jnlp.getImage())) {
             jnlp.setImage(DEFAULT_JNLP_IMAGE);
         }
         Map<String, EnvVar> envVars = new HashMap<>();
-        envVars.putAll(jnlpEnvVars(jnlp.getWorkingDir() != null ? jnlp.getWorkingDir() : ContainerTemplate.DEFAULT_WORKING_DIR));
+        envVars.putAll(jnlpEnvVars(jnlp.getWorkingDir()));
         envVars.putAll(defaultEnvVars(template.getEnvVars()));
         envVars.putAll(jnlp.getEnv().stream().collect(Collectors.toMap(EnvVar::getName, Function.identity())));
         jnlp.setEnv(new ArrayList<>(envVars.values()));
@@ -287,6 +288,9 @@ public class PodTemplateBuilder {
     }
 
     private Map<String, EnvVar> jnlpEnvVars(String workingDir) {
+        if (workingDir == null) {
+            workingDir = ContainerTemplate.DEFAULT_WORKING_DIR;
+        }
         // Last-write wins map of environment variable names to values
         HashMap<String, String> env = new HashMap<>();
 

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
@@ -447,4 +447,9 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
         r.assertBuildStatusSuccess(r.waitForCompletion(b));
         r.assertLogNotContains(jnlpMac, b);
     }
+
+    @Test
+    public void jnlpWorkingDir() throws Exception {
+        r.assertBuildStatusSuccess(r.waitForCompletion(b));
+    }
 }

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/jnlpWorkingDir.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/jnlpWorkingDir.groovy
@@ -1,0 +1,13 @@
+podTemplate(containers: [
+        containerTemplate(name: 'jnlp', image: 'jenkinsci/jnlp-slave:latest', workingDir: '/home/jenkins'),
+        containerTemplate(name: 'busybox', image: 'busybox', ttyEnabled: true, command: '/bin/cat')
+]) {
+    node (POD_LABEL) {
+      stage('Run') {
+        sh 'env | sort'
+        container('busybox') {
+          sh 'env | sort'
+        }
+      }
+    }
+}

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/jnlpWorkingDir.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/jnlpWorkingDir.groovy
@@ -1,13 +1,13 @@
 podTemplate(containers: [
-        containerTemplate(name: 'jnlp', image: 'jenkinsci/jnlp-slave:latest', workingDir: '/home/jenkins'),
-        containerTemplate(name: 'busybox', image: 'busybox', ttyEnabled: true, command: '/bin/cat')
+    containerTemplate(name: 'jnlp', image: 'jenkinsci/jnlp-slave:latest', workingDir: '/home/jenkins'),
+    containerTemplate(name: 'busybox', image: 'busybox', ttyEnabled: true, command: '/bin/cat')
 ]) {
     node (POD_LABEL) {
-      stage('Run') {
-        sh 'env | sort'
-        container('busybox') {
-          sh 'env | sort'
+        stage('Run') {
+            sh 'env | sort'
+            container('busybox') {
+                sh 'env | sort'
+            }
         }
-      }
     }
 }


### PR DESCRIPTION
If containers don't specify an explicit working dir, just use the one
specified in jnlp, because if they don't match, the build will fail
anyway.