### PR TITLE
PodTemplate’s copy constructor was incomplete

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -162,6 +162,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
     public PodTemplate(PodTemplate from) {
         XStream2 xs = new XStream2();
         xs.unmarshal(XStream2.getDefaultDriver().createReader(new StringReader(xs.toXML(from))), this);
+        this.yamls = from.yamls;
     }
 
     @Deprecated

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -171,12 +171,15 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
         this.setServiceAccount(from.getServiceAccount());
         this.setSlaveConnectTimeout(from.getSlaveConnectTimeout());
         this.setActiveDeadlineSeconds(from.getActiveDeadlineSeconds());
+        this.setIdleMinutes(from.getIdleMinutes());
         this.setVolumes(from.getVolumes());
         this.setWorkspaceVolume(from.getWorkspaceVolume());
         this.yaml = from.yaml;
         this.setYamls(from.getYamls());
-        this.setShowRawYaml(from.isShowRawYaml());
-        this.setNodeProperties(from.getNodeProperties());
+        this.showRawYaml = from.showRawYaml;
+        if (from.nodeProperties != null) {
+            this.setNodeProperties(from.getNodeProperties());
+        }
         this.setPodRetention(from.getPodRetention());
     }
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -39,8 +39,10 @@ import hudson.model.Node;
 import hudson.model.Saveable;
 import hudson.model.labels.LabelAtom;
 import hudson.slaves.NodeProperty;
+import hudson.util.XStream2;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import java.io.StringReader;
 import jenkins.model.Jenkins;
 
 /**
@@ -158,29 +160,8 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
     }
 
     public PodTemplate(PodTemplate from) {
-        this.setAnnotations(from.getAnnotations());
-        this.setContainers(from.getContainers());
-        this.setImagePullSecrets(from.getImagePullSecrets());
-        this.setInstanceCap(from.getInstanceCap());
-        this.setLabel(from.getLabel());
-        this.setName(from.getName());
-        this.setNamespace(from.getNamespace());
-        this.setInheritFrom(from.getInheritFrom());
-        this.setNodeSelector(from.getNodeSelector());
-        this.setNodeUsageMode(from.getNodeUsageMode());
-        this.setServiceAccount(from.getServiceAccount());
-        this.setSlaveConnectTimeout(from.getSlaveConnectTimeout());
-        this.setActiveDeadlineSeconds(from.getActiveDeadlineSeconds());
-        this.setIdleMinutes(from.getIdleMinutes());
-        this.setVolumes(from.getVolumes());
-        this.setWorkspaceVolume(from.getWorkspaceVolume());
-        this.yaml = from.yaml;
-        this.setYamls(from.getYamls());
-        this.showRawYaml = from.showRawYaml;
-        if (from.nodeProperties != null) {
-            this.setNodeProperties(from.getNodeProperties());
-        }
-        this.setPodRetention(from.getPodRetention());
+        XStream2 xs = new XStream2();
+        xs.unmarshal(XStream2.getDefaultDriver().createReader(new StringReader(xs.toXML(from))), this);
     }
 
     @Deprecated
@@ -741,10 +722,6 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
                 yaml = yamls.get(0);
             }
             yamls = null;
-        }
-
-        if (showRawYaml == null) {
-            showRawYaml = Boolean.TRUE;
         }
 
         if (yamlMergeStrategy == null) {

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateFilterTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateFilterTest.java
@@ -45,9 +45,7 @@ public class PodTemplateFilterTest {
         podtemplates.add(podTemplate);
         List<PodTemplate> result = PodTemplateFilter.applyAll(null, podtemplates, Label.get("label"));
         assertEquals(1, result.size());
-        List<String> yamls = result.get(0).getYamls();
-        assertEquals(2, yamls.size());
-        assertThat(yamls, Matchers.containsInAnyOrder("yaml1", "yaml2"));
+        assertThat(result.get(0).getYamls(), Matchers.containsInAnyOrder("yaml1", "yaml2"));
     }
 
     private static PodTemplate addYaml(@Nonnull PodTemplate podTemplate, String yaml) {

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateTest.java
@@ -1,10 +1,11 @@
 package org.csanchez.jenkins.plugins.kubernetes;
 
+import hudson.util.XStream2;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 
 public class PodTemplateTest {
     @Test
@@ -18,4 +19,16 @@ public class PodTemplateTest {
         podTemplate.setYaml(null);
         assertThat(podTemplate.getYamls(), empty());
     }
+
+    @Test
+    public void copyConstructor() throws Exception {
+        XStream2 xs = new XStream2();
+        PodTemplate pt = new PodTemplate();
+        assertEquals(xs.toXML(pt), xs.toXML(new PodTemplate(pt)));
+        pt.setActiveDeadlineSeconds(99);
+        assertEquals(xs.toXML(pt), xs.toXML(new PodTemplate(pt)));
+        pt.setIdleMinutes(99);
+        assertEquals(xs.toXML(pt), xs.toXML(new PodTemplate(pt)));
+    }
+
 }


### PR DESCRIPTION
Evidently unused in this plugin, but can cause problems in downstream plugins.

Note that `PodTemplateUtils.combine(PodTemplate, PodTemplate)` also has a similar long enumeration of fields, and could well be missing some, though this seems to have better test coverage.