### PR TITLE
Handle compatibility with 2.238 introducing Agent/ExtendedRead

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
@@ -229,6 +229,7 @@ public class PodTemplateStepExecution extends AbstractStepExecutionImpl {
             KubernetesCloud cloud = resolveCloud();
             TaskListener listener = getContext().get(TaskListener.class);
             newTemplate.setListener(listener);
+            LOGGER.log(Level.FINE, "Injecting template after resume: " + newTemplate);
             cloud.addDynamicTemplate(newTemplate);
         } catch (AbortException e) {
             throw new RuntimeException(e.getMessage(), e.getCause());

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
@@ -46,6 +46,7 @@ import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import hudson.model.Label;
 import hudson.model.Run;
 import hudson.slaves.SlaveComputer;
+import hudson.util.VersionNumber;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.client.KubernetesClientException;
@@ -494,7 +495,11 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
 
         HtmlPage nodeIndex = wc.getPage(node);
         assertNotXPath(nodeIndex, "//*[text() = 'configure']");
-        wc.assertFails(node.toComputer().getUrl()+"configure", 403);
+        if (Jenkins.get().getVersion().isNewerThanOrEqualTo(new VersionNumber("2.238"))) {
+            r.assertXPath(nodeIndex, "//*[text() = 'View Configuration']");
+        } else {
+            wc.assertFails(node.toComputer().getUrl()+"configure", 403);
+        }
         SemaphoreStep.success("pod/1", null);
     }
 


### PR DESCRIPTION
https://www.jenkins.io/changelog/#v2.238
 Add `Agent/ExtendedRead` support for viewing agent configuration, system
 information, and logs. ([issue 61206](https://issues.jenkins-ci.org/browse/JENKINS-61206))