### PR TITLE
[JENKINS-60133] Remove openshift-specific behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,6 +573,21 @@ containerLog 'mongodb'
 
 Also see the online help and [examples/containerLog.groovy](examples/containerLog.groovy).
 
+# Running on OpenShift
+
+OpenShift runs containers using a 'random' UID that is overriding what is specified in Docker images.
+For this reason, you may end up with the following warning in your build
+
+```
+[WARNING] HOME is set to / in the jnlp container. You may encounter troubles when using tools or ssh client. This usually happens if the uid doesnt have any entry in /etc/passwd. Please add a user to your Dockerfile or set the HOME environment variable to a valid directory in the pod template definition.
+```
+
+At the moment the jenkinsci agent image is not built for OpenShift and will issue this warning.
+
+This issue can be circumvented in various ways:
+* build a docker image for OpenShift in order to behave when running using an arbitrary uid.
+* override HOME environment variable in the pod spec to use `/home/jenkins` and mount a volume to `/home/jenkins` to ensure the user running the container can write to it
+
 # Windows support
 
 You can run pods on Windows if your cluster has Windows nodes.

--- a/README.md
+++ b/README.md
@@ -588,6 +588,8 @@ This issue can be circumvented in various ways:
 * build a docker image for OpenShift in order to behave when running using an arbitrary uid.
 * override HOME environment variable in the pod spec to use `/home/jenkins` and mount a volume to `/home/jenkins` to ensure the user running the container can write to it
 
+See this [example](examples/openshift-home-yaml.groovy) configuration.
+
 # Windows support
 
 You can run pods on Windows if your cluster has Windows nodes.

--- a/examples/openshift-home-yaml.groovy
+++ b/examples/openshift-home-yaml.groovy
@@ -1,0 +1,43 @@
+/**
+ * OpenShift runs containers with a custom UID, overridding the UID defined in docker images.
+ * This is an example of how to run docker images from DockerHub in OpenShift. It comes with no warranty.
+ *
+ * Define HOME for containers running in OpenShift
+ * Define user.home system property for maven as it relies on /etc/passwd to infer its value
+ */
+podTemplate(yaml:'''
+spec:
+  containers:
+  - name: jnlp
+    image: jenkins/jnlp-slave:4.0.1-1
+    volumeMounts:
+    - name: home-volume
+      mountPath: /home/jenkins
+    env:
+    - name: HOME
+      value: /home/jenkins
+  - name: maven
+    image: maven:3.6.3-jdk-8
+    command: ['cat']
+    tty: true
+    volumeMounts:
+    - name: home-volume
+      mountPath: /home/jenkins
+    env:
+    - name: HOME
+      value: /home/jenkins
+    - name: MAVEN_OPTS
+      value: -Duser.home=/home/jenkins
+  volumes:
+  - name: home-volume
+    emptyDir: {}
+''') {
+  node(POD_LABEL) {
+    stage('Build a Maven project') {
+      container('maven') {
+        git 'https://github.com/jenkinsci/kubernetes-plugin.git'
+        sh 'mvn -B clean package -DskipTests'
+      }
+    }
+  }
+}

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -202,17 +202,6 @@ public class KubernetesCloud extends Cloud {
         this.defaultsProviderTemplate = defaultsProviderTemplate;
     }
 
-    public boolean isOpenShift() {
-        try {
-            if (connect().isAdaptable(OpenShiftClient.class)) {
-                return true;
-            }
-        } catch (Exception e) {
-            // ignore
-        }
-        return false;
-    }
-
     @Nonnull
     public List<PodTemplate> getTemplates() {
         return templates;

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -101,8 +101,6 @@ public class PodTemplateBuilder {
     private static final String JNLPMAC_REF = "\\$\\{computer.jnlpmac\\}";
     private static final String NAME_REF = "\\$\\{computer.name\\}";
 
-    private static final String DEFAULT_HOME = System.getProperty(PodTemplateBuilder.class.getName() + ".defaultHome", "/home/jenkins");
-
     private PodTemplate template;
 
     @CheckForNull
@@ -293,13 +291,6 @@ public class PodTemplateBuilder {
                 if (!StringUtils.isBlank(httpProxy)) {
                     env.put("http_proxy", httpProxy);
                 }
-            }
-
-            if (cloud.isOpenShift()) {
-                // Running on OpenShift Enterprise, security concerns force use of arbitrary user ID
-                // As a result, container is running without a home set for user, resulting into using `/` for some tools,
-                // and `?` for java build tools. So we force HOME to a safe location.
-                env.put("HOME", DEFAULT_HOME);
             }
         }
         Map<String, EnvVar> envVarsMap = new HashMap<>();

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
@@ -239,21 +239,6 @@ public class PodTemplateBuilderTest {
         assertEquals(Long.valueOf(2000L), containersMap.get("busybox").getSecurityContext().getRunAsGroup());
     }
 
-    @Test
-    public void homeIsSetOnOpenShift() {
-        when(slave.getKubernetesCloud()).thenReturn(cloud);
-        doReturn(JENKINS_URL).when(cloud).getJenkinsUrlOrDie();
-        doReturn(true).when(cloud).isOpenShift();
-
-        PodTemplate template = new PodTemplate();
-        Pod pod = new PodTemplateBuilder(template).withSlave(slave).build();
-
-        Map<String, Container> containers = pod.getSpec().getContainers().stream()
-                .collect(Collectors.toMap(Container::getName, Function.identity()));
-        Container jnlp = containers.get("jnlp");
-        assertThat(jnlp.getEnv(), hasItems(new EnvVar("HOME", "/home/jenkins", null)));
-    }
-
     private void setupStubs() {
         doReturn(JENKINS_URL).when(cloud).getJenkinsUrlOrDie();
         when(computer.getName()).thenReturn(AGENT_NAME);


### PR DESCRIPTION
[JENKINS-60133](https://issues.jenkins-ci.org/browse/JENKINS-60133)

Running in openshift with the default jnlp image (`jenkins/jnlp-slave:4.0.1-1`) will issue the following warning

```
[WARNING] HOME is set to / in the jnlp container. You may encounter troubles when using tools or ssh client. This usually happens if the uid doesnt have any entry in /etc/passwd. Please add a user to your Dockerfile or set the HOME environment variable to a valid directory in the pod template definition.
```