### PR TITLE
Prevent NPE when null set in container's volume mounts

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -256,6 +256,12 @@ public class PodTemplateBuilder {
         if (jnlp.getResources() == null) {
             jnlp.setResources(new ContainerBuilder().editOrNewResources().addToRequests("cpu", new Quantity("100m")).addToRequests("memory", new Quantity("256Mi")).endResources().build().getResources());
         }
+        
+        // If the volume mounts of any container has been set to null, set it to empty list.
+        // Without this being done the code below would throw a NPE if such null existed.
+        pod.getSpec().getContainers().stream()
+               .filter(c -> c.getVolumeMounts() == null)
+               .forEach(c -> c.setVolumeMounts(new ArrayList<>()));
 
         // default workspace volume, add an empty volume to share the workspace across the pod
         if (pod.getSpec().getVolumes().stream().noneMatch(v -> WORKSPACE_VOLUME_NAME.equals(v.getName()))) {


### PR DESCRIPTION
Prevents a null pointer exception when a null is set in the volume mounts collection of a container.

This can happen for instance when a yaml file specifies an empty `volumeMounts` section:

```yaml
 containers:
  - name: jnlp
    image: jenkins/jnlp-slave:alpine
    imagePullPolicy: IfNotPresent
    volumeMounts:
    env:
      - name: JAVA_TOOL_OPTIONS
        value: -Xmx1G
    resources:
      limits:
        memory: "1Gi"
        cpu: "1"
```

Signed-off-by: arjantijms <arjan.tijms@gmail.com>