### PR TITLE
[JENKINS-60977] Drop the working dir migration

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
@@ -33,8 +33,6 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
 
     public static final String DEFAULT_WORKING_DIR = "/home/jenkins/agent";
 
-    private static final String OLD_DEFAULT_WORKING_DIR = "/home/jenkins";
-
     private String name;
 
     private String image;
@@ -434,9 +432,6 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
 
     private Object readResolve() {
         this.workingDir = Util.fixEmpty(workingDir);
-        if (OLD_DEFAULT_WORKING_DIR.equals(workingDir)) {
-            this.workingDir = DEFAULT_WORKING_DIR;
-        }
         return this;
     }
 }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest.java
@@ -92,7 +92,8 @@ public class KubernetesTest {
         PodTemplate pt = cloud.getTemplate(Label.get("java"));
         assertNotNull(pt);
         for (ContainerTemplate ct : pt.getContainers()) {
-            assertEquals(ContainerTemplate.DEFAULT_WORKING_DIR, ct.getWorkingDir());
+            // Retain working dir used in previous version
+            assertEquals("/home/jenkins", ct.getWorkingDir());
         }
     }
 


### PR DESCRIPTION
It is causing issues to people who really want to keep the old value.

[JENKINS-60977](https://issues.jenkins-ci.org/browse/JENKINS-60977)