### PR TITLE
Suggest NodeProvisioner review after adding new pods

### DIFF
--- a/src/main/java/io/jenkins/plugins/kubernetes/NoDelayProvisionerStrategy.java
+++ b/src/main/java/io/jenkins/plugins/kubernetes/NoDelayProvisionerStrategy.java
@@ -6,12 +6,14 @@ import hudson.slaves.Cloud;
 import hudson.slaves.CloudProvisioningListener;
 import hudson.slaves.NodeProvisioner;
 import jenkins.model.Jenkins;
+import jenkins.util.Timer;
 import org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -71,6 +73,11 @@ public class NoDelayProvisionerStrategy extends NodeProvisioner.Strategy {
             }
         }
         if (availableCapacity >= currentDemand) {
+            NodeProvisioner nodeProvisioner = label.nodeProvisioner;
+            if (availableCapacity > 0 && nodeProvisioner != null) {
+                LOGGER.log(Level.FINE, "Suggesting NodeProvisioner review");
+                Timer.get().schedule(nodeProvisioner::suggestReviewNow, 1L, TimeUnit.SECONDS);
+            }
             LOGGER.log(Level.FINE, "Provisioning completed");
             return NodeProvisioner.StrategyDecision.PROVISIONING_COMPLETED;
         } else {


### PR DESCRIPTION
When the Kubernetes plugin provisions new pods, there is a delay of up to `hudson.slaves.NodeProvisioner.recurrencePeriod` before the queue is checked and new pods are actually started.

NodeProvisioner has a method `suggestReviewNow` to get around this. I'm not sure about the best way to trigger it, so if there's a better way I'm all for it. For now I'm triggering it with a one-off timer with a delay of 1 second.

From my testing, this results in significantly faster pod provisioning, which makes a big difference in short-running jobs.