### PR TITLE
[JENKINS-60537] Sanitize label

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -379,7 +379,17 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
     }
 
     public Map<String, String> getLabelsMap() {
-        return ImmutableMap.of("jenkins/label", label == null ? DEFAULT_ID : label);
+        return ImmutableMap.of("jenkins/label", label == null ? DEFAULT_ID : sanitizeLabel(label));
+    }
+
+    private String sanitizeLabel(String input) {
+        String label = input;
+        int max = 63; // Kubernetes limit
+        if (label.length() > max) {
+            label = label.substring(label.length() - max);
+        }
+        label = label.replaceAll("[^_.a-zA-Z0-9-]", "_").replaceFirst("^[^a-zA-Z0-9]", "x");
+        return label;
     }
 
     @DataBoundSetter

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -382,7 +382,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
         return ImmutableMap.of("jenkins/label", label == null ? DEFAULT_ID : sanitizeLabel(label));
     }
 
-    private String sanitizeLabel(String input) {
+    static String sanitizeLabel(String input) {
         String label = input;
         int max = 63; // Kubernetes limit
         if (label.length() > max) {

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateJenkinsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateJenkinsTest.java
@@ -24,6 +24,6 @@ public class PodTemplateJenkinsTest {
     public void multiLabel() {
         PodTemplate podTemplate = new PodTemplate();
         podTemplate.setLabel("foo bar");
-        assertEquals("foo bar", podTemplate.getLabelsMap().get("jenkins/label"));
+        assertEquals("foo_bar", podTemplate.getLabelsMap().get("jenkins/label"));
     }
 }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateTest.java
@@ -3,6 +3,7 @@ package org.csanchez.jenkins.plugins.kubernetes;
 import hudson.util.XStream2;
 import org.junit.Test;
 
+import static org.csanchez.jenkins.plugins.kubernetes.PodTemplate.*;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.junit.Assert.*;
@@ -29,6 +30,14 @@ public class PodTemplateTest {
         assertEquals(xs.toXML(pt), xs.toXML(new PodTemplate(pt)));
         pt.setIdleMinutes(99);
         assertEquals(xs.toXML(pt), xs.toXML(new PodTemplate(pt)));
+    }
+
+    @Test
+    public void sanitizeLabels() {
+        assertEquals("label1", sanitizeLabel("label1"));
+        assertEquals("label1_label2", sanitizeLabel("label1 label2"));
+        assertEquals("el1_label2_verylooooooooooooooooooooooooooooonglabelover63chars", sanitizeLabel("label1 label2 verylooooooooooooooooooooooooooooonglabelover63chars"));
+        assertEquals("xfoo_bar", sanitizeLabel(":foo:bar"));
     }
 
 }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
@@ -42,6 +42,7 @@ import hudson.model.Computer;
 import com.gargoylesoftware.htmlunit.html.DomNodeUtil;
 import com.gargoylesoftware.htmlunit.html.HtmlElement;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import hudson.model.Label;
 import hudson.slaves.SlaveComputer;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodList;
@@ -395,6 +396,11 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
         SemaphoreStep.waitForStart("pod/1", b);
         Map<String, String> labels = getLabels(cloud, this, name);
         labels.put("jenkins/label","label1_label2");
+        KubernetesSlave node = r.jenkins.getNodes().stream()
+                .filter(KubernetesSlave.class::isInstance)
+                .map(KubernetesSlave.class::cast)
+                .findAny().get();
+        assertTrue(node.getAssignedLabels().containsAll(Label.parse("label1 label2")));
         PodList pods = cloud.connect().pods().withLabels(labels).list();
         assertThat(
                 "Expected one pod with labels " + labels + " but got: "

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/podTemplateWithMultipleLabels.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/podTemplateWithMultipleLabels.groovy
@@ -1,0 +1,4 @@
+node('label1') {
+    semaphore 'pod'
+    sh 'echo "It works"'
+}


### PR DESCRIPTION
[JENKINS-60537](https://issues.jenkins-ci.org/browse/JENKINS-60537)

Should fix behaviour when using multiple labels on a single pod template.

For a pod template with the labels `label1 label2`, the pod will be labeled `jenkins/label=label1_label2`, since spaces are not allowed in kubernetes labels values.

Amends #666