### PR TITLE
test-in-k8s.sh did not support Incrementals

### DIFF
--- a/test-in-k8s.sh
+++ b/test-in-k8s.sh
@@ -7,6 +7,7 @@ kubectl apply -f test-in-k8s.yaml
 kubectl wait --for=condition=Ready --timeout=15m pod/jenkins
 kubectl exec jenkins -- sh -c 'rm -rf /checkout && mkdir /checkout'
 kubectl cp pom.xml jenkins:/checkout/pom.xml
+kubectl cp .mvn jenkins:/checkout/.mvn
 kubectl cp src jenkins:/checkout/src
 kubectl cp settings-azure.xml jenkins:/settings-azure.xml
 if [ -v TEST ]


### PR DESCRIPTION
Noticed in #649 that #616 omitted a subdirectory needed for `-Pconsume-incrementals`.