### PR TITLE
Remove containers grace period

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -132,6 +132,8 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
 
     private PodTemplateToolLocation nodeProperties;
 
+    private Long terminationGracePeriodSeconds;
+
     /**
      * Persisted yaml fragment
      */
@@ -727,6 +729,14 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
             podRetention = PodRetention.getPodTemplateDefault();
         }
         this.podRetention = podRetention;
+    }
+
+    public Long getTerminationGracePeriodSeconds() {
+        return terminationGracePeriodSeconds;
+    }
+
+    public void setTerminationGracePeriodSeconds(Long terminationGracePeriodSeconds) {
+        this.terminationGracePeriodSeconds = terminationGracePeriodSeconds;
     }
 
     protected Object readResolve() {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -198,7 +198,9 @@ public class PodTemplateBuilder {
             builder.withNodeSelector(nodeSelector);
         }
 
-        builder.withTerminationGracePeriodSeconds(0L);
+        if (template.getTerminationGracePeriodSeconds() != null) {
+            builder.withTerminationGracePeriodSeconds(template.getTerminationGracePeriodSeconds());
+        }
         builder.withContainers(containers.values().toArray(new Container[containers.size()]));
 
         Long runAsUser = template.getRunAsUserAsLong();

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -198,6 +198,7 @@ public class PodTemplateBuilder {
             builder.withNodeSelector(nodeSelector);
         }
 
+        builder.withTerminationGracePeriodSeconds(0L);
         builder.withContainers(containers.values().toArray(new Container[containers.size()]));
 
         Long runAsUser = template.getRunAsUserAsLong();

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/AbstractKubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/AbstractKubernetesPipelineTest.java
@@ -39,6 +39,7 @@ import org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate;
 import org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud;
 import org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil;
 import org.csanchez.jenkins.plugins.kubernetes.PodTemplate;
+import org.csanchez.jenkins.plugins.kubernetes.PodTemplateBuilder;
 import org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar;
 import org.csanchez.jenkins.plugins.kubernetes.model.SecretEnvVar;
 import org.csanchez.jenkins.plugins.kubernetes.model.TemplateEnvVar;
@@ -160,6 +161,7 @@ public abstract class AbstractKubernetesPipelineTest {
         // Create a busybox template
         PodTemplate podTemplate = new PodTemplate();
         podTemplate.setLabel(label);
+        podTemplate.setTerminationGracePeriodSeconds(0L);
 
         ContainerTemplate containerTemplate = new ContainerTemplate("busybox", "busybox", "cat", "");
         containerTemplate.setTtyEnabled(true);

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorTest.java
@@ -116,7 +116,7 @@ public class ContainerExecDecoratorTest {
                 .withCommand("cat").withTty(true).withWorkingDir("/home/jenkins/agent1").build();
         String podName = "test-command-execution-" + RandomStringUtils.random(5, "bcdfghjklmnpqrstvwxz0123456789");
         pod = client.pods().create(new PodBuilder().withNewMetadata().withName(podName)
-                .withLabels(getLabels(this, name)).endMetadata().withNewSpec().withContainers(c, d).withNodeSelector(Collections.singletonMap("kubernetes.io/os", "linux")).endSpec().build());
+                .withLabels(getLabels(this, name)).endMetadata().withNewSpec().withContainers(c, d).withNodeSelector(Collections.singletonMap("kubernetes.io/os", "linux")).withTerminationGracePeriodSeconds(0L).endSpec().build());
 
         System.out.println("Created pod: " + pod.getMetadata().getName());
 

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/RestartPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/RestartPipelineTest.java
@@ -110,6 +110,7 @@ public class RestartPipelineTest {
         // Create a busybox template
         PodTemplate podTemplate = new PodTemplate();
         podTemplate.setLabel(label);
+        podTemplate.setTerminationGracePeriodSeconds(0L);
 
         ContainerTemplate containerTemplate = new ContainerTemplate("busybox", "busybox", "cat", "");
         containerTemplate.setTtyEnabled(true);

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/cascadingDelete.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/cascadingDelete.groovy
@@ -62,6 +62,7 @@ spec:
                       labels:
                         app: cascading-delete
                     spec:
+                      terminationGracePeriodSeconds: 0
                       containers:
                       - name: ubuntu
                         image: ubuntu


### PR DESCRIPTION
Nothing interesting should be running in agents containers when it is requested to be terminated, so don't wait these 30 seconds to kill remaining processes inside it.

Should speed up a lot tests hopefully.

Subsumes #689 and #690, please review [this](https://github.com/jenkinsci/kubernetes-plugin/pull/686/commits/e5faa7f39ad15fe8acfdbbf691b9b6b10bb478e9) commit.