### PR TITLE
Removing docker 'slave' ref.. New image is inbound-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ For that some environment variables are automatically injected:
 * `JENKINS_AGENT_NAME`: the name of the Jenkins agent
 * `JENKINS_NAME`: the name of the Jenkins agent (Deprecated. Only here for backwards compatibility)
 
-Tested with [`jenkins/jnlp-slave`](https://hub.docker.com/r/jenkins/jnlp-slave),
-see the [Docker image source code](https://github.com/jenkinsci/docker-jnlp-slave).
+Tested with [`jenkins/inbound-agent`](https://hub.docker.com/r/jenkins/inbound-agent),
+see the [Docker image source code](https://github.com/jenkinsci/docker-inbound-agent).
 
 It is not required to run the Jenkins master inside Kubernetes. 
 # Generic Setup
@@ -198,7 +198,7 @@ Either way it provides access to the following fields:
 * **annotations** Annotations to apply to the pod.
 * **inheritFrom** List of one or more pod templates to inherit from *(more details below)*.
 * **slaveConnectTimeout** Timeout in seconds for an agent to be online *(more details below)*.
-* **podRetention** Controls the behavior of keeping slave pods. Can be 'never()', 'onFailure()', 'always()', or 'default()' - if empty will default to deleting the pod after `activeDeadlineSeconds` has passed.
+* **podRetention** Controls the behavior of keeping agent pods. Can be 'never()', 'onFailure()', 'always()', or 'default()' - if empty will default to deleting the pod after `activeDeadlineSeconds` has passed.
 * **activeDeadlineSeconds** If `podRetention` is set to 'never()' or 'onFailure()', pod is deleted after this deadline is passed.
 * **idleMinutes** Allows the Pod to remain active for reuse until the configured number of minutes has passed since the last step was executed on it.
 * **showRawYaml** Enable or disable the output of the raw Yaml file. Defaults to `true`
@@ -616,7 +616,7 @@ Other containers must run a long running process, so the container does not exit
 just runs something and exit then it should be overridden with something like `cat` with `ttyEnabled: true`.
 
 **WARNING**
-If you want to provide your own Docker image for the JNLP slave, you **must** name the container `jnlp` so it overrides the default one. Failing to do so will result in two slaves trying to concurrently connect to the master.
+If you want to provide your own Docker image for the JNLP agent, you **must** name the container `jnlp` so it overrides the default one. Failing to do so will result in two agents trying to concurrently connect to the master.
 
 
 
@@ -847,7 +847,7 @@ Set `Container Cap` to a reasonable number for tests, i.e. 3.
 
 Add an image with
 
-* Docker image: `jenkins/jnlp-slave`
+* Docker image: `jenkins/inbound-agent`
 * Jenkins agent root directory: `/home/jenkins/agent`
 
 ![image](configuration.png)


### PR DESCRIPTION
With regards to the image change [here](:exclamation: Warning! This image used to be published as jenkinsci/jnlp-slave and jenkins/jnlp-slave. These images are deprecated, use jenkins/inbound-agent.) and per the mailing list [here](https://groups.google.com/forum/#!topic/jenkinsci-dev/oxD-Hd_7l9k), I am starting the corrections to the [README](https://github.com/jenkinsci/kubernetes-plugin/blob/master/README.md)