### PR TITLE
Suppressing testCommandExecution as too flaky

### DIFF
--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorTest.java
@@ -75,6 +75,7 @@ import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.client.HttpClientAware;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import okhttp3.OkHttpClient;
+import org.junit.Ignore;
 
 /**
  * @author Carlos Sanchez
@@ -146,10 +147,9 @@ public class ContainerExecDecoratorTest {
     }
 
     /**
-     * Test that multiple command execution in parallel works
-     * 
-     * @throws Exception
+     * Test that multiple command execution in parallel works.
      */
+    @Ignore("TODO PID_PATTERN match flaky in CI")
     @Test
     public void testCommandExecution() throws Exception {
         Thread[] t = new Thread[10];


### PR DESCRIPTION
Flaking [in master](https://ci.jenkins.io/job/Plugins/job/kubernetes-plugin/job/master/673/testReport/junit/org.csanchez.jenkins.plugins.kubernetes.pipeline/ContainerExecDecoratorTest/kind___testCommandExecution/) and on PRs. Probably some issue with failure to flush a stream or something: some, but not all, threads print their output.