### PR TITLE
[JENKINS-53790] Kubernetes plugin shows failing templates to only admins

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
@@ -127,7 +127,7 @@ public class KubernetesLauncher extends JNLPLauncher {
             String podName = pod.getMetadata().getName();
             String namespace1 = pod.getMetadata().getNamespace();
             template.getWorkspaceVolume().createVolume(client, pod.getMetadata());
-            watcher = new AllContainersRunningPodWatcher(client, pod);
+            watcher = new AllContainersRunningPodWatcher(client, pod, template.getListener());
             try (Watch _w = client.pods().inNamespace(namespace1).withName(podName).watch(watcher)) {
                 watcher.await(template.getSlaveConnectTimeout(), TimeUnit.SECONDS);
             }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -37,6 +37,7 @@ import hudson.model.DescriptorVisibilityFilter;
 import hudson.model.Label;
 import hudson.model.Node;
 import hudson.model.Saveable;
+import hudson.model.TaskListener;
 import hudson.model.labels.LabelAtom;
 import hudson.slaves.NodeProperty;
 import hudson.util.XStream2;
@@ -922,4 +923,20 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
                 (yamls == null || yamls.isEmpty() ? "" : ", yamls=" + yamls) +
                 '}';
     }
+    
+    
+    /* Adding task listener to fix https://issues.jenkins-ci.org/browse/JENKINS-53790 */
+    
+    @CheckForNull
+    private transient TaskListener listener;		// Listener for printing logs in Pod/Job's running console
+    
+    @Nonnull
+    public TaskListener getListener() {
+        return listener == null ? TaskListener.NULL : listener;
+    }
+
+    public void setListener(@CheckForNull TaskListener listener) {
+        this.listener = listener;
+    }
+    
 }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
@@ -26,6 +26,7 @@ import hudson.AbortException;
 import hudson.model.ItemGroup;
 import hudson.model.Job;
 import hudson.model.Run;
+import hudson.model.TaskListener;
 import hudson.slaves.Cloud;
 import java.util.Collections;
 import jenkins.model.Jenkins;
@@ -126,6 +127,7 @@ public class PodTemplateStepExecution extends AbstractStepExecutionImpl {
                 newTemplate.getAnnotations().add(new PodAnnotation("buildUrl", url + run.getUrl()));
             }
         }
+        newTemplate.setListener(getContext().get(TaskListener.class));
         newTemplate.setImagePullSecrets(
                 step.getImagePullSecrets().stream().map(x -> new PodImagePullSecret(x)).collect(toList()));
         newTemplate.setYaml(step.getYaml());


### PR DESCRIPTION
Fix for JENKINS-53790 with proper message in the Job's console using TaskListener. 