### PR TITLE
[JENKINS-61387] - Clean up the slave after the channel terminated

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
@@ -241,6 +241,26 @@ public class KubernetesLauncher extends JNLPLauncher {
         }
     }
 
+    @Override
+    public void afterDisconnect(SlaveComputer computer, TaskListener listener) {
+        // return if it is not a KubernetesComputer
+        if (!(computer instanceof KubernetesComputer)) {
+            return;
+        }
+
+        KubernetesSlave slave = (KubernetesSlave) computer.getNode();
+        // if slave is null, we should not proceed as it might haven't create a slave
+        if (slave == null) {
+            return;
+        }
+
+        try {
+            slave.terminate();
+        } catch (IOException | InterruptedException e) {
+            listener.getLogger().printf("Failed to terminate slave %s after disconnect", slave.getNodeName());
+        }
+    }
+
     /**
      * Log the last lines of containers logs
      */


### PR DESCRIPTION
Currently, the SlaveComputer won't be clean up after the channel to this computer terminated unexpectedly. This will cuase build run forever. 

https://issues.jenkins-ci.org/browse/JENKINS-61387