### PR TITLE
[JENKINS-56764] use `withTTY()` for executing `container` commands

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -369,6 +369,7 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
                 Execable<String, ExecWatch> execable = getClient().pods().inNamespace(getNamespace()).withName(getPodName()).inContainer(containerName) //
                         .redirectingInput(STDIN_BUFFER_SIZE) // JENKINS-50429
                         .writingOutput(stream).writingError(stream).writingErrorChannel(error)
+                        .withTTY() // JENKINS-56764
                         .usingListener(new ExecListener() {
                             @Override
                             public void onOpen(Response response) {


### PR DESCRIPTION
The issue was easily reproducible for me with just using the following with Amazon EKS:
```
pipeline {
  agent {
    kubernetes {
      yaml """
apiVersion: v1
kind: Pod
spec:
  containers:
  - name: cuda
    image: nvidia/cuda:10.2-devel
    command:
    - cat
    tty: true
  tolerations:
  - key: "gpu"
    operator: "Equal"
    value: "true"
    effect: "NoSchedule"
  nodeSelector:
    beta.kubernetes.io/instance-type: g3s.xlarge
"""
    }
  }
  stages {
    stage('Test') {
      steps {
        container('cuda') {
          sh "nvidia-smi"
        }
      }
    }
  }
}
```

Strangely, when using the g3s.xlarge node, the cluster closes the websocket with code: 1000 and reason: "", when running `sh` right after it was opened.
The line above solves the issue in my case.

The same kind of behavior can be experienced with kubectl as well:
When running `kubectl exec pod-name -c container-name --stdin sh` on an m5.xlarge node, I don't get a prompt, but kubectl doesn't return either and I can type commands and get a result back. However if I run the same command on a g3s.xlarge, kubectl returns with 0 exit code immediately.
If I'm using the `--tty` flag I get a fully working prompt in either cases.

 