### PR TITLE
Don't emit any securityContext block if there is nothing valuable to put inside.

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -483,7 +483,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
 
     @DataBoundSetter
     public void setSupplementalGroups(String supplementalGroups) {
-        this.supplementalGroups = supplementalGroups;
+        this.supplementalGroups = Util.fixEmpty(supplementalGroups);
     }
 
     public String getSupplementalGroups() {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
@@ -293,18 +293,20 @@ public class PodTemplateUtils {
 
 
         // Security context
-        specBuilder.editOrNewSecurityContext()
-                .withRunAsUser(
-                        template.getSpec().getSecurityContext() != null && template.getSpec().getSecurityContext().getRunAsUser() != null ? template.getSpec().getSecurityContext().getRunAsUser() : (
-                                parent.getSpec().getSecurityContext() != null && parent.getSpec().getSecurityContext().getRunAsUser() != null ? parent.getSpec().getSecurityContext().getRunAsUser() : null
-                        )
-                )
-                .withRunAsGroup(
-                        template.getSpec().getSecurityContext() != null && template.getSpec().getSecurityContext().getRunAsGroup() != null ? template.getSpec().getSecurityContext().getRunAsGroup() : (
-                                parent.getSpec().getSecurityContext() != null && parent.getSpec().getSecurityContext().getRunAsGroup() != null ? parent.getSpec().getSecurityContext().getRunAsGroup() : null
-                        )
-                )
-                .endSecurityContext();
+        if (template.getSpec().getSecurityContext() != null || parent.getSpec().getSecurityContext() != null) {
+            specBuilder.editOrNewSecurityContext()
+                    .withRunAsUser(
+                            template.getSpec().getSecurityContext() != null && template.getSpec().getSecurityContext().getRunAsUser() != null ? template.getSpec().getSecurityContext().getRunAsUser() : (
+                                    parent.getSpec().getSecurityContext() != null && parent.getSpec().getSecurityContext().getRunAsUser() != null ? parent.getSpec().getSecurityContext().getRunAsUser() : null
+                            )
+                    )
+                    .withRunAsGroup(
+                            template.getSpec().getSecurityContext() != null && template.getSpec().getSecurityContext().getRunAsGroup() != null ? template.getSpec().getSecurityContext().getRunAsGroup() : (
+                                    parent.getSpec().getSecurityContext() != null && parent.getSpec().getSecurityContext().getRunAsGroup() != null ? parent.getSpec().getSecurityContext().getRunAsGroup() : null
+                            )
+                    )
+                    .endSecurityContext();
+        }
 
         // podTemplate.setLabel(label);
 //        podTemplate.setEnvVars(combineEnvVars(parent, template));

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
@@ -3,8 +3,12 @@ package org.csanchez.jenkins.plugins.kubernetes;
 import static java.util.stream.Collectors.toList;
 import static org.csanchez.jenkins.plugins.kubernetes.PodTemplateBuilder.*;
 import static org.csanchez.jenkins.plugins.kubernetes.PodTemplateUtils.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
@@ -124,9 +128,7 @@ public class PodTemplateBuilderTest {
         template.setSupplementalGroups("");
         Pod pod = new PodTemplateBuilder(template).build();
         validatePod(pod, directConnection);
-        assertNull(pod.getSpec().getSecurityContext().getRunAsUser());
-        assertNull(pod.getSpec().getSecurityContext().getRunAsGroup());
-        assertEquals(new ArrayList<Long>(), pod.getSpec().getSecurityContext().getSupplementalGroups());
+        assertNull(pod.getSpec().getSecurityContext());
     }
 
     @Test


### PR DESCRIPTION
While I was investigating some failures to schedule windows pods on GKE. Although this doesn't solve the problem, seems to be a bug on GKE side.