### PR TITLE
Add Support for https_proxy env var in podtemplate

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -259,6 +259,10 @@ public class PodTemplateBuilder {
                 if (!StringUtils.isBlank(noProxy)) {
                     env.put("no_proxy", noProxy);
                 }
+                String httpsProxy = System.getenv("https_proxy");
+                if (!StringUtils.isBlank(httpsProxy)) {
+                    env.put("https_proxy", httpsProxy);
+                }
                 String httpProxy = null;
                 if (System.getProperty("http.proxyHost") == null) {
                     httpProxy = System.getenv("http_proxy");


### PR DESCRIPTION
- Consider `https_proxy` as default podTemplate env variable
- More secure proxy option compared to `http_proxy`.

