### PR TITLE
Fix DinD Example

### DIFF
--- a/examples/dind.groovy
+++ b/examples/dind.groovy
@@ -29,9 +29,9 @@ spec:
         value: ""
 ''') {
     node(POD_LABEL) {
-        git 'https://github.com/jenkinsci/docker-jnlp-slave.git'
+        writeFile encoding: 'UTF-8', file: 'Dockerfile', text: 'FROM scratch'
         container('docker') {
-            sh 'docker version && DOCKER_BUILDKIT=1 docker build --progress plain -t testing -f 11/alpine/Dockerfile .'
+            sh 'docker version && DOCKER_BUILDKIT=1 docker build --progress plain -t testing .'
         }
     }
 }

--- a/examples/dind.groovy
+++ b/examples/dind.groovy
@@ -31,7 +31,7 @@ spec:
     node(POD_LABEL) {
         git 'https://github.com/jenkinsci/docker-jnlp-slave.git'
         container('docker') {
-            sh 'docker version && DOCKER_BUILDKIT=1 docker build --progress plain -t testing .'
+            sh 'docker version && DOCKER_BUILDKIT=1 docker build --progress plain -t testing -f 11/alpine/Dockerfile .'
         }
     }
 }


### PR DESCRIPTION
Since there is no `Dockerfile` in the root of https://github.com/jenkinsci/docker-jnlp-slave.git, we need to point to one to build.