### PR TITLE
Picking a safer name for clusters

### DIFF
--- a/kind.sh
+++ b/kind.sh
@@ -14,13 +14,14 @@ then
 fi
 
 # TODO use kind load to take better advantage of images cached in the host VM
-kind create cluster --name $BUILD_TAG --wait 5m
+export cluster=ci$RANDOM
+kind create cluster --name $cluster --wait 5m
 function cleanup() {
-    kind export logs --name $BUILD_TAG $WSTMP/kindlogs || :
-    kind delete cluster --name $BUILD_TAG || :
+    kind export logs --name $cluster $WSTMP/kindlogs || :
+    kind delete cluster --name $cluster || :
 }
 trap cleanup EXIT
-export KUBECONFIG="$(kind get kubeconfig-path --name $BUILD_TAG)"
+export KUBECONFIG="$(kind get kubeconfig-path --name $cluster)"
 kubectl cluster-info
 
 # https://github.com/kubernetes-sigs/kind/issues/118#issuecomment-475134086


### PR DESCRIPTION
#618 failed with

```
docker: Error response from daemon: Invalid container name (jenkins-Plugins-kubernetes-plugin-dependabot%2Fmaven%2Forg.jenkins-ci.plugins-docker-workflow-1.21-1-control-plane), only [a-zA-Z0-9][a-zA-Z0-9_.-] are allowed.
```