### PR TITLE
Prevent fragmentation of kube exec calls by bumping the container exec buffer size to 16 kb

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -93,7 +93,7 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
      * stdin buffer size for commands sent to Kubernetes exec api. A low value will cause slowness in commands executed.
      * A higher value will consume more memory
      */
-    private final static int STDIN_BUFFER_SIZE = Integer.getInteger(ContainerExecDecorator.class.getName() + ".stdinBufferSize", 16 * 1024);
+    private static final int STDIN_BUFFER_SIZE = Integer.getInteger(ContainerExecDecorator.class.getName() + ".stdinBufferSize", 16 * 1024);
 
     @SuppressFBWarnings(value = "SE_TRANSIENT_FIELD_NOT_RESTORED", justification = "not needed on deserialization")
     private transient List<Closeable> closables;

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -93,7 +93,7 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
      * stdin buffer size for commands sent to Kubernetes exec api. A low value will cause slowness in commands executed.
      * A higher value will consume more memory
      */
-    public static int STDIN_BUFFER_SIZE = Integer.getInteger(ContainerExecDecorator.class.getName() + ".stdinBufferSize", 16 * 1024);
+    private final static int STDIN_BUFFER_SIZE = Integer.getInteger(ContainerExecDecorator.class.getName() + ".stdinBufferSize", 16 * 1024);
 
     @SuppressFBWarnings(value = "SE_TRANSIENT_FIELD_NOT_RESTORED", justification = "not needed on deserialization")
     private transient List<Closeable> closables;

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -93,8 +93,7 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
      * stdin buffer size for commands sent to Kubernetes exec api. A low value will cause slowness in commands executed.
      * A higher value will consume more memory
      */
-    private static final int STDIN_BUFFER_SIZE = Integer
-            .getInteger(ContainerExecDecorator.class.getName() + ".stdinBufferSize", 2 * 1024);
+    public static int STDIN_BUFFER_SIZE = Integer.getInteger(ContainerExecDecorator.class.getName() + ".stdinBufferSize", 16 * 1024);
 
     @SuppressFBWarnings(value = "SE_TRANSIENT_FIELD_NOT_RESTORED", justification = "not needed on deserialization")
     private transient List<Closeable> closables;
@@ -612,6 +611,7 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
     }
 
     private static void doExec(PrintStream in, PrintStream out, boolean[] masks, String... statements) {
+        long start = System.nanoTime();
         // For logging
         ByteArrayOutputStream loggingOutput = new ByteArrayOutputStream();
         // Tee both outputs
@@ -632,7 +632,7 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
                    .append("\" ");
             }
             tee.println();
-            LOGGER.log(Level.FINEST, loggingOutput.toString(encoding));
+            LOGGER.log(Level.FINEST, loggingOutput.toString(encoding) + "[" + TimeUnit.NANOSECONDS.toMicros(System.nanoTime() - start) + " μs." + "]");
             // We need to exit so that we know when the command has finished.
             tee.println(EXIT);
             tee.flush();


### PR DESCRIPTION
The rationale is that the typical command will be wrapped in a script
before being sent to the exec api

This typical command looks like this

```
nohup sh -c ({ while [ -d
'/home/jenkins/agent/workspace/container-time@tmp/durable-3ac42cdf' -a !
-f
'/home/jenkins/agent/workspace/container-time@tmp/durable-3ac42cdf/jenkins-result.txt'
]; do touch
'/home/jenkins/agent/workspace/container-time@tmp/durable-3ac42cdf/jenkins-log.txt';
sleep 3; done } & jsc=durable-cd155196dc95897e8d1241f162c2ceac;
JENKINS_SERVER_COOKIE=$jsc 'sh' -xe
'/home/jenkins/agent/workspace/container-time@tmp/durable-3ac42cdf/script.sh'
>
'/home/jenkins/agent/workspace/container-time@tmp/durable-3ac42cdf/jenkins-log.txt'
2>&1; echo $? >
'/home/jenkins/agent/workspace/container-time@tmp/durable-3ac42cdf/jenkins-result.txt.tmp';
mv
'/home/jenkins/agent/workspace/container-time@tmp/durable-3ac42cdf/jenkins-result.txt.tmp'
'/home/jenkins/agent/workspace/container-time@tmp/durable-3ac42cdf/jenkins-result.txt';
wait) >&- 2>&- &
```

Its length depends on the Jenkins agent path as well as the path to
reach the workspace, but in the example above (standard path, rather
short job name) it is already about 6800 bits long, which should fit in
a 8kb packet. Doubling that amount to be pretty sure that in 99.999%
cases we're not fragmenting commands.