### PR TITLE
Add support for yamlMergeStrategy in declarative pipelines

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgent.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgent.java
@@ -2,6 +2,7 @@ package org.csanchez.jenkins.plugins.kubernetes.pipeline;
 
 import org.apache.commons.lang.StringUtils;
 import org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate;
+import org.csanchez.jenkins.plugins.kubernetes.pod.yaml.YamlMergeStrategy;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgent;
 import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentDescriptor;
@@ -46,6 +47,7 @@ public class KubernetesDeclarativeAgent extends DeclarativeAgent<KubernetesDecla
     private String defaultContainer;
     private String yaml;
     private String yamlFile;
+    private YamlMergeStrategy yamlMergeStrategy;
 
     @DataBoundConstructor
     public KubernetesDeclarativeAgent() {
@@ -214,6 +216,15 @@ public class KubernetesDeclarativeAgent extends DeclarativeAgent<KubernetesDecla
         this.yamlFile = yamlFile;
     }
 
+    public YamlMergeStrategy getYamlMergeStrategy() {
+        return yamlMergeStrategy;
+    }
+
+    @DataBoundSetter
+    public void setYamlMergeStrategy(YamlMergeStrategy yamlMergeStrategy) {
+        this.yamlMergeStrategy = yamlMergeStrategy;
+    }
+
     public Map<String, Object> getAsArgs() {
         Map<String, Object> argMap = new TreeMap<>();
 
@@ -235,6 +246,9 @@ public class KubernetesDeclarativeAgent extends DeclarativeAgent<KubernetesDecla
 
         if (!StringUtils.isEmpty(yaml)) {
             argMap.put("yaml", yaml);
+        }
+        if (yamlMergeStrategy != null) {
+            argMap.put("yamlMergeStrategy", yamlMergeStrategy);
         }
         if (!StringUtils.isEmpty(cloud)) {
             argMap.put("cloud", cloud);


### PR DESCRIPTION
Allows to merge yaml with inherited templates like this:

```
pipeline {
  agent {
    kubernetes {
      inheritFrom "test-template"
      yamlMergeStrategy merge()
      yaml """
apiVersion: v1
kind: Pod
spec:
  containers:
  - name: maven
    image: maven:3.3.9-jdk-8-alpine
    command: ['cat']
    tty: true
"""
    }
  }
  stages {
    stage('Run maven') {
      steps {
        container('maven') {
          sh 'mvn -version'
        }
      }
    }
  }
}
```