### PR TITLE
Fixed "IllegalStateException: Jenkins URL null" in PodTemplateStepExecution

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -318,6 +318,26 @@ public class KubernetesCloud extends Cloud {
      */
     @Nonnull
     public String getJenkinsUrlOrDie() {
+        String url = getJenkinsUrlOrNull();
+        if (url == null) {
+            throw new IllegalStateException("Jenkins URL for Kubernetes is null");
+        }
+        return url;
+    }
+
+    /**
+     * Returns Jenkins URL to be used by agents launched by this cloud. Always ends with a trailing slash.
+     *
+     * Uses in order:
+     * * cloud configuration
+     * * environment variable <b>KUBERNETES_JENKINS_URL</b>
+     * * Jenkins Location URL
+     *
+     * @return Jenkins URL to be used by agents launched by this cloud. Always ends with a trailing slash.
+     *         Null if no Jenkins URL could be computed.
+     */
+    @CheckForNull
+    public String getJenkinsUrlOrNull() {
         JenkinsLocationConfiguration locationConfiguration = JenkinsLocationConfiguration.get();
         String url = StringUtils.defaultIfBlank(
                 getJenkinsUrl(),
@@ -327,7 +347,7 @@ public class KubernetesCloud extends Cloud {
                 )
         );
         if (url == null) {
-            throw new IllegalStateException("Jenkins URL for Kubernetes is null");
+            return null;
         }
         url = url.endsWith("/") ? url : url + "/";
         return url;

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
@@ -58,7 +58,7 @@ public class PodTemplateStepExecution extends AbstractStepExecutionImpl {
     @Override
     public boolean start() throws Exception {
 
-        Cloud cloud = Jenkins.getInstance().getCloud(cloudName);
+        Cloud cloud = Jenkins.get().getCloud(cloudName);
         if (cloud == null) {
             throw new AbortException(String.format("Cloud does not exist: %s", cloudName));
         }
@@ -207,7 +207,7 @@ public class PodTemplateStepExecution extends AbstractStepExecutionImpl {
     @Override
     public void onResume() {
         super.onResume();
-        Cloud cloud = Jenkins.getInstance().getCloud(cloudName);
+        Cloud cloud = Jenkins.get().getCloud(cloudName);
         if (cloud == null) {
             throw new RuntimeException(String.format("Cloud does not exist: %s", cloudName));
         }
@@ -234,7 +234,7 @@ public class PodTemplateStepExecution extends AbstractStepExecutionImpl {
          * Remove the template after step is done
          */
         protected void finished(StepContext context) throws Exception {
-            Cloud cloud = Jenkins.getInstance().getCloud(cloudName);
+            Cloud cloud = Jenkins.get().getCloud(cloudName);
             if (cloud == null) {
                 LOGGER.log(Level.WARNING, "Cloud {0} no longer exists, cannot delete pod template {1}",
                         new Object[] { cloudName, podTemplate.getName() });

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
@@ -116,7 +116,10 @@ public class PodTemplateStepExecution extends AbstractStepExecutionImpl {
         newTemplate.setAnnotations(step.getAnnotations());
         newTemplate.setYamlMergeStrategy(step.getYamlMergeStrategy());
         if(run!=null) {
-            newTemplate.getAnnotations().add(new PodAnnotation("buildUrl", ((KubernetesCloud)cloud).getJenkinsUrlOrDie()+run.getUrl()));
+            String url = ((KubernetesCloud)cloud).getJenkinsUrlOrNull();
+            if(url != null) {
+                newTemplate.getAnnotations().add(new PodAnnotation("buildUrl", url + run.getUrl()));
+            }
         }
         newTemplate.setImagePullSecrets(
                 step.getImagePullSecrets().stream().map(x -> new PodImagePullSecret(x)).collect(toList()));

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudTest.java
@@ -115,6 +115,36 @@ public class KubernetesCloudTest {
     }
 
     @Test
+    public void getJenkinsUrlOrNull_NoJenkinsUrl() {
+        JenkinsLocationConfiguration.get().setUrl(null);
+        KubernetesCloud cloud = new KubernetesCloud("name");
+        String url = cloud.getJenkinsUrlOrNull();
+        assertNull(url);
+    }
+
+    @Test
+    public void getJenkinsUrlOrNull_UrlInCloud() {
+        System.setProperty("KUBERNETES_JENKINS_URL", "http://mylocationinsysprop");
+        KubernetesCloud cloud = new KubernetesCloud("name");
+        cloud.setJenkinsUrl("http://mylocation");
+        assertEquals("http://mylocation/", cloud.getJenkinsUrlOrNull());
+    }
+
+    @Test
+    public void getJenkinsUrlOrNull_UrlInSysprop() {
+        System.setProperty("KUBERNETES_JENKINS_URL", "http://mylocation");
+        KubernetesCloud cloud = new KubernetesCloud("name");
+        assertEquals("http://mylocation/", cloud.getJenkinsUrlOrNull());
+    }
+
+    @Test
+    public void getJenkinsUrlOrNull_UrlInLocation() {
+        JenkinsLocationConfiguration.get().setUrl("http://mylocation");
+        KubernetesCloud cloud = new KubernetesCloud("name");
+        assertEquals("http://mylocation/", cloud.getJenkinsUrlOrNull());
+    }
+
+    @Test
     public void testKubernetesCloudDefaults() {
         KubernetesCloud cloud = new KubernetesCloud("name");
         assertEquals(PodRetention.getKubernetesCloudDefault(), cloud.getPodRetention());


### PR DESCRIPTION
When KubernetesCloud.directConnection is used and no Jenkins URL is configured (e.g. because Jenkinsfile Runner does not expose an http port -> no Jenkins URL) the following Exception is thrown:

```
java.lang.IllegalStateException: Jenkins URL for Kubernetes is null
	at org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud.getJenkinsUrlOrDie(KubernetesCloud.java:330)
	at org.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution.start(PodTemplateStepExecution.java:119)
```

This Pull Request fixes the behavior.