### PR TITLE
Validation for ContainerTemplate.image

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
@@ -74,15 +74,13 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
 
     @DataBoundConstructor
     public ContainerTemplate(String name, String image) {
-        Preconditions.checkArgument(!StringUtils.isBlank(image));
+        Preconditions.checkArgument(PodTemplateUtils.validateImage(image));
         this.name = name;
         this.image = image;
     }
 
     public ContainerTemplate(String name, String image, String command, String args) {
-        Preconditions.checkArgument(!StringUtils.isBlank(image));
-        this.name = name;
-        this.image = image;
+        this(name, image);
         this.command = command;
         this.args = args;
     }
@@ -311,6 +309,16 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
                 return FormValidation.error(Messages.RFC1123_error(value));
             }
             return FormValidation.ok();
+        }
+
+        public FormValidation doCheckImage(@QueryParameter String value) {
+            if (StringUtils.isEmpty(value)) {
+                return FormValidation.ok("Image is mandatory");
+            } else if (PodTemplateUtils.validateImage(value)) {
+                return FormValidation.ok();
+            } else {
+                return FormValidation.error("Malformed image");
+            }
         }
 
         @SuppressWarnings("unused") // jelly

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
@@ -619,6 +619,11 @@ public class PodTemplateUtils {
         return StringUtils.isBlank(label) ? true : label.length() <= 63 && LABEL_VALIDATION.matcher(label).matches();
     }
 
+    /** TODO perhaps enforce https://docs.docker.com/engine/reference/commandline/tag/#extended-description */
+    public static boolean validateImage(String image) {
+        return image != null && image.matches("\\S+");
+    }
+
     private static List<EnvVar> combineEnvVars(Container parent, Container template) {
         Map<String,EnvVar> combinedEnvVars = mergeMaps(envVarstoMap(parent.getEnv()),envVarstoMap(template.getEnv()));
         return combinedEnvVars.entrySet().stream()

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplateTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplateTest.java
@@ -15,9 +15,10 @@
 
 package org.csanchez.jenkins.plugins.kubernetes;
 
+import hudson.util.FormValidation;
 import java.util.Collections;
 
-import org.junit.Assert;
+import static org.junit.Assert.*;
 import org.junit.Test;
 
 public class ContainerTemplateTest {
@@ -42,9 +43,24 @@ public class ContainerTemplateTest {
 
         ContainerTemplate clonedTemplate = new ContainerTemplate(originalTemplate);
 
-        Assert.assertEquals("Cloned ContainerTemplate is not equal to the original one!", originalTemplate, clonedTemplate);
-        Assert.assertEquals("String representation (toString()) of the cloned and original ContainerTemplate is not equal!",
+        assertEquals("Cloned ContainerTemplate is not equal to the original one!", originalTemplate, clonedTemplate);
+        assertEquals("String representation (toString()) of the cloned and original ContainerTemplate is not equal!",
                 originalTemplate.toString(), clonedTemplate.toString());
+    }
+
+    @SuppressWarnings("ResultOfObjectAllocationIgnored")
+    @Test
+    public void badImage() throws Exception {
+        new ContainerTemplate("n", "something");
+        assertEquals(FormValidation.Kind.OK, new ContainerTemplate.DescriptorImpl().doCheckImage("something").kind);
+        for (String empty : new String[] {null, ""}) {
+            assertThrows("rejected " + empty, IllegalArgumentException.class, () -> new ContainerTemplate("n", empty));
+            assertEquals("tolerating " + empty + " during form validation", FormValidation.Kind.OK, new ContainerTemplate.DescriptorImpl().doCheckImage(empty).kind);
+        }
+        for (String bad : new String[] {" ", " something"}) {
+            assertThrows("rejected " + bad, IllegalArgumentException.class, () -> new ContainerTemplate("n", bad));
+            assertEquals("rejected " + bad, FormValidation.Kind.ERROR, new ContainerTemplate.DescriptorImpl().doCheckImage(bad).kind);
+        }
     }
 
 }


### PR DESCRIPTION
@jtnord reported having accidentally pasted text into this field with a leading space and getting hard-to-diagnose `KubernetesClientException`s later. Better to do a basic sanity check right away.