### PR TITLE
Fix incorrect permission checks in KubernetesComputer views

### DIFF
--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesComputer/container.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesComputer/container.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <l:layout title="${it.displayName} log" secured="true">
+  <l:layout title="${it.displayName} log" permission="${app.ADMINISTER}">
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
       <pre id="out" />

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesComputer/events.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesComputer/events.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <l:layout title="${it.displayName} log" secured="true">
+  <l:layout title="${it.displayName} log" permission="${app.ADMINISTER}">
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
       <table class="sortable pane bigtable">

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesComputer/podLog.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesComputer/podLog.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <l:layout title="${it.displayName} log" secured="true">
+  <l:layout title="${it.displayName} log" permission="${app.ADMINISTER}">
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
       <table class="sortable pane bigtable">

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesComputer/sidepanel2.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesComputer/sidepanel2.jelly
@@ -24,9 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
-  <l:isAdmin>
-  <l:task icon="icon-clipboard icon-md" href="${rootURL}/${it.url}log" title="${%Log}" permission="${it.CONNECT}" />
-  <l:task icon="icon-computer icon-md" href="${rootURL}/${it.url}podLog" title="${%PodLog}"/>
-  <l:task icon="icon-computer icon-md" href="${rootURL}/${it.url}events" title="${%Events}"/>
-  </l:isAdmin>
+  <l:task icon="icon-clipboard icon-md" href="${rootURL}/${it.url}log" title="${%Log}" permission="${app.ADMINISTER}"/>
+  <l:task icon="icon-computer icon-md" href="${rootURL}/${it.url}podLog" title="${%Pod Log}" permission="${app.ADMINISTER}"/>
+  <l:task icon="icon-computer icon-md" href="${rootURL}/${it.url}events" title="${%Events}" permission="${app.ADMINISTER}"/>
 </j:jelly>


### PR DESCRIPTION
#367 added views for `KubernetesComputer`. The backends methods need administer role however the views are not protected. They don't display stacktraces since #430 however, the links shouldn't even be there.

Noting #657 is proposing to require `EXTENDED_READ` only. Will likely be affected by this PR.