### PR TITLE
Make default JNLP container resource requests/limits overridable

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -98,6 +98,11 @@ public class PodTemplateBuilder {
     static final String DEFAULT_JNLP_IMAGE = System
             .getProperty(PodTemplateStepExecution.class.getName() + ".defaultImage", "jenkins/inbound-agent:4.3-4");
 
+    static final String DEFAULT_JNLP_CONTAINER_MEMORY_REQUEST = System
+            .getProperty(PodTemplateStepExecution.class.getName() + ".defaultContainer.defaultMemoryRequest", "256Mi");
+    static final String DEFAULT_JNLP_CONTAINER_CPU_REQUEST = System
+            .getProperty(PodTemplateStepExecution.class.getName() + ".defaultContainer.defaultCpuRequest", "100m");
+
     private static final String JNLPMAC_REF = "\\$\\{computer.jnlpmac\\}";
     private static final String NAME_REF = "\\$\\{computer.name\\}";
 
@@ -253,7 +258,7 @@ public class PodTemplateBuilder {
         envVars.putAll(jnlp.getEnv().stream().collect(Collectors.toMap(EnvVar::getName, Function.identity())));
         jnlp.setEnv(new ArrayList<>(envVars.values()));
         if (jnlp.getResources() == null) {
-            jnlp.setResources(new ContainerBuilder().editOrNewResources().addToRequests("cpu", new Quantity("100m")).addToRequests("memory", new Quantity("256Mi")).endResources().build().getResources());
+            jnlp.setResources(new ContainerBuilder().editOrNewResources().addToRequests("cpu", new Quantity(DEFAULT_JNLP_CONTAINER_CPU_REQUEST)).addToRequests("memory", new Quantity(DEFAULT_JNLP_CONTAINER_MEMORY_REQUEST)).endResources().build().getResources());
         }
         
         // If the volume mounts of any container has been set to null, set it to empty list.

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
@@ -344,8 +344,8 @@ public class PodTemplateBuilderTest {
         assertNotNull(resources);
         Map<String, Quantity> requests = resources.getRequests();
         assertNotNull(requests);
-        assertEquals(PodTemplateBuilder.DEFAULT_JNLP_CONTAINER_CPU_REQUEST, requests.get("cpu"));
-        assertEquals(PodTemplateBuilder.DEFAULT_JNLP_CONTAINER_MEMORY_REQUEST, requests.get("memory"));
+        PodTemplateUtilsTest.assertQuantity(PodTemplateBuilder.DEFAULT_JNLP_CONTAINER_CPU_REQUEST, requests.get("cpu"));
+        PodTemplateUtilsTest.assertQuantity(PodTemplateBuilder.DEFAULT_JNLP_CONTAINER_MEMORY_REQUEST, requests.get("memory"));
     }
 
     @Test

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
@@ -344,8 +344,8 @@ public class PodTemplateBuilderTest {
         assertNotNull(resources);
         Map<String, Quantity> requests = resources.getRequests();
         assertNotNull(requests);
-        assertTrue(requests.containsKey("cpu"));
-        assertTrue(requests.containsKey("memory"));
+        assertEquals(PodTemplateBuilder.DEFAULT_JNLP_CONTAINER_CPU_REQUEST, requests.get("cpu"));
+        assertEquals(PodTemplateBuilder.DEFAULT_JNLP_CONTAINER_MEMORY_REQUEST, requests.get("memory"));
     }
 
     @Test


### PR DESCRIPTION
We used to use LimitRange to define default resource limits/requests for the jnlp container but since a couple of release, we have to define the limits/request in each pod templates if we want different values from the hardcoded values. 

This can be an issue as some pipeline stuff can't be executed outside of the JNLP container (like git clone / fetch from the git client) and the limited hardcoded resources make the operations very slow or even fail. See https://issues.jenkins-ci.org/browse/JENKINS-51542 (and also probably https://issues.jenkins-ci.org/browse/JENKINS-30600 as a root cause). See also https://bugs.eclipse.org/bugs/show_bug.cgi?id=560283#c16 for details about performance issue.

This PR adds system properties to let the Jenkins instance be started with specific values instead of hardcoded values.

It also now sets limits and not only requests.