### PR TITLE
[JENKINS-60042] Restore delete button to pod template list

### DIFF
--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/config.jelly
@@ -86,7 +86,13 @@
     </f:entry>
 
     <f:entry title="${%Pod Templates}" description="${%List of Pods to be launched as agents}">
-      <f:repeatableProperty field="templates" add="${%Add Pod Template}" header="${%Pod Template}"/>
+      <f:repeatableProperty field="templates" add="${%Add Pod Template}" header="${%Pod Template}">
+        <f:block>
+          <div align="right">
+            <f:repeatableDeleteButton value="${%Delete Pod Template}"/>
+          </div>
+        </f:block>
+      </f:repeatableProperty>
     </f:entry>
 
 </j:jelly>


### PR DESCRIPTION
https://github.com/jenkinsci/kubernetes-plugin/commit/826e8f3160637609132b02e1d2e3a31e735d2404 appears to have lost the "Delete Pod Template" button in Jenkins core 2.190.2 LTS. [This (fairly old) comment](https://groups.google.com/d/msg/jenkinsci-dev/XHvOM5Co2Mk/YLE2xG0QyHAJ) seems to indicate that you usually need to add your own `f:repeatableDeleteButton`  when using `f:repeatableProperty`