### PR TITLE
ContainerExecDecoratorTest: Access to results must be synchronized

### DIFF
--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorTest.java
@@ -172,14 +172,11 @@ public class ContainerExecDecoratorTest {
     }
 
     private Thread newThread(int i, List<ProcReturn> results) {
-        return new Thread(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    command(results, i);
-                } finally {
-                    System.out.println("Thread " + i + " finished");
-                }
+        return new Thread(() -> {
+            try {
+                command(results, i);
+            } finally {
+                System.out.println("Thread " + i + " finished");
             }
         }, "test-" + i);
     }
@@ -191,7 +188,9 @@ public class ContainerExecDecoratorTest {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-        results.add(r);
+        synchronized (results) {
+            results.add(r);
+        }
     }
 
     @Test


### PR DESCRIPTION
Still trying to address the flake in `ContainerExecDecoratorTest#testCommandExecution`