### PR TITLE
[JENKINS-47591] dynamic pvc workspace volume

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
@@ -38,9 +38,7 @@ import java.util.stream.Collectors;
 
 import javax.annotation.CheckForNull;
 
-import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import org.apache.commons.lang.StringUtils;
-import org.csanchez.jenkins.plugins.kubernetes.volumes.workspace.DynamicPVCWorkspaceVolume;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import com.google.common.base.Throwables;

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
@@ -38,7 +38,9 @@ import java.util.stream.Collectors;
 
 import javax.annotation.CheckForNull;
 
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import org.apache.commons.lang.StringUtils;
+import org.csanchez.jenkins.plugins.kubernetes.volumes.workspace.DynamicPVCWorkspaceVolume;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import com.google.common.base.Throwables;
@@ -126,6 +128,9 @@ public class KubernetesLauncher extends JNLPLauncher {
             listener.getLogger().printf("Created Pod: %s/%s%n", namespace, podId);
             String podName = pod.getMetadata().getName();
             String namespace1 = pod.getMetadata().getNamespace();
+            if (template.getWorkspaceVolume() != null){
+                template.getWorkspaceVolume().createVolume(client, pod.getMetadata());
+            }
             watcher = new AllContainersRunningPodWatcher(client, pod);
             try (Watch _w = client.pods().inNamespace(namespace1).withName(podName).watch(watcher)) {
                 watcher.await(template.getSlaveConnectTimeout(), TimeUnit.SECONDS);

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -140,7 +140,9 @@ public class PodTemplateBuilder {
         if (template.getWorkspaceVolume() != null) {
             LOGGER.log(Level.FINE, "Adding workspace volume from template: {0}",
                     template.getWorkspaceVolume().toString());
-            volumes.put(WORKSPACE_VOLUME_NAME, template.getWorkspaceVolume().buildVolume(WORKSPACE_VOLUME_NAME));
+            if (slave != null) {
+                volumes.put(WORKSPACE_VOLUME_NAME, template.getWorkspaceVolume().buildVolume(WORKSPACE_VOLUME_NAME, slave.getPodName()));
+            }
         } else {
             // add an empty volume to share the workspace across the pod
             LOGGER.log(Level.FINE, "Adding empty workspace volume");

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes/workspace/DynamicPVCWorkspaceVolume.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes/workspace/DynamicPVCWorkspaceVolume.java
@@ -1,0 +1,136 @@
+package org.csanchez.jenkins.plugins.kubernetes.volumes.workspace;
+
+import com.google.common.collect.ImmutableMap;
+import hudson.Extension;
+import hudson.model.Descriptor;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.OwnerReference;
+import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimBuilder;
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static java.util.logging.Level.INFO;
+import static org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud.DEFAULT_POD_LABELS;
+import static org.csanchez.jenkins.plugins.kubernetes.PodTemplateUtils.substituteEnv;
+
+/**
+ * @author <a href="root@junwuhui.cn">runzexia</a>
+ */
+public class DynamicPVCWorkspaceVolume extends WorkspaceVolume {
+    private String storageClassName;
+    private String requestsSize;
+    private String accessModes;
+    private static final Logger LOGGER = Logger.getLogger(DynamicPVCWorkspaceVolume.class.getName());
+
+    @DataBoundConstructor
+    public DynamicPVCWorkspaceVolume(String storageClassName,
+                                     String requestsSize, String accessModes) {
+        this.storageClassName = storageClassName;
+        this.requestsSize = requestsSize;
+        this.accessModes = accessModes;
+    }
+
+    public String getAccessModes() {
+        return accessModes;
+    }
+
+    public String getRequestsSize() {
+        return requestsSize;
+    }
+
+    public String getStorageClassName() {
+        return storageClassName;
+    }
+
+
+    @Override
+    public Volume buildVolume(String volumeName, String podName) {
+        return new VolumeBuilder()
+                .withName(volumeName)
+                .withNewPersistentVolumeClaim()
+                .withClaimName("pvc-" + podName)
+                .withReadOnly(false)
+                .and()
+                .build();
+    }
+
+    @Override
+    public PersistentVolumeClaim createVolume(KubernetesClient client, ObjectMeta podMetaData){
+        String namespace = podMetaData.getNamespace();
+        String podId = podMetaData.getName();
+        LOGGER.log(Level.FINE, "Adding workspace volume from pod: {0}/{1}", new Object[] { namespace, podId });
+        OwnerReference ownerReference = new OwnerReferenceBuilder().
+                withApiVersion("v1").
+                withKind("Pod").
+                withBlockOwnerDeletion(true).
+                withController(true).
+                withName(podMetaData.getName()).
+                withUid(podMetaData.getUid()).build();
+
+         PersistentVolumeClaim pvc = new PersistentVolumeClaimBuilder()
+                .withNewMetadata()
+                .withName("pvc-" + podMetaData.getName())
+                .withOwnerReferences(ownerReference)
+                .withLabels(DEFAULT_POD_LABELS)
+                .endMetadata()
+                .withNewSpec()
+                .withAccessModes(getAccessModesOrDefault())
+                .withNewResources()
+                .withRequests(getResourceMap())
+                .endResources()
+                .withStorageClassName(getStorageClassNameOrDefault())
+                .endSpec()
+                .build();
+         pvc = client.persistentVolumeClaims().inNamespace(podMetaData.getNamespace()).create(pvc);
+         LOGGER.log(INFO, "Created PVC: {0}/{1}", new Object[] { namespace, pvc.getMetadata().getName() });
+         return pvc;
+    }
+
+    public String getStorageClassNameOrDefault(){
+        if (getStorageClassName() != null) {
+            return getStorageClassName();
+        }
+        return null;
+    }
+
+    public String getAccessModesOrDefault() {
+        if (getAccessModes() != null) {
+            return getAccessModes();
+        }
+        return "ReadWriteOnce";
+    }
+
+    public String getRequestsSizeOrDefault() {
+        if (getRequestsSize() != null) {
+            return getRequestsSize();
+        }
+        return "10Gi";
+    }
+
+    protected Map<String, Quantity> getResourceMap() {
+        ImmutableMap.Builder<String, Quantity> builder = ImmutableMap.<String, Quantity>builder();
+        String actualStorage = substituteEnv(getRequestsSizeOrDefault());
+            Quantity storageQuantity = new Quantity(actualStorage);
+            builder.put("storage", storageQuantity);
+        return builder.build();
+    }
+
+    @Extension
+    @Symbol("dynamicPVC")
+    public static class DescriptorImpl extends Descriptor<WorkspaceVolume> {
+        @Override
+        public String getDisplayName() {
+            return "Dynamic Persistent Volume Claim Workspace Volume";
+        }
+    }
+}

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes/workspace/WorkspaceVolume.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes/workspace/WorkspaceVolume.java
@@ -27,7 +27,10 @@ package org.csanchez.jenkins.plugins.kubernetes.volumes.workspace;
 import java.io.Serializable;
 
 import hudson.model.AbstractDescribableImpl;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.client.KubernetesClient;
 
 /**
  * Base class for all Kubernetes volume types
@@ -36,6 +39,18 @@ public abstract class WorkspaceVolume extends AbstractDescribableImpl<WorkspaceV
 
     private static final long serialVersionUID = 5367004248055474414L;
 
+    // Builds a Volume model with the given name.require podName to generate pvc name
+    public Volume buildVolume(String volumeName, String podName){
+        return buildVolume(volumeName);
+    };
+
     // Builds a Volume model with the given name.
-    public abstract Volume buildVolume(String volumeName);
+    @Deprecated
+    public Volume buildVolume(String volumeName){
+        throw new UnsupportedOperationException("could not build volume without podName");
+    }
+
+    public PersistentVolumeClaim createVolume(KubernetesClient client, ObjectMeta podMetaData) {
+        return null;
+    }
 }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
@@ -452,4 +452,15 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
     public void jnlpWorkingDir() throws Exception {
         r.assertBuildStatusSuccess(r.waitForCompletion(b));
     }
+
+    @Test
+    public void dynamicPVC() throws Exception {
+        try {
+            cloud.connect().persistentVolumeClaims().list();
+        } catch (KubernetesClientException x) {
+            // Error from server (Forbidden): persistentvolumeclaims is forbidden: User "system:serviceaccount:kubernetes-plugin-test:default" cannot list resource "persistentvolumeclaims" in API group "" in the namespace "kubernetes-plugin-test"
+            assumeNoException("was not permitted to list pvcs, so presumably cannot run test either", x);
+        }
+        r.assertBuildStatusSuccess(r.waitForCompletion(b));
+    }
 }

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/dynamicPVC.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/dynamicPVC.groovy
@@ -1,0 +1,11 @@
+podTemplate(workspaceVolume: dynamicPVC(requestsSize: "10Gi"), containers: [
+        containerTemplate(name: 'jnlp', image: 'jenkins/jnlp-slave:3.10-1-alpine', args: '${computer.jnlpmac} ${computer.name}')
+]) {
+
+    node(POD_LABEL) {
+        container(name: 'jnlp') {
+            sh 'cat /var/run/secrets/kubernetes.io/serviceaccount/namespace'
+            git 'https://github.com/jenkinsci/kubernetes-plugin.git'
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: runzexia <runzexia@yunify.com>
 Add this kind of workspace volume because during use, we found that some IO-intensive tasks have some problems with the performance of emptyDir.
I want to use dynamic pvc to avoid this performance problem.


When I implemented this part, I found that the original WorkspaceVolume abstract class seems to be only suitable for static PVC.
So I want to find some comments about this part of the code, any comments are very grateful

@Vlatombe @jglick 