### PR TITLE
Merge pull request #687 from timothydowney/bugfix/sanitize-label-end

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -384,11 +384,15 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
 
     static String sanitizeLabel(String input) {
         String label = input;
-        int max = 63; // Kubernetes limit
+        int max = 63;
+        // Kubernetes limit
+        // a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must
+        // start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used
+        // for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
         if (label.length() > max) {
             label = label.substring(label.length() - max);
         }
-        label = label.replaceAll("[^_.a-zA-Z0-9-]", "_").replaceFirst("^[^a-zA-Z0-9]", "x");
+        label = label.replaceAll("[^_.a-zA-Z0-9-]", "_").replaceFirst("^[^a-zA-Z0-9]", "x").replaceFirst("[^a-zA-Z0-9]$", "x");
         return label;
     }
 

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateTest.java
@@ -38,6 +38,8 @@ public class PodTemplateTest {
         assertEquals("label1_label2", sanitizeLabel("label1 label2"));
         assertEquals("el1_label2_verylooooooooooooooooooooooooooooonglabelover63chars", sanitizeLabel("label1 label2 verylooooooooooooooooooooooooooooonglabelover63chars"));
         assertEquals("xfoo_bar", sanitizeLabel(":foo:bar"));
+        assertEquals("xfoo_barx", sanitizeLabel(":foo:bar:"));
+        assertEquals("l2_verylooooooooooooooooooooooooooooonglabelendinginunderscorex", sanitizeLabel("label1 label2 verylooooooooooooooooooooooooooooonglabelendinginunderscore_"));
     }
 
 }


### PR DESCRIPTION
This fixes an edge case with labels that don't end in alphanumeric characters.  This occurs most likely in the existing code when the space between labels just happens to land on the truncation boundary and gets turned into an _.

This is related to [JENKINS-60537](https://issues.jenkins-ci.org/browse/JENKINS-60537).

I followed the lead of the previous PR and chose to convert the non-valid trailing character to an `x`.