### PR TITLE
Poll for template availability for a few seconds once the pipeline is ready to run

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
@@ -87,11 +87,17 @@ public class KubernetesSlave extends AbstractCloudSlave {
     @Nonnull
     public PodTemplate getTemplate() {
         // Look up updated pod template after a restart
+        PodTemplate template = getTemplateOrNull();
+        if (template == null) {
+            throw new IllegalStateException("Not expecting pod template to be null at this point");
+        }
+        return template;
+    }
+
+    @CheckForNull
+    public PodTemplate getTemplateOrNull() {
         if (template == null) {
             template = getKubernetesCloud().getTemplateById(podTemplateId);
-            if (template == null) {
-                throw new IllegalStateException("Not expecting pod template to be null at this point");
-            }
         }
         return template;
     }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/RestartPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/RestartPipelineTest.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -276,7 +277,7 @@ public class RestartPipelineTest {
             assertTrue("Kubernetes node should be present after restart", first.isPresent());
             KubernetesSlave node = (KubernetesSlave) first.get();
             r.waitForMessage("Ready to run", b);
-            node.getTemplate().getListener().getLogger().println("This got printed");
+            waitForTemplate(node, 5, TimeUnit.SECONDS).getListener().getLogger().println("This got printed");
             r.waitForMessage("This got printed", b);
             b.getExecutor().interrupt();
             r.assertBuildStatus(Result.ABORTED, r.waitForCompletion(b));
@@ -299,11 +300,19 @@ public class RestartPipelineTest {
             assertTrue("Kubernetes node should be present after restart", first.isPresent());
             KubernetesSlave node = (KubernetesSlave) first.get();
             r.waitForMessage("Ready to run", b);
-            node.getTemplate().getListener().getLogger().println("This got printed");
+            waitForTemplate(node, 5, TimeUnit.SECONDS).getListener().getLogger().println("This got printed");
             r.waitForMessage("This got printed", b);
             b.getExecutor().interrupt();
             r.assertBuildStatus(Result.ABORTED, r.waitForCompletion(b));
         });
+    }
+
+    private PodTemplate waitForTemplate(KubernetesSlave node, int timeout, TimeUnit timeoutUnit) throws InterruptedException {
+        long beginning = System.nanoTime();
+        while (node.getTemplateOrNull() == null && TimeUnit.NANOSECONDS.convert(System.nanoTime() - beginning, timeoutUnit) < timeout) {
+            Thread.sleep(100L);
+        }
+        return node.getTemplate();
     }
 
     @Test


### PR DESCRIPTION
Should fix the flakiness observed [here](https://ci.jenkins.io/blue/organizations/jenkins/Plugins%2Fkubernetes-plugin/detail/PR-839/6/tests) and [there](https://ci.jenkins.io/blue/organizations/jenkins/Plugins%2Fkubernetes-plugin/detail/PR-844/2/tests).