### PR TITLE
Ensure http proxy is set when addMasterProxyEnvVars is checked

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -287,10 +287,7 @@ public class PodTemplateBuilder {
                 if (!StringUtils.isBlank(noProxy)) {
                     env.put("no_proxy", noProxy);
                 }
-                String httpProxy = null;
-                if (System.getProperty("http.proxyHost") == null) {
-                    httpProxy = System.getenv("http_proxy");
-                }
+                String httpProxy = System.getenv("http_proxy");
                 if (!StringUtils.isBlank(httpProxy)) {
                     env.put("http_proxy", httpProxy);
                 }


### PR DESCRIPTION
When working with openshift, when an http_proxy env var is set in the pod, we have autmatically a  -Dhttp.proxyHost setting in the jenkins jvm hence, it is never null. The jenkins http proxy is bever propagated to the pod template even if we check the option.
I was thinking of adding a special test for openshift (kind of is cloud.isOpenshit) to have a specific behaviour for it, but I am wondering In which case we want to propagate the http proxy only if a proxy is not set the jenkins master, which is kind of contradictory.