### PR TITLE
Randomize ports used by test-in-k8s

### DIFF
--- a/test-in-k8s.sh
+++ b/test-in-k8s.sh
@@ -3,9 +3,13 @@ set -euxo pipefail
 kubectl get ns kubernetes-plugin-test || kubectl create ns kubernetes-plugin-test
 kubectl get ns kubernetes-plugin-test-overridden-namespace || kubectl create ns kubernetes-plugin-test-overridden-namespace
 kubectl config set-context --current --namespace=kubernetes-plugin-test
-kubectl apply -f test-in-k8s.yaml
+port_offset=$RANDOM
+http_port=$((2000 + $port_offset))
+tcp_port=$((2001 + $port_offset))
+kubectl delete --ignore-not-found --now pod jenkins
+sed "s/@HTTP_PORT@/$http_port/g; s/@TCP_PORT@/$tcp_port/g" < test-in-k8s.yaml | kubectl apply -f -
 kubectl wait --for=condition=Ready --timeout=15m pod/jenkins
-kubectl exec jenkins -- sh -c 'rm -rf /checkout && mkdir /checkout'
+kubectl exec jenkins -- mkdir /checkout
 kubectl cp pom.xml jenkins:/checkout/pom.xml
 kubectl cp .mvn jenkins:/checkout/.mvn
 kubectl cp src jenkins:/checkout/src
@@ -23,8 +27,8 @@ kubectl exec jenkins -- \
         -s /settings-azure.xml \
         -f /checkout \
         -DconnectorHost=0.0.0.0 \
-        -Dport=8000 \
-        -DslaveAgentPort=50000 \
+        -Dport=$http_port \
+        -DslaveAgentPort=$tcp_port \
         -Djenkins.host.address=jenkins.kubernetes-plugin-test.svc.cluster.local \
         -Dmaven.test.failure.ignore \
         $args

--- a/test-in-k8s.yaml
+++ b/test-in-k8s.yaml
@@ -30,8 +30,8 @@ spec:
     args:
       - infinity
     ports:
-      - containerPort: 8000
-      - containerPort: 50000
+      - containerPort: @HTTP_PORT@
+      - containerPort: @TCP_PORT@
     volumeMounts:
     - name: m2repo
       mountPath: /root/.m2/repository
@@ -51,12 +51,12 @@ spec:
     app: jenkins
   ports:
     - name: http
-      port: 8000
-      targetPort: 8000
+      port: @HTTP_PORT@
+      targetPort: @HTTP_PORT@
       protocol: TCP
     - name: agent
-      port: 50000
-      targetPort: 50000
+      port: @TCP_PORT@
+      targetPort: @TCP_PORT@
       protocol: TCP
 ---
 kind: ClusterRole


### PR DESCRIPTION
Hoping this will fix occasional test failures caused by an inability to rebind 8000.