### PR TITLE
Fix copy constructor of PodTemplate to keep TaskListener

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -180,6 +180,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
         XStream2 xs = new XStream2();
         xs.unmarshal(XStream2.getDefaultDriver().createReader(new StringReader(xs.toXML(from))), this);
         this.yamls = from.yamls;
+        this.listener = from.listener;
     }
 
     @Deprecated


### PR DESCRIPTION
Amends #497

`org.csanchez.jenkins.plugins.kubernetes.pipeline.KubernetesDeclarativeAgentTest#declarativeWithNonexistentDockerImageLongLabel` is passing but when the `PodTemplate` was copied the TaskListener reference wasn't kept.