### PR TITLE
Update DinD Example

### DIFF
--- a/examples/dind.groovy
+++ b/examples/dind.groovy
@@ -10,6 +10,9 @@ podTemplate(yaml: '''
 apiVersion: v1
 kind: Pod
 spec:
+  volumes:
+  - name: docker-socket
+    emptyDir: {}
   containers:
   - name: docker
     image: docker:19.03.1
@@ -17,16 +20,16 @@ spec:
     - sleep
     args:
     - 99d
-    env:
-      - name: DOCKER_HOST
-        value: tcp://localhost:2375
+    volumeMounts:
+    - name: docker-socket
+      mountPath: /var/run
   - name: docker-daemon
     image: docker:19.03.1-dind
     securityContext:
       privileged: true
-    env:
-      - name: DOCKER_TLS_CERTDIR
-        value: ""
+    volumeMounts:
+    - name: docker-socket
+      mountPath: /var/run
 ''') {
     node(POD_LABEL) {
         writeFile encoding: 'UTF-8', file: 'Dockerfile', text: 'FROM scratch'

--- a/examples/dind.groovy
+++ b/examples/dind.groovy
@@ -32,7 +32,7 @@ spec:
       mountPath: /var/run
 ''') {
     node(POD_LABEL) {
-        writeFile encoding: 'UTF-8', file: 'Dockerfile', text: 'FROM scratch'
+        writeFile file: 'Dockerfile', text: 'FROM scratch'
         container('docker') {
             sh 'docker version && DOCKER_BUILDKIT=1 docker build --progress plain -t testing .'
         }

--- a/examples/dind.groovy
+++ b/examples/dind.groovy
@@ -29,9 +29,9 @@ spec:
         value: ""
 ''') {
     node(POD_LABEL) {
-        git 'https://github.com/jenkinsci/docker-jnlp-slave.git'
+        writeFile encoding: 'UTF-8', file: 'Dockerfile', text: 'FROM scratch'
         container('docker') {
-            sh 'docker version && DOCKER_BUILDKIT=1 docker build --progress plain -t testing -f 11/alpine/Dockerfile .'
+            sh 'docker version && DOCKER_BUILDKIT=1 docker build --progress plain -t testing .'
         }
     }
 }

--- a/examples/dind.groovy
+++ b/examples/dind.groovy
@@ -31,7 +31,7 @@ spec:
     node(POD_LABEL) {
         git 'https://github.com/jenkinsci/docker-jnlp-slave.git'
         container('docker') {
-            sh 'docker version && DOCKER_BUILDKIT=1 docker build --progress plain -t testing .'
+            sh 'docker version && DOCKER_BUILDKIT=1 docker build --progress plain -t testing -f 11/alpine/Dockerfile .'
         }
     }
 }


### PR DESCRIPTION
Supersedes https://github.com/jenkinsci/kubernetes-plugin/pull/829.

As per the comments in https://github.com/jenkinsci/kubernetes-plugin/pull/581#issuecomment-683481580, the environment variable which allows containers to connect over TCP will not work without TLS in future versions of docker.

So the example has been updated to use `/var/run`(/docker.sock) instead of TCP.

Note: `/var/run` is used instead of `/var/run/docker.sock` because `docker.sock` is a file and `emptyDir` is a directory, so if `/docker.sock` is used, the daemon fails to start with an error:
> failed to load listeners: can't create unix socket /var/run/docker.sock: is a directory