### PR TITLE
Handle odd job names that do not match DNS_SUBDOMAIN

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
@@ -227,7 +227,11 @@ public class KubernetesSlave extends AbstractCloudSlave {
         name = name.replaceAll("[ _]", "-").toLowerCase();
         // keep it under 63 chars (62 is used to account for the '-')
         name = name.substring(0, Math.min(name.length(), 62 - randString.length()));
-        return String.format("%s-%s", name, randString);
+        String slaveName = String.format("%s-%s", name, randString);
+        if (!slaveName.matches("[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*")) {
+            return String.format("%s-%s", DEFAULT_AGENT_PREFIX, randString);
+        }
+        return slaveName;
     }
 
     @Override

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlaveTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlaveTest.java
@@ -43,17 +43,17 @@ import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import hudson.model.Descriptor;
+import org.jvnet.hudson.test.WithoutJenkins;
 
 /**
  * @author Carlos Sanchez
- * @since
- *
  */
 public class KubernetesSlaveTest {
 
     @Rule
     public JenkinsRule r = new JenkinsRule();
 
+    @WithoutJenkins
     @Test
     public void testGetSlaveName() {
         List<? extends PodVolume> volumes = Collections.emptyList();
@@ -65,6 +65,7 @@ public class KubernetesSlaveTest {
                 ("^a-name-[0-9a-z]{5}$"));
         assertRegex(KubernetesSlave.getSlaveName(new PodTemplate("an_other_name", volumes, containers)),
                 ("^an-other-name-[0-9a-z]{5}$"));
+        assertRegex(KubernetesSlave.getSlaveName(new PodTemplate("whatever...", volumes, containers)), ("jenkins-agent-[0-9a-z]{5}"));
     }
 
     @Test

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodNameTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodNameTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 CloudBees, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.csanchez.jenkins.plugins.kubernetes.pipeline;
+
+import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.deletePods;
+import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.getLabels;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.junit.Before;
+import org.junit.Test;
+
+public class PodNameTest extends AbstractKubernetesPipelineTest {
+
+    @Before
+    public void setUp() throws Exception {
+        deletePods(cloud.connect(), getLabels(cloud, this, name), false);
+    }
+
+    @Test
+    public void trailingDots() throws Exception {
+        WorkflowJob p = r.createProject(WorkflowJob.class, "whatever...");
+        p.setDefinition(new CpsFlowDefinition("podTemplate {node(POD_LABEL) {sh 'echo ok'}}", true));
+        r.buildAndAssertSuccess(p);
+    }
+
+}


### PR DESCRIPTION
https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names is a bit vague but I found insufficient sanitization here.