### PR TITLE
Add permissions for secrets

### DIFF
--- a/src/main/kubernetes/service-account.yml
+++ b/src/main/kubernetes/service-account.yml
@@ -24,7 +24,7 @@ rules:
   verbs: ["get","list","watch"]
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["get"]
+  verbs: ["get","list","watch"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
This is a fix for **kubernetes-credentials-provider-plugin**

The "jenkins" service account (running jenkins instance) must have the 3 permissions to be able to access secrets properly.

I edited the service account to test, and restarted Jenkins, I could not see any Credentials in my Jenkins instance before (installed with src/main/kubernetes/jenkins.yml file from this repository I installed plugins manually after.