### PR TITLE
Looks like in some case of workspace reuse the executable exist but don't have right permission

### DIFF
--- a/kind.sh
+++ b/kind.sh
@@ -2,12 +2,12 @@
 set -euxo pipefail
 
 export PATH=$WSTMP:$PATH
-if [ \! -f $WSTMP/kind ]
+if [ \! -x $WSTMP/kind ]
 then
     curl -Lo $WSTMP/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-$(uname | tr '[:upper:]' '[:lower:]')-amd64
     chmod +x $WSTMP/kind
 fi
-if [ \! -f $WSTMP/kubectl ]
+if [ \! -x $WSTMP/kubectl ]
 then
     curl -Lo $WSTMP/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.17.0/bin/$(uname | tr '[:upper:]' '[:lower:]')/amd64/kubectl
     chmod +x $WSTMP/kubectl


### PR DESCRIPTION
cf. https://ci.jenkins.io/job/Plugins/job/kubernetes-plugin/job/master/743/console

```
15:40:12  Have a question, bug, or feature request? Let us know! https://kind.sigs.k8s.io/#community 🙂
15:40:12  + trap cleanup EXIT
15:40:12  + kubectl cluster-info
15:40:12  kind.sh: line 25: /home/jenkins/workspace/Plugins_kubernetes-plugin_master@tmp/kubectl: Permission denied
15:40:12  + cleanup
```