### PR TITLE
Prevent concurrent launches

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
@@ -37,6 +37,7 @@ import java.util.stream.Collectors;
 
 import javax.annotation.CheckForNull;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.Queue;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import jenkins.model.Jenkins;
@@ -92,6 +93,7 @@ public class KubernetesLauncher extends JNLPLauncher {
     }
 
     @Override
+    @SuppressFBWarnings(value = "SWL_SLEEP_WITH_LOCK_HELD", justification = "This is fine")
     public synchronized void launch(SlaveComputer computer, TaskListener listener) {
         if (!(computer instanceof KubernetesComputer)) {
             throw new IllegalArgumentException("This Launcher can be used only with KubernetesComputer");

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
@@ -92,8 +92,7 @@ public class KubernetesLauncher extends JNLPLauncher {
     }
 
     @Override
-    public void launch(SlaveComputer computer, TaskListener listener) {
-
+    public synchronized void launch(SlaveComputer computer, TaskListener listener) {
         if (!(computer instanceof KubernetesComputer)) {
             throw new IllegalArgumentException("This Launcher can be used only with KubernetesComputer");
         }


### PR DESCRIPTION
Seems that in some cases `KubernetesLauncher#launch` is being called
concurrently. The launcher is designed to run only once, and cleans up
the node upon failure, so it should never be called by concurrent
threads.