### PR TITLE
Set default cpu & memory requests on the jnlp container

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -253,6 +253,9 @@ public class PodTemplateBuilder {
         envVars.putAll(defaultEnvVars(template.getEnvVars()));
         envVars.putAll(jnlp.getEnv().stream().collect(Collectors.toMap(EnvVar::getName, Function.identity())));
         jnlp.setEnv(new ArrayList<>(envVars.values()));
+        if (jnlp.getResources() == null) {
+            jnlp.setResources(new ContainerBuilder().editOrNewResources().addToRequests("cpu", new Quantity("100m")).addToRequests("memory", new Quantity("256Mi")).endResources().build().getResources());
+        }
 
         // default workspace volume, add an empty volume to share the workspace across the pod
         if (pod.getSpec().getVolumes().stream().noneMatch(v -> WORKSPACE_VOLUME_NAME.equals(v.getName()))) {

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
@@ -349,10 +349,10 @@ public class PodTemplateBuilderTest {
         assertEquals(1, containers.size());
         Container jnlp = containers.get("jnlp");
         assertThat("Wrong number of volume mounts: " + jnlp.getVolumeMounts(), jnlp.getVolumeMounts(), hasSize(1));
-        assertEquals(new Quantity("2"), jnlp.getResources().getLimits().get("cpu"));
-        assertEquals(new Quantity("2Gi"), jnlp.getResources().getLimits().get("memory"));
-        assertEquals(new Quantity("200m"), jnlp.getResources().getRequests().get("cpu"));
-        assertEquals(new Quantity("256Mi"), jnlp.getResources().getRequests().get("memory"));
+        PodTemplateUtilsTest.assertQuantity("2", jnlp.getResources().getLimits().get("cpu"));
+        PodTemplateUtilsTest.assertQuantity("2Gi", jnlp.getResources().getLimits().get("memory"));
+        PodTemplateUtilsTest.assertQuantity("200m", jnlp.getResources().getRequests().get("cpu"));
+        PodTemplateUtilsTest.assertQuantity("256Mi", jnlp.getResources().getRequests().get("memory"));
         validateContainers(pod, slave, directConnection);
     }
 
@@ -387,10 +387,10 @@ public class PodTemplateBuilderTest {
         Map<String, Container> containers = toContainerMap(pod);
         assertEquals(1, containers.size());
         Container jnlp = containers.get("jnlp");
-        assertEquals(new Quantity("1"), jnlp.getResources().getLimits().get("cpu"));
-        assertEquals(new Quantity("1Gi"), jnlp.getResources().getLimits().get("memory"));
-        assertEquals(new Quantity("100m"), jnlp.getResources().getRequests().get("cpu"));
-        assertEquals(new Quantity("156Mi"), jnlp.getResources().getRequests().get("memory"));
+        PodTemplateUtilsTest.assertQuantity("1", jnlp.getResources().getLimits().get("cpu"));
+        PodTemplateUtilsTest.assertQuantity("1Gi", jnlp.getResources().getLimits().get("memory"));
+        PodTemplateUtilsTest.assertQuantity("100m", jnlp.getResources().getRequests().get("cpu"));
+        PodTemplateUtilsTest.assertQuantity("156Mi", jnlp.getResources().getRequests().get("memory"));
         assertEquals(Long.valueOf(1000L), jnlp.getSecurityContext().getRunAsUser());
         assertEquals(Long.valueOf(2000L), jnlp.getSecurityContext().getRunAsGroup());
         validateContainers(pod, slave, directConnection);

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
@@ -49,6 +49,7 @@ import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
@@ -333,6 +334,18 @@ public class PodTemplateBuilderTest {
             assertThat(jnlp.getArgs(), empty());
         }
         assertThat(jnlp.getEnv(), containsInAnyOrder(envVars.toArray(new EnvVar[envVars.size()])));
+    }
+
+    @Test
+    public void defaultRequests() throws Exception {
+        PodTemplate template = new PodTemplate();
+        Pod pod = new PodTemplateBuilder(template).build();
+        ResourceRequirements resources = pod.getSpec().getContainers().get(0).getResources();
+        assertNotNull(resources);
+        Map<String, Quantity> requests = resources.getRequests();
+        assertNotNull(requests);
+        assertTrue(requests.containsKey("cpu"));
+        assertTrue(requests.containsKey("memory"));
     }
 
     @Test

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
@@ -56,6 +56,7 @@ import jenkins.model.Jenkins;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
+import org.jvnet.hudson.test.WithoutJenkins;
 
 @RunWith(JUnitParamsRunner.class)
 public class PodTemplateBuilderTest {
@@ -84,6 +85,7 @@ public class PodTemplateBuilderTest {
     @Mock
     private KubernetesComputer computer;
 
+    @WithoutJenkins
     @Test
     public void testParseDockerCommand() {
         assertNull(parseDockerCommand(""));
@@ -93,6 +95,7 @@ public class PodTemplateBuilderTest {
         assertEquals(ImmutableList.of("a", "b", "c", "d"), parseDockerCommand("a b c d"));
     }
 
+    @WithoutJenkins
     @Test
     public void testParseLivenessProbe() {
         assertNull(parseLivenessProbe(""));

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
@@ -61,7 +61,6 @@ import io.fabric8.kubernetes.api.model.SecretEnvSource;
 import io.fabric8.kubernetes.api.model.Toleration;
 import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
-import io.fabric8.kubernetes.client.KubernetesClientException;
 
 public class PodTemplateUtilsTest {
 

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
@@ -553,10 +553,20 @@ public class PodTemplateUtilsTest {
 
         Container result = combine(container1, container2);
 
-        assertEquals(new Quantity("2"), result.getResources().getLimits().get("cpu"));
-        assertEquals(new Quantity("2Gi"), result.getResources().getLimits().get("memory"));
-        assertEquals(new Quantity("200m"), result.getResources().getRequests().get("cpu"));
-        assertEquals(new Quantity("256Mi"), result.getResources().getRequests().get("memory"));
+        assertQuantity("2", result.getResources().getLimits().get("cpu"));
+        assertQuantity("2Gi", result.getResources().getLimits().get("memory"));
+        assertQuantity("200m", result.getResources().getRequests().get("cpu"));
+        assertQuantity("256Mi", result.getResources().getRequests().get("memory"));
+    }
+
+    /**
+     * Use instead of {@link org.junit.Assert#assertEquals(Object, Object)} on {@link Quantity}.
+     * @see <a href="https://github.com/fabric8io/kubernetes-client/issues/2034">kubernetes-client #2034</a>
+     */
+    public static void assertQuantity(String expected, Quantity actual) {
+        if (Quantity.getAmountInBytes(new Quantity(expected)).compareTo(Quantity.getAmountInBytes(actual)) != 0) {
+            fail("expected: " + expected + " but was: " + actual.getAmount() + actual.getFormat());
+        }
     }
 
     @Test

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
@@ -534,6 +534,7 @@ public class PodTemplateUtilsTest {
         assertThat(combine(template1, template2).getPorts(), contains(port2));
     }
 
+    @Test
     public void shouldCombineAllResources() {
         Container container1 = new Container();
         container1.setResources(new ResourceRequirementsBuilder() //


### PR DESCRIPTION
Suggested by @jtnord. If the user has not bothered to set any resource requests or limits on the `jnlp` container, it is wise to offer some reasonable default values. I chose 100m CPU and 256Mi memory based on `kubectl top pod` of a container from a simple build in EKS that was generating a modest amount of log output and consuming somewhat less than these values.