### PR TITLE
[JENKINS-63441] Fix: Invalid Pod Template Check

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/AllContainersRunningPodWatcher.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/AllContainersRunningPodWatcher.java
@@ -9,6 +9,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import hudson.model.Queue;
 import hudson.model.TaskListener;
 import io.fabric8.kubernetes.api.model.ContainerStateWaiting;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
@@ -19,6 +20,7 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.KubernetesClientTimeoutException;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.utils.Serialization;
+import jenkins.model.Jenkins;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -65,8 +67,8 @@ public class AllContainersRunningPodWatcher implements Watcher<Pod> {
         }
     }
 
-    boolean areAllContainersRunning(Pod pod) {
-        return pod.getSpec().getContainers().size() == pod.getStatus().getContainerStatuses().size() && PodUtils.getContainerStatus(pod).stream().allMatch(ContainerStatus::getReady);
+    boolean areAllContainersRunning(Pod pod) throws InvalidPodTemplateException {
+        return pod.getSpec().getContainers().size() == pod.getStatus().getContainerStatuses().size() && PodUtils.getContainerStatus(pod, true).stream().allMatch(ContainerStatus::getReady);
     }
 
     @Override

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/InvalidPodTemplateException.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/InvalidPodTemplateException.java
@@ -1,0 +1,14 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+public class InvalidPodTemplateException extends RuntimeException {
+    String reason;
+
+    public InvalidPodTemplateException(String reason, String msg) {
+        super(msg);
+        this.reason = reason;
+    }
+
+    public String getReason() {
+        return this.reason;
+    }
+}

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
@@ -138,6 +138,17 @@ public class KubernetesLauncher extends JNLPLauncher {
                  Watch w2 = eventWatch(client, podName, namespace, runListener)) {
                 assert watcher != null; // assigned 3 lines above
                 watcher.await(template.getSlaveConnectTimeout(), TimeUnit.SECONDS);
+            } catch (InvalidPodTemplateException e) {
+                LOGGER.info("Caught invalid pod template exception");
+                switch (e.getReason()) {
+                    case "ImagePullBackOff":
+                        runListener.getLogger().printf(e.getMessage());
+                        PodUtils.cancelInvalidPodTemplateJob(pod, "ImagePullBackOff");
+                        break;
+                    default:
+                        LOGGER.warning("Unknown reason for InvalidPodTemplateException : " + e.getReason());
+                        break;
+                }
             }
             LOGGER.log(INFO, "Pod is running: {0}/{1}", new Object[] { namespace, podName });
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
@@ -1,6 +1,7 @@
 package org.csanchez.jenkins.plugins.kubernetes;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Optional;
@@ -18,7 +19,11 @@ import javax.annotation.Nonnull;
 import hudson.FilePath;
 import hudson.Util;
 import hudson.slaves.SlaveComputer;
+import hudson.util.StreamTaskListener;
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerStateWaiting;
+import io.fabric8.kubernetes.api.model.ContainerStatus;
+import io.fabric8.kubernetes.api.model.PodStatus;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.commons.lang.StringUtils;
@@ -325,6 +330,7 @@ public class KubernetesSlave extends AbstractCloudSlave {
 
         if (deletePod) {
             deleteSlavePod(listener, client);
+
         } else {
             // Log warning, as the slave pod may still be running
             LOGGER.log(Level.WARNING, "Slave pod {0} was not deleted due to retention policy {1}.",

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodUtils.java
@@ -16,17 +16,25 @@
 
 package org.csanchez.jenkins.plugins.kubernetes;
 
+import com.ctc.wstx.util.StringUtil;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.model.Queue;
+import hudson.model.TaskListener;
+import io.fabric8.kubernetes.api.model.ContainerStateWaiting;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodStatus;
+import jenkins.model.Jenkins;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 public final class PodUtils {
+    private static final Logger LOGGER = Logger.getLogger(PodUtils.class.getName());
+
 
     public static final Predicate<ContainerStatus> CONTAINER_IS_TERMINATED = cs -> cs.getState().getTerminated() != null;
     public static final Predicate<ContainerStatus> CONTAINER_IS_WAITING = cs -> cs.getState().getWaiting() != null;
@@ -41,14 +49,53 @@ public final class PodUtils {
     }
 
     public static List<ContainerStatus> getContainerStatus(Pod pod) {
+        return getContainerStatus(pod, false);
+    }
+
+    public static List<ContainerStatus> getContainerStatus(Pod pod, boolean checkForError) throws InvalidPodTemplateException {
         PodStatus podStatus = pod.getStatus();
         if (podStatus == null) {
             return Collections.emptyList();
         }
-        return podStatus.getContainerStatuses();
+        List<ContainerStatus> csList = podStatus.getContainerStatuses();
+        if (checkForError) {
+            checkContainersForInvalidPodTemplate(csList);
+        }
+        return csList;
     }
 
     public static List<ContainerStatus> getContainers(Pod pod, Predicate<ContainerStatus> predicate) {
         return getContainerStatus(pod).stream().filter(predicate).collect(Collectors.toList());
+    }
+
+    /* currently checks for ImagePullBackOff error */
+    public static void checkContainersForInvalidPodTemplate(List<ContainerStatus> containerStatusList) throws InvalidPodTemplateException {
+        for (ContainerStatus cs : containerStatusList) {
+            ContainerStateWaiting waiting = cs.getState().getWaiting();
+            if (waiting != null && "ImagePullBackOff".equals(waiting.getReason())) {
+                throw new InvalidPodTemplateException(waiting.getReason(), waiting.getMessage());
+            }
+        }
+    }
+
+    public static void cancelInvalidPodTemplateJob(Pod pod) {
+        cancelInvalidPodTemplateJob(pod, null);
+    }
+
+    public static void cancelInvalidPodTemplateJob(Pod pod, String reason) {
+        Queue q = Jenkins.get().getQueue();
+        String runUrl = pod.getMetadata().getAnnotations().get("runUrl");
+        for (Queue.Item item: q.getItems()) {
+            if (item.task.getUrl().equals(runUrl)) {
+                String cancelMsg = "Canceling queue item: " + item;
+                if (reason != null && !StringUtil.isAllWhitespace(reason)) {
+                    cancelMsg += " due to " + reason;
+                }
+                LOGGER.info(cancelMsg);
+                q.cancel(item);
+                break;
+            }
+        }
+        LOGGER.info("Failed to find corresponding queue item to cancel for pod: " + pod);
     }
 }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/retention/Reaper.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/retention/Reaper.java
@@ -63,7 +63,7 @@ import org.csanchez.jenkins.plugins.kubernetes.PodUtils;
  */
 @Extension
 public class Reaper extends ComputerListener implements Watcher<Pod> {
-    
+
     private static final Logger LOGGER = Logger.getLogger(Reaper.class.getName());
 
     /**
@@ -260,7 +260,7 @@ public class Reaper extends ComputerListener implements Watcher<Pod> {
         public void onEvent(@NonNull Action action, @NonNull KubernetesSlave node, @NonNull Pod pod) throws IOException, InterruptedException {
             List<ContainerStatus> backOffContainers = PodUtils.getContainers(pod, cs -> {
                 ContainerStateWaiting waiting = cs.getState().getWaiting();
-                return waiting != null && waiting.getMessage() != null && waiting.getMessage().contains("Back-off pulling image");
+                return waiting != null && waiting.getReason().equals("ImagePullBackOff") && waiting.getMessage() != null && waiting.getMessage().contains("Back-off pulling image");
             });
             if (backOffContainers.isEmpty()) {
                 return;


### PR DESCRIPTION
Revert responsibility to cancel jobs with invalid pod templates back to the `KubernetesLauncher.launch()` using thrown `InvalidPodTemplateException`

The migration of the responsibility to the `Reaper` fails because the corresponding `Queue.Item` needed to cancel the job is no longer in the `Queue` by the time the `Reaper` is made aware of the error. 

Further discussions and explanations found in the JIRA story. 