### PR TITLE
Change StatefulSet apiVersion

### DIFF
--- a/src/main/kubernetes/jenkins.yml
+++ b/src/main/kubernetes/jenkins.yml
@@ -1,7 +1,7 @@
 # jenkins
 
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: jenkins


### PR DESCRIPTION
> StatefulSet versions apps/v1beta1 and apps/v1beta2 are deprecated
> - use apps/v1, available since Kubernetes 1.9