### PR TITLE
Allow test-in-k8s.sh to be used when PodSecurityPolicy is enabled

### DIFF
--- a/kind.sh
+++ b/kind.sh
@@ -15,7 +15,7 @@ fi
 
 export cluster=ci$RANDOM
 export KUBECONFIG=$WSTMP/kubeconfig-$cluster
-kind create cluster --name $cluster --wait 5m
+kind create cluster --name $cluster --wait 5m --config kind.yaml
 function cleanup() {
     kind export logs --name $cluster $WSTMP/kindlogs || :
     kind delete cluster --name $cluster || :

--- a/kind.yaml
+++ b/kind.yaml
@@ -1,0 +1,11 @@
+apiVersion: kind.x-k8s.io/v1alpha4
+kind: Cluster
+kubeadmConfigPatches:
+- |
+  kind: ClusterConfiguration
+  metadata:
+    name: config
+  apiServer:
+    extraArgs:
+      # TODO does not work: https://github.com/kubernetes-sigs/kind/issues/973
+      # enable-admission-plugins: PodSecurityPolicy

--- a/test-in-k8s.yaml
+++ b/test-in-k8s.yaml
@@ -94,6 +94,11 @@ rules:
 - apiGroups: [""]
   resources: ["persistentvolumeclaims"] # KubernetesPipelineTest#dynamicPVC
   verbs: ["create","delete","get","list","patch","update","watch"]
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - privileged
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -107,3 +112,32 @@ subjects:
 - kind: ServiceAccount
   name: jenkins
   namespace: kubernetes-plugin-test
+---
+# https://kubernetes.io/docs/concepts/policy/pod-security-policy/#example-policies
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: privileged
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  volumes:
+  - '*'
+  hostNetwork: true
+  hostPorts:
+  - min: 0
+    max: 65535
+  hostIPC: true
+  hostPID: true
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'


### PR DESCRIPTION
Required for testing inside some clusters.