### PR TITLE
Use Serialization.asYaml when printing API resources to log

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/AllContainersRunningPodWatcher.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/AllContainersRunningPodWatcher.java
@@ -18,6 +18,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.KubernetesClientTimeoutException;
 import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.utils.Serialization;
 
 /**
  * A pod watcher reporting when all containers are running
@@ -158,7 +159,7 @@ public class AllContainersRunningPodWatcher implements Watcher<Pod> {
             throw new IllegalStateException(String.format("Pod is no longer available: %s/%s",
                     this.pod.getMetadata().getNamespace(), this.pod.getMetadata().getName()));
         } else {
-            LOGGER.finest(() -> "Updating pod for " + this.pod.getMetadata().getNamespace() + "/" + this.pod.getMetadata().getName() + " : " + pod);
+            LOGGER.finest(() -> "Updating pod for " + this.pod.getMetadata().getNamespace() + "/" + this.pod.getMetadata().getName() + " : " + Serialization.asYaml(pod));
             this.pod = pod;
         }
         List<ContainerStatus> terminatedContainers = getTerminatedContainers(pod);

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -74,6 +74,7 @@ import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeBuilder;
 import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
+import io.fabric8.kubernetes.client.utils.Serialization;
 
 import jenkins.model.Jenkins;
 import static org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud.JNLP_NAME;
@@ -269,7 +270,7 @@ public class PodTemplateBuilder {
                                 c.getWorkingDir() != null ? c.getWorkingDir() : ContainerTemplate.DEFAULT_WORKING_DIR)))
                 .forEach(c -> c.getVolumeMounts().add(getDefaultVolumeMount(c.getWorkingDir())));
 
-        LOGGER.log(Level.FINE, "Pod built: {0}", pod);
+        LOGGER.fine(() -> "Pod built: " + Serialization.asYaml(pod));
         return pod;
     }
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
@@ -61,6 +61,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 
 import static hudson.Util.replaceMacro;
+import io.fabric8.kubernetes.client.utils.Serialization;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
@@ -228,8 +229,7 @@ public class PodTemplateUtils {
             return template;
         }
 
-        LOGGER.log(Level.FINE, "Combining pods, parent: {0}", parent);
-        LOGGER.log(Level.FINE, "Combining pods, template: {0}", template);
+        LOGGER.fine(() -> "Combining pods, parent: " + Serialization.asYaml(parent) + " template: " + Serialization.asYaml(template));
 
         Map<String, String> nodeSelector = mergeMaps(parent.getSpec().getNodeSelector(),
                 template.getSpec().getNodeSelector());
@@ -314,7 +314,7 @@ public class PodTemplateUtils {
 //        podTemplate.setYaml(template.getYaml() == null ? parent.getYaml() : template.getYaml());
 
         Pod pod = specBuilder.endSpec().build();
-        LOGGER.log(Level.FINE, "Pods combined: {0}", pod);
+        LOGGER.fine(() -> "Pods combined: " + Serialization.asYaml(pod));
         return pod;
     }
 
@@ -566,7 +566,7 @@ public class PodTemplateUtils {
             } catch (IOException | KubernetesClientException e) {
                 throw new RuntimeException(String.format("Failed to parse yaml: \"%s\"", yaml), e);
             }
-            LOGGER.log(Level.FINEST, "Parsed pod template from yaml: {0}", podFromYaml);
+            LOGGER.finest(() -> "Parsed pod template from yaml: " + Serialization.asYaml(podFromYaml));
             // yaml can be just a fragment, avoid NPEs
             if (podFromYaml.getMetadata() == null) {
                 podFromYaml.setMetadata(new ObjectMeta());

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/SecretsMasker.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/SecretsMasker.java
@@ -27,6 +27,7 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.SecretKeySelector;
 import io.fabric8.kubernetes.client.dsl.ExecListener;
 import io.fabric8.kubernetes.client.dsl.ExecWatch;
+import io.fabric8.kubernetes.client.utils.Serialization;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -143,7 +144,7 @@ public final class SecretsMasker extends TaskListenerDecorator {
             Pod pod = slave.getTemplate().build(slave);
             Set<String> values = new HashSet<>();
             values.add(c.getJnlpMac());
-            LOGGER.finer(() -> "inspecting " + pod);
+            LOGGER.finer(() -> "inspecting " + Serialization.asYaml(pod));
             for (Container container : pod.getSpec().getContainers()) {
                 Set<String> secretContainerKeys = new TreeSet<>();
                 for (EnvVar envVar : container.getEnv()) {

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesTestUtil.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesTestUtil.java
@@ -69,6 +69,7 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
+import io.fabric8.kubernetes.client.utils.Serialization;
 import java.net.InetAddress;
 import java.net.URL;
 import jenkins.model.Jenkins;
@@ -263,16 +264,16 @@ public class KubernetesTestUtil {
                 .withName("container-secret").endMetadata().build();
         secret = client.secrets().inNamespace(namespace).createOrReplace(secret);
 
-        LOGGER.log(Level.INFO, "Created container secret: {0}", secret);
+        LOGGER.log(Level.INFO, "Created container secret: " + Serialization.asYaml(secret));
         secret = new SecretBuilder().withStringData(ImmutableMap.of(SECRET_KEY, POD_ENV_VAR_FROM_SECRET_VALUE))
                 .withNewMetadata().withName("pod-secret").endMetadata().build();
         secret = client.secrets().inNamespace(namespace).createOrReplace(secret);
-        LOGGER.log(Level.INFO, "Created pod secret: {0}", secret);
+        LOGGER.log(Level.INFO, "Created pod secret: " + Serialization.asYaml(secret));
 
         secret = new SecretBuilder().withStringData(ImmutableMap.of(SECRET_KEY, ""))
                 .withNewMetadata().withName("empty-secret").endMetadata().build();
         secret = client.secrets().inNamespace(namespace).createOrReplace(secret);
-        LOGGER.log(Level.INFO, "Created pod secret: {0}", secret);
+        LOGGER.log(Level.INFO, "Created pod secret: " + Serialization.asYaml(secret));
     }
 
     public static String generateProjectName(String name) {


### PR DESCRIPTION
Not sure if you consider this an improvement or not. Mainly relevant during tests. Replaces long, basically unreadable single-line messages with long, readable multiline messages.