### PR TITLE
Experiment: Remove nodemonitors to speed up tests

### DIFF
--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/AbstractKubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/AbstractKubernetesPipelineTest.java
@@ -34,6 +34,8 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
 
+import hudson.ExtensionList;
+import hudson.node_monitors.NodeMonitor;
 import org.apache.commons.lang3.StringUtils;
 import org.csanchez.jenkins.plugins.kubernetes.ContainerEnvVar;
 import org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate;
@@ -140,6 +142,7 @@ public abstract class AbstractKubernetesPipelineTest {
 
     @Before
     public void configureCloud() throws Exception {
+        ExtensionList.lookup(NodeMonitor.class).clear();
         cloud = setupCloud(this, name);
         createSecret(cloud.connect(), cloud.getNamespace());
         cloud.getTemplates().clear();

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/RestartPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/RestartPipelineTest.java
@@ -36,6 +36,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import hudson.ExtensionList;
+import hudson.node_monitors.NodeMonitor;
 import org.apache.commons.compress.utils.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.csanchez.jenkins.plugins.kubernetes.ContainerEnvVar;
@@ -123,6 +125,7 @@ public class RestartPipelineTest {
     }
 
     public void configureCloud() throws Exception {
+        ExtensionList.lookup(NodeMonitor.class).clear();
         cloud = setupCloud(this, name);
         createSecret(cloud.connect(), cloud.getNamespace());
         cloud.getTemplates().clear();


### PR DESCRIPTION
Sometimes the kubernetes agents come and go so quickly that there is no
time for node monitors to run. As a result, the test takes longer just
because it has to wait for node monitors to time out.