### PR TITLE
Ensure retention timeout is always >= 5

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -202,11 +202,7 @@ public class KubernetesCloud extends Cloud {
 
     @DataBoundSetter
     public void setRetentionTimeout(int retentionTimeout) {
-        if (retentionTimeout < DEFAULT_RETENTION_TIMEOUT_MINUTES) {
-            this.retentionTimeout = DEFAULT_RETENTION_TIMEOUT_MINUTES;
-        } else {
-            this.retentionTimeout = retentionTimeout;
-        }
+        this.retentionTimeout = Math.max(DEFAULT_RETENTION_TIMEOUT_MINUTES, retentionTimeout);
     }
 
     public String getDefaultsProviderTemplate() {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -94,7 +94,7 @@ public class KubernetesCloud extends Cloud {
     public static final Map<String, String> DEFAULT_POD_LABELS = ImmutableMap.of("jenkins", "slave");
 
     /** Default timeout for idle workers that don't correctly indicate exit. */
-    private static final int DEFAULT_RETENTION_TIMEOUT_MINUTES = 5;
+    public static final int DEFAULT_RETENTION_TIMEOUT_MINUTES = 5;
 
     private String defaultsProviderTemplate;
 
@@ -202,7 +202,11 @@ public class KubernetesCloud extends Cloud {
 
     @DataBoundSetter
     public void setRetentionTimeout(int retentionTimeout) {
-        this.retentionTimeout = retentionTimeout;
+        if (retentionTimeout < DEFAULT_RETENTION_TIMEOUT_MINUTES) {
+            this.retentionTimeout = DEFAULT_RETENTION_TIMEOUT_MINUTES;
+        } else {
+            this.retentionTimeout = retentionTimeout;
+        }
     }
 
     public String getDefaultsProviderTemplate() {
@@ -913,6 +917,7 @@ public class KubernetesCloud extends Cloud {
         if (podRetention == null) {
             podRetention = PodRetention.getKubernetesCloudDefault();
         }
+        setRetentionTimeout(retentionTimeout);
         if (waitForPodSec == null) {
             waitForPodSec = DEFAULT_WAIT_FOR_POD_SEC;
         }

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/help-retentionTimeout.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/help-retentionTimeout.html
@@ -1,7 +1,15 @@
-Time in minutes after which the Kubernetes cloud plugin will clean up an idle
-worker that has not already terminated. This cleanup is only necessary in
-exceptional conditions; typically workers will terminate upon completion of the
-invoking task.
+<p>
+    Time in minutes after which the Kubernetes cloud plugin will clean up an idle
+    worker that has not already terminated. This cleanup is only necessary in
+    exceptional conditions; typically workers will terminate upon completion of the
+    invoking task.
+</p>
 
-<p>For tasks that use very large images, this timeout can be increased to avoid
-early termination of the task while the Kubernetes pod is still deploying.</p>
+<p>
+    Minimum value is 5 minutes as lower values can cause problems upon Jenkins restart.
+</p>
+
+<p>
+    For tasks that use very large images, this timeout can be increased to avoid
+    early termination of the task while the Kubernetes pod is still deploying.
+</p>

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudTest.java
@@ -36,6 +36,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.LoggerRule;
+import org.jvnet.hudson.test.recipes.LocalData;
 import org.mockito.Mockito;
 
 import hudson.model.Label;
@@ -321,6 +322,21 @@ public class KubernetesCloudTest {
         assertEquals(WorkspaceVolume.getDefault(), podTemplate.getWorkspaceVolume());
     }
 
+    @Test
+    public void minRetentionTimeout() {
+        KubernetesCloud cloud = new KubernetesCloud("kubernetes");
+        assertEquals(KubernetesCloud.DEFAULT_RETENTION_TIMEOUT_MINUTES, cloud.getRetentionTimeout());
+        cloud.setRetentionTimeout(0);
+        assertEquals(KubernetesCloud.DEFAULT_RETENTION_TIMEOUT_MINUTES, cloud.getRetentionTimeout());
+    }
+
+    @Test
+    @LocalData
+    public void minRetentionTimeoutReadResolve() {
+        KubernetesCloud cloud = j.jenkins.clouds.get(KubernetesCloud.class);
+        assertEquals(KubernetesCloud.DEFAULT_RETENTION_TIMEOUT_MINUTES, cloud.getRetentionTimeout());
+    }
+
     public HtmlInput getInputByName(DomElement root, String name) {
         DomNodeList<HtmlElement> inputs = root.getElementsByTagName("input");
         for (HtmlElement input : inputs) {
@@ -330,6 +346,5 @@ public class KubernetesCloudTest {
         }
         return null;
     }
-
 
 }

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudTest/minRetentionTimeoutReadResolve/config.xml
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudTest/minRetentionTimeoutReadResolve/config.xml
@@ -1,0 +1,40 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<hudson>
+  <disabledAdministrativeMonitors/>
+  <version>2.190.1</version>
+  <installStateName>DEVELOPMENT</installStateName>
+  <numExecutors>2</numExecutors>
+  <mode>NORMAL</mode>
+  <useSecurity>true</useSecurity>
+  <authorizationStrategy class="hudson.security.AuthorizationStrategy$Unsecured"/>
+  <securityRealm class="hudson.security.SecurityRealm$None"/>
+  <disableRememberMe>false</disableRememberMe>
+  <projectNamingStrategy class="jenkins.model.ProjectNamingStrategy$DefaultProjectNamingStrategy"/>
+  <workspaceDir>${JENKINS_HOME}/workspace/${ITEM_FULL_NAME}</workspaceDir>
+  <buildsDir>${ITEM_ROOTDIR}/builds</buildsDir>
+  <jdks/>
+  <viewsTabBar class="hudson.views.DefaultViewsTabBar"/>
+  <myViewsTabBar class="hudson.views.DefaultMyViewsTabBar"/>
+  <clouds>
+    <org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud>
+      <name>kubernetes</name>
+      <templates/>
+    </org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud>
+  </clouds>
+  <quietPeriod>5</quietPeriod>
+  <scmCheckoutRetryCount>0</scmCheckoutRetryCount>
+  <views>
+    <hudson.model.AllView>
+      <owner class="hudson" reference="../../.."/>
+      <name>all</name>
+      <filterExecutors>false</filterExecutors>
+      <filterQueue>false</filterQueue>
+      <properties class="hudson.model.View$PropertyList"/>
+    </hudson.model.AllView>
+  </views>
+  <primaryView>all</primaryView>
+  <slaveAgentPort>0</slaveAgentPort>
+  <label></label>
+  <nodeProperties/>
+  <globalNodeProperties/>
+</hudson>


### PR DESCRIPTION
I've seen cases where retention timeout was 0 and this caused agents to be removed after a Jenkins instance restart.