### PR TITLE
[JENKINS-60937] Pods are not created due to 'invalid label value: "jenkins/slave-default"'

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -56,7 +56,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
 
     private static final String FALLBACK_ARGUMENTS = "${computer.jnlpmac} ${computer.name}";
 
-    private static final String DEFAULT_ID = "jenkins/slave-default";
+    private static final String DEFAULT_LABEL = "slave-default";
 
     private static final Logger LOGGER = Logger.getLogger(PodTemplate.class.getName());
 
@@ -381,7 +381,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
     }
 
     public Map<String, String> getLabelsMap() {
-        return ImmutableMap.of("jenkins/label", label == null ? DEFAULT_ID : sanitizeLabel(label));
+        return ImmutableMap.of("jenkins/label", label == null ? DEFAULT_LABEL : sanitizeLabel(label));
     }
 
     static String sanitizeLabel(String input) {

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateJenkinsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateJenkinsTest.java
@@ -26,4 +26,12 @@ public class PodTemplateJenkinsTest {
         podTemplate.setLabel("foo bar");
         assertEquals("foo_bar", podTemplate.getLabelsMap().get("jenkins/label"));
     }
+    
+    @Test
+    @Issue("JENKINS-60937")
+    public void defaultLabel() {
+        PodTemplate podTemplate = new PodTemplate();
+        podTemplate.setLabel(null);
+        assertEquals("slave-default", podTemplate.getLabelsMap().get("jenkins/label"));
+    }
 }


### PR DESCRIPTION
Rename DEFAULT_ID to DEFAULT_LABEL and set value to "slave-default"