### PR TITLE
[JENKINS-63705] [JENKINS-59959] Remove broken calculation related to concurrency limits

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -611,7 +611,7 @@ public class KubernetesCloud extends Cloud {
         // check template-level concurrency limit using template-level labels
         Map<String, String> templateLabels = new HashMap<>(podLabels);
         templateLabels.putAll(template.getLabelsMap());
-        numRunningOrPending = getNumActiveSlavePods(client, templateNamespace, podLabels);
+        numRunningOrPending = getNumActiveSlavePods(client, templateNamespace, templateLabels);
         if (numRunningOrPending + numProvisioned >= template.getInstanceCap()) {
             LOGGER.log(Level.INFO,
                     "Maximum number of concurrently running agent pods ({0}) reached for template {1} in Kubernetes Cloud {6}, " +

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -550,7 +550,7 @@ public class KubernetesCloud extends Cloud {
                 LOGGER.log(Level.INFO, "Template for label {0}: {1}", new Object[] { label, podTemplate.getName() });
                 for (int i = 0; i < toBeProvisioned; i++) {
                     // Check concurrency limits
-                    if (!addProvisionedSlave(podTemplate, label, i + allInProvisioning.size())) {
+                    if (!addProvisionedSlave(podTemplate, label, i)) {
                         break;
                     }
                     plannedNodes.add(PlannedNodeBuilderFactory.createInstance().cloud(this).template(podTemplate).label(label).build());


### PR DESCRIPTION
Reverts a small but important part of https://github.com/jenkinsci/kubernetes-plugin/pull/824. As per the description in [JENKINS-63075](https://issues.jenkins-ci.org/browse/JENKINS-63705), when multiple pod templates exist, each with their own concurrency limit, sometimes one pod template will outright fail to provision, even if it's well under its concurrency limit.

@sonykus highlighted the root cause in https://github.com/jenkinsci/kubernetes-plugin/pull/824#commitcomment-42436096:

> It seems to somehow take into account the number of all running agents. Instead, it should count the agents running within the scope of this templateNamespace only.

This PR reverts the logic which takes the number of all running agents (`allInProvisioning.size()`) into account. @Vlatombe's changes in https://github.com/jenkinsci/jenkins/pull/4922 as well as its downstream PR for this plugin should offer what's needed to fix the original issue, [JENKINS-59959](https://issues.jenkins-ci.org/browse/JENKINS-59959), for good.

cc @jglick