### PR TITLE
Ignore `KubernetesPipelineTest#computerCantBeConfigured`

### DIFF
--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
@@ -481,6 +481,7 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
     }
 
     @Test
+    @Ignore
     public void computerCantBeConfigured() throws Exception {
         r.jenkins.setSecurityRealm(r.createDummySecurityRealm());
         r.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy().
@@ -490,8 +491,9 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
         assertTrue(optionalNode.isPresent());
         KubernetesSlave node = optionalNode.get();
 
-        JenkinsRule.WebClient wc = r.createWebClient().login("admin");
+        JenkinsRule.WebClient wc = r.createWebClient();
         wc.getOptions().setPrintContentOnFailingStatusCode(false);
+        wc.login("admin");
 
         HtmlPage nodeIndex = wc.getPage(node);
         assertNotXPath(nodeIndex, "//*[text() = 'configure']");


### PR DESCRIPTION
This test is flaky due to random HtmlUnit NPEs which I couldn't find a fix for.

```
java.lang.RuntimeException: Could not retrieve XPath >//input[lower-case(@type)='radio' and @name='tab-group-1600698390637']< on HtmlPage(http://localhost:30656/jenkins/)@1301124704
	at com.gargoylesoftware.htmlunit.html.xpath.XPathHelper.getByXPath(XPathHelper.java:93)
	at com.gargoylesoftware.htmlunit.html.DomNode.getByXPath(DomNode.java:1613)
	at com.gargoylesoftware.htmlunit.html.HtmlRadioButtonInput.setCheckedForPage(HtmlRadioButtonInput.java:183)
	at com.gargoylesoftware.htmlunit.html.HtmlRadioButtonInput.setChecked(HtmlRadioButtonInput.java:139)
	at com.gargoylesoftware.htmlunit.html.HtmlRadioButtonInput.onAddedToPage(HtmlRadioButtonInput.java:292)
	at com.gargoylesoftware.htmlunit.html.HtmlPage.notifyNodeAdded(HtmlPage.java:1767)
	at com.gargoylesoftware.htmlunit.html.DomNode.fireAddition(DomNode.java:1089)
	at com.gargoylesoftware.htmlunit.html.DomNode.appendChild(DomNode.java:983)
	at com.gargoylesoftware.htmlunit.html.parser.neko.HtmlUnitNekoDOMBuilder.addNodeToRightParent(HtmlUnitNekoDOMBuilder.java:478)
	at com.gargoylesoftware.htmlunit.html.parser.neko.HtmlUnitNekoDOMBuilder.startElement(HtmlUnitNekoDOMBuilder.java:362)
	at org.apache.xerces.parsers.AbstractSAXParser.startElement(Unknown Source)
	at com.gargoylesoftware.htmlunit.html.parser.neko.HtmlUnitNekoDOMBuilder.startElement(HtmlUnitNekoDOMBuilder.java:287)
	at org.apache.xerces.parsers.AbstractXMLDocumentParser.emptyElement(Unknown Source)
	at net.sourceforge.htmlunit.cyberneko.HTMLTagBalancer.startElement(HTMLTagBalancer.java:779)
	at net.sourceforge.htmlunit.cyberneko.filters.DefaultFilter.startElement(DefaultFilter.java:140)
	at net.sourceforge.htmlunit.cyberneko.filters.NamespaceBinder.startElement(NamespaceBinder.java:278)
	at net.sourceforge.htmlunit.cyberneko.HTMLScanner$ContentScanner.scanStartElement(HTMLScanner.java:2811)
	at net.sourceforge.htmlunit.cyberneko.HTMLScanner$ContentScanner.scan(HTMLScanner.java:2131)
	at net.sourceforge.htmlunit.cyberneko.HTMLScanner.scanDocument(HTMLScanner.java:937)
	at net.sourceforge.htmlunit.cyberneko.HTMLConfiguration.parse(HTMLConfiguration.java:443)
	at net.sourceforge.htmlunit.cyberneko.HTMLConfiguration.parse(HTMLConfiguration.java:394)
	at org.apache.xerces.parsers.XMLParser.parse(Unknown Source)
	at com.gargoylesoftware.htmlunit.html.parser.neko.HtmlUnitNekoDOMBuilder.parse(HtmlUnitNekoDOMBuilder.java:760)
	at com.gargoylesoftware.htmlunit.html.parser.neko.HtmlUnitNekoHtmlParser.parse(HtmlUnitNekoHtmlParser.java:236)
	at com.gargoylesoftware.htmlunit.html.parser.neko.HtmlUnitNekoHtmlParser.parseHtml(HtmlUnitNekoHtmlParser.java:179)
	at com.gargoylesoftware.htmlunit.DefaultPageCreator.createHtmlPage(DefaultPageCreator.java:280)
	at com.gargoylesoftware.htmlunit.DefaultPageCreator.createPage(DefaultPageCreator.java:163)
	at org.jvnet.hudson.test.HudsonPageCreator.createPage(HudsonPageCreator.java:54)
	at com.gargoylesoftware.htmlunit.WebClient.loadWebResponseInto(WebClient.java:638)
	at com.gargoylesoftware.htmlunit.WebClient.loadDownloadedResponses(WebClient.java:2440)
	at com.gargoylesoftware.htmlunit.html.HtmlFormUtil.submit(HtmlFormUtil.java:82)
	at org.jvnet.hudson.test.JenkinsRule$WebClient.login(JenkinsRule.java:2403)
	at org.jvnet.hudson.test.JenkinsRule$WebClient.login(JenkinsRule.java:2270)
	at org.jvnet.hudson.test.JenkinsRule$WebClient.login(JenkinsRule.java:2415)
	at org.csanchez.jenkins.plugins.kubernetes.pipeline.KubernetesPipelineTest.computerCantBeConfigured(KubernetesPipelineTest.java:493)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:54)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:54)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:54)
	at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:61)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:599)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:288)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:282)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.lang.Thread.run(Thread.java:748)
Caused by: javax.xml.transform.TransformerException: Unknown error in XPath.
	at com.gargoylesoftware.htmlunit.html.xpath.XPathAdapter.execute(XPathAdapter.java:182)
	at com.gargoylesoftware.htmlunit.html.xpath.XPathHelper.evaluateXPath(XPathHelper.java:137)
	at com.gargoylesoftware.htmlunit.html.xpath.XPathHelper.getByXPath(XPathHelper.java:71)
	... 53 more
Caused by: java.lang.NullPointerException
	at org.apache.xml.dtm.ref.dom2dtm.DOM2DTM.nextNode(DOM2DTM.java:390)
	at org.apache.xml.dtm.ref.DTMDefaultBase._nextsib(DTMDefaultBase.java:565)
	at org.apache.xml.dtm.ref.DTMDefaultBase.getNextSibling(DTMDefaultBase.java:1142)
	at org.apache.xml.dtm.ref.DTMDefaultBaseTraversers$ChildTraverser.next(DTMDefaultBaseTraversers.java:463)
	at org.apache.xpath.axes.AxesWalker.getNextNode(AxesWalker.java:335)
	at org.apache.xpath.axes.AxesWalker.nextNode(AxesWalker.java:363)
	at org.apache.xpath.axes.WalkingIterator.nextNode(WalkingIterator.java:195)
	at org.apache.xpath.axes.NodeSequence.nextNode(NodeSequence.java:335)
	at org.apache.xpath.axes.NodeSequence.runTo(NodeSequence.java:494)
	at org.apache.xpath.axes.NodeSequence.setRoot(NodeSequence.java:270)
	at org.apache.xpath.axes.LocPathIterator.execute(LocPathIterator.java:212)
	at com.gargoylesoftware.htmlunit.html.xpath.XPathAdapter.execute(XPathAdapter.java:161)
	... 55 more
```