### PR TITLE
[JENKINS-61306] Fix: HostNetwork always displayed and reset to false …

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -496,7 +496,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
     }
 
     public boolean isHostNetwork() {
-        return hostNetwork;
+        return isHostNetworkSet()?hostNetwork.booleanValue():false;
     }
 
     public boolean isHostNetworkSet() {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -495,7 +495,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
         this.hostNetwork = hostNetwork;
     }
 
-    public Boolean isHostNetwork() {
+    public boolean isHostNetwork() {
         return hostNetwork;
     }
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
@@ -417,7 +417,11 @@ public class PodTemplateUtils {
 
         podTemplate.setSupplementalGroups(template.getSupplementalGroups() != null ? template.getSupplementalGroups() : parent.getSupplementalGroups());
 
-        podTemplate.setHostNetwork(template.isHostNetworkSet() ? template.isHostNetwork() : parent.isHostNetwork());
+        if (template.isHostNetworkSet()) {
+            podTemplate.setHostNetwork(template.isHostNetwork());
+        } else if (parent.isHostNetworkSet()) {
+            podTemplate.setHostNetwork(parent.isHostNetwork());
+        }
 
         List<String> yamls = new ArrayList<>(parent.getYamls());
         yamls.addAll(template.getYamls());


### PR DESCRIPTION
…on Jenkins GUI

Jenkins is using `commons-jexl`(1.1-jenkins-20111212) to discover getter for variables. Jexl cannot find the correct getter for boolean variable if the return type is `Boolean` instead of `boolean` in this version. https://github.com/jenkinsci/jexl/blob/patched/src/java/org/apache/commons/jexl/util/BooleanPropertyExecutor.java#L93
