### PR TITLE
Don't disconnect before deleting pod

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
@@ -308,16 +308,8 @@ public class KubernetesSlave extends AbstractCloudSlave {
         }
 
         // Disconnect the master from the slave agent
-        OfflineCause offlineCause = OfflineCause.create(new Localizable(HOLDER, "offline"));
-
-        Future<?> disconnected = computer.disconnect(offlineCause);
-        // wait a bit for disconnection to avoid stack traces in logs
-        try {
-            disconnected.get(DISCONNECTION_TIMEOUT, TimeUnit.SECONDS);
-        } catch (Exception e) {
-            String msg = String.format("Ignoring error waiting for agent disconnection %s: %s", name, e.getMessage());
-            LOGGER.log(Level.INFO, msg, e);
-        }
+        OfflineCause offlineCause = OfflineCause.create(new Localizable(HOLDER, "Setting offline before shutting down"));
+        computer.setTemporarilyOffline(true, offlineCause);
 
         if (getCloudName() == null) {
             String msg = String.format("Cloud name is not set for agent, can't terminate: %s", name);


### PR DESCRIPTION
With the previous implementation, I've seen the agent attempting to
reconnect even before the pod is purged, which cause unnecessary errors
displayed in logs (both agent and master side).

With the following change, the node is only marked as temporary offline
until the pod gets deleted.