### PR TITLE
Adding changes to accommodate to situation when k8s API server is behind firewall

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesClientProvider.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesClientProvider.java
@@ -92,7 +92,7 @@ public class KubernetesClientProvider {
         String displayName = cloud.getDisplayName();
         final Client c = clients.getIfPresent(displayName);
         if (c == null) {
-            KubernetesClient client = new KubernetesFactoryAdapter(cloud.getServerUrl(), cloud.getNamespace(),
+            KubernetesClient client = new KubernetesFactoryAdapter(cloud.getServerUrl(), cloud.getHttps_proxy(), cloud.getNamespace(),
                     cloud.getServerCertificate(), cloud.getCredentialsId(), cloud.isSkipTlsVerify(),
                     cloud.getConnectTimeout(), cloud.getReadTimeout(), cloud.getMaxRequestsPerHost()).createClient();
             clients.put(displayName, new Client(getValidity(cloud), client));

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -98,6 +98,7 @@ public class KubernetesCloud extends Cloud {
     @Nonnull
     private List<PodTemplate> templates = new ArrayList<>();
     private String serverUrl;
+    private String https_proxy;
     @CheckForNull
     private String serverCertificate;
 
@@ -148,6 +149,7 @@ public class KubernetesCloud extends Cloud {
         this.defaultsProviderTemplate = source.defaultsProviderTemplate;
         this.templates.addAll(source.templates);
         this.serverUrl = source.serverUrl;
+        this.https_proxy = source.https_proxy;
         this.skipTlsVerify = source.skipTlsVerify;
         this.addMasterProxyEnvVars = source.addMasterProxyEnvVars;
         this.namespace = source.namespace;
@@ -246,6 +248,15 @@ public class KubernetesCloud extends Cloud {
     @DataBoundSetter
     public void setServerUrl(@Nonnull String serverUrl) {
         this.serverUrl = serverUrl;
+    }
+
+    public String getHttps_proxy() {
+        return https_proxy;
+    }
+
+    @DataBoundSetter
+    public void setHttps_proxy(@Nonnull String https_proxy) {
+        this.https_proxy = https_proxy;
     }
 
     public String getServerCertificate() {
@@ -731,6 +742,7 @@ public class KubernetesCloud extends Cloud {
                                                @QueryParameter String serverCertificate,
                                                @QueryParameter boolean skipTlsVerify,
                                                @QueryParameter String namespace,
+                                               @QueryParameter String https_proxy,
                                                @QueryParameter int connectionTimeout,
                                                @QueryParameter int readTimeout) throws Exception {
             Jenkins.get().checkPermission(Jenkins.ADMINISTER);
@@ -738,7 +750,7 @@ public class KubernetesCloud extends Cloud {
             if (StringUtils.isBlank(name))
                 return FormValidation.error("name is required");
 
-            try (KubernetesClient client = new KubernetesFactoryAdapter(serverUrl, namespace,
+            try (KubernetesClient client = new KubernetesFactoryAdapter(serverUrl, https_proxy, namespace,
                         Util.fixEmpty(serverCertificate), Util.fixEmpty(credentialsId), skipTlsVerify,
                         connectionTimeout, readTimeout).createClient()) {
                     // test listing pods

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFactoryAdapter.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFactoryAdapter.java
@@ -71,23 +71,24 @@ public class KubernetesFactoryAdapter {
     private final int connectTimeout;
     private final int readTimeout;
     private final int maxRequestsPerHost;
+    private final String https_proxy;
 
     public KubernetesFactoryAdapter(String serviceAddress, @CheckForNull String caCertData,
                                     @CheckForNull String credentials, boolean skipTlsVerify) {
-        this(serviceAddress, null, caCertData, credentials, skipTlsVerify);
+        this(serviceAddress, null, null, caCertData, credentials, skipTlsVerify);
     }
 
-    public KubernetesFactoryAdapter(String serviceAddress, String namespace, @CheckForNull String caCertData,
+    public KubernetesFactoryAdapter(String serviceAddress, @CheckForNull String https_proxy, String namespace, @CheckForNull String caCertData,
                                     @CheckForNull String credentials, boolean skipTlsVerify) {
-        this(serviceAddress, namespace, caCertData, credentials, skipTlsVerify, DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT);
+        this(serviceAddress, https_proxy, namespace, caCertData, credentials, skipTlsVerify, DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT);
     }
 
-    public KubernetesFactoryAdapter(String serviceAddress, String namespace, @CheckForNull String caCertData,
+    public KubernetesFactoryAdapter(String serviceAddress, @CheckForNull String https_proxy, String namespace, @CheckForNull String caCertData,
                                     @CheckForNull String credentials, boolean skipTlsVerify, int connectTimeout, int readTimeout) {
-        this(serviceAddress, namespace, caCertData, credentials, skipTlsVerify, connectTimeout, readTimeout, KubernetesCloud.DEFAULT_MAX_REQUESTS_PER_HOST);
+        this(serviceAddress, https_proxy, namespace, caCertData, credentials, skipTlsVerify, connectTimeout, readTimeout, KubernetesCloud.DEFAULT_MAX_REQUESTS_PER_HOST);
     }
 
-    public KubernetesFactoryAdapter(String serviceAddress, String namespace, @CheckForNull String caCertData,
+    public KubernetesFactoryAdapter(String serviceAddress, @CheckForNull String https_proxy, String namespace, @CheckForNull String caCertData,
                                     @CheckForNull String credentials, boolean skipTlsVerify, int connectTimeout, int readTimeout, int maxRequestsPerHost) {
         this.serviceAddress = serviceAddress;
         this.namespace = namespace;
@@ -97,6 +98,7 @@ public class KubernetesFactoryAdapter {
         this.connectTimeout = connectTimeout;
         this.readTimeout = readTimeout;
         this.maxRequestsPerHost = maxRequestsPerHost;
+        this.https_proxy = https_proxy != null && !https_proxy.isEmpty() ? https_proxy : null;
     }
 
     private StandardCredentials getCredentials(String credentials) {
@@ -170,6 +172,11 @@ public class KubernetesFactoryAdapter {
 
         builder = builder.withRequestTimeout(readTimeout * 1000).withConnectionTimeout(connectTimeout * 1000);
         builder.withMaxConcurrentRequestsPerHost(maxRequestsPerHost);
+
+        if(https_proxy != null && !https_proxy.isEmpty()) {
+            LOGGER.info("Http proxy used is " + https_proxy);
+            builder.withHttpsProxy(https_proxy);
+        }
 
         if (!StringUtils.isBlank(namespace)) {
             builder.withNamespace(namespace);

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubectlBuildWrapper/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubectlBuildWrapper/config.jelly
@@ -5,6 +5,10 @@
     <f:textbox/>
   </f:entry>
 
+  <f:entry field="https_proxy" title="${%https_proxy}">
+    <f:textbox/>
+  </f:entry>
+
   <f:entry title="${%Certificate of certificate authority (CA)}" field="caCertificate">
     <f:textarea/>
   </f:entry>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubectlBuildWrapper/help-https_proxy.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubectlBuildWrapper/help-https_proxy.html
@@ -1,0 +1,3 @@
+<div>
+    Use proxy when kubernetes api server is behind the firewall.
+</div>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/config.jelly
@@ -9,6 +9,10 @@
       <f:textbox/>
     </f:entry>
 
+    <f:entry title="${%https_proxy}" field="https_proxy">
+        <f:textbox/>
+    </f:entry>
+
     <f:entry title="${%Kubernetes server certificate key}" field="serverCertificate">
       <f:textarea/>
     </f:entry>
@@ -25,7 +29,7 @@
       <c:select/>
     </f:entry>
 
-    <f:validateButton title="${%Test Connection}" progress="${%Testing...}" method="testConnection" with="name,serverUrl,credentialsId,serverCertificate,skipTlsVerify,namespace" />
+    <f:validateButton title="${%Test Connection}" progress="${%Testing...}" method="testConnection" with="name,serverUrl,credentialsId,serverCertificate,skipTlsVerify,namespace,https_proxy" />
 
     <f:entry title="${%Jenkins URL}" field="jenkinsUrl">
       <f:textbox />

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/help-https_proxy.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/help-https_proxy.html
@@ -1,0 +1,3 @@
+<div>
+    Use proxy when kubernetes api server is behind the firewall.
+</div>


### PR DESCRIPTION
* Adding changes to accommodate to situation when k8s API server is behind firewall.
* This will run kubectl commands using proxy when the value is set and ignore it otherwise.