### PR TITLE
Removing warning about container step

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ spec:
 
 Multiple containers can be defined for the agent pod, with shared resources, like mounts. Ports in each container can be accessed as in any Kubernetes pod, by using `localhost`.
 
-The `container` statement allows to execute commands directly into each container. This feature is considered **ALPHA** as there are still some problems with concurrent execution and pipeline resumption
+The `container` statement allows to execute commands directly into each container.
 
 ```groovy
 podTemplate(containers: [


### PR DESCRIPTION
@jtnord highlighted this. a583b4720a202e720df9ddc0fc5e5d4a79e2c6ff was nearly three years ago. If there are bugs not caught by the likes of https://github.com/jenkinsci/kubernetes-plugin/blob/c77a64d8c7f70d0337302c1d204f51676c408b19/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/RestartPipelineTest.java#L168-L187 + https://github.com/jenkinsci/kubernetes-plugin/blob/c77a64d8c7f70d0337302c1d204f51676c408b19/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runInPodWithRestartWithLongSleep.groovy#L10, we will endeavour to fix them.