### PR TITLE
Make KubernetesSamples extensions optional

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesSamples.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesSamples.java
@@ -29,7 +29,7 @@ public class KubernetesSamples {
     @Extension public static final class SuppressToolBasedSamples extends ExtensionFilter {
 
         @Override public <T> boolean allows(Class<T> type, ExtensionComponent<T> component) {
-            if (type == GroovySample.class) {
+            if (type.getName().equals("org.jenkinsci.plugins.workflow.cps.GroovySample")) { // do not link against GroovySample yet
                 switch (((GroovySample) component.getInstance()).name()) {
                 case "github-maven":
                 case "scripted":
@@ -55,7 +55,7 @@ public class KubernetesSamples {
 
     }
 
-    @Extension(ordinal = 1500) public static final class Declarative extends Static {
+    @Extension(ordinal = 1500, optional = true) public static final class Declarative extends Static {
 
         @Override public String name() {
             return "kubernetes-declarative";
@@ -67,7 +67,7 @@ public class KubernetesSamples {
 
     }
 
-    @Extension(ordinal = 1400) public static final class Maven extends Static {
+    @Extension(ordinal = 1400, optional = true) public static final class Maven extends Static {
 
         @Override public String name() {
             return "kubernetes-maven";
@@ -79,7 +79,7 @@ public class KubernetesSamples {
 
     }
 
-    @Extension(ordinal = 1300) public static final class Windows extends Static {
+    @Extension(ordinal = 1300, optional = true) public static final class Windows extends Static {
 
         @Override public String name() {
             return "kubernetes-windows";


### PR DESCRIPTION
Amends #707 to avoid errors when `workflow-cps` is not enabled. Noticed in startup logs of CloudBees `core-oc`.