### PR TITLE
Fix packaging of unwanted dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,10 +149,6 @@
           <groupId>org.jboss.marshalling</groupId>
           <artifactId>jboss-marshalling-river</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>org.jboss.marshalling</groupId>
-          <artifactId>jboss-marshalling</artifactId>
-        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,16 @@
       <artifactId>workflow-support</artifactId>
       <classifier>tests</classifier>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.marshalling</groupId>
+          <artifactId>jboss-marshalling-river</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jboss.marshalling</groupId>
+          <artifactId>jboss-marshalling</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkinsci.plugins</groupId>
@@ -167,34 +177,12 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <!-- Already included through pipeline-model-extensions and causing them to be packaged -->
-        <exclusion>
-          <groupId>org.jenkins-ci.plugins</groupId>
-          <artifactId>ssh-credentials</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>joda-time</groupId>
-          <artifactId>joda-time</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
       <classifier>tests</classifier>
       <scope>test</scope>
-      <exclusions>
-        <!-- Already included through pipeline-model-extensions and causing them to be packaged -->
-        <exclusion>
-          <groupId>org.jenkins-ci.plugins</groupId>
-          <artifactId>ssh-credentials</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>joda-time</groupId>
-          <artifactId>joda-time</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -213,16 +201,12 @@
           <groupId>org.apache.sshd</groupId>
           <artifactId>sshd-core</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>org.jenkins-ci.plugins</groupId>
-          <artifactId>ssh-credentials</artifactId>
-        </exclusion>
       </exclusions>
     </dependency>
-    <dependency> <!-- TODO for #sshagent pending https://github.com/jenkinsci/ssh-credentials-plugin/pull/47 -->
+    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>trilead-api</artifactId>
-      <version>1.0.5</version>
+      <artifactId>ssh-credentials</artifactId>
+      <version>1.18</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -246,6 +230,7 @@
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>instance-identity</artifactId>
       <version>2.2</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>pl.pragmatists</groupId>
@@ -264,6 +249,13 @@
         <version>5</version>
         <scope>import</scope>
         <type>pom</type>
+      </dependency>
+      <dependency>
+        <!-- Avoid it from being bundled -->
+        <groupId>com.google.code.findbugs</groupId>
+        <artifactId>jsr305</artifactId>
+        <version>3.0.2</version>
+        <scope>provided</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
* instance-identity scope should be provided
* ssh-credentials 1.18
* fix bundled dependencies that shouldn't be packaged
(https://github.com/jenkinsci/maven-hpi-plugin/pull/140 doesn't cover
all use cases)