### PR TITLE
Specify jnlp container limits through system properties

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -266,18 +266,18 @@ public class PodTemplateBuilder {
         jnlp.setEnv(new ArrayList<>(envVars.values()));
         if (jnlp.getResources() == null) {
 
-            containerBuilder = new ContainerBuilder();
-            containerBuilder.editOrNewResources().addToRequests("cpu", new Quantity(DEFAULT_JNLP_CONTAINER_CPU_REQUEST)).addToRequests("memory", new Quantity(DEFAULT_JNLP_CONTAINER_MEMORY_REQUEST));
+            ContainerBuilder containerBuilder = new ContainerBuilder();
+            containerBuilder.editOrNewResources().addToRequests("cpu", new Quantity(DEFAULT_JNLP_CONTAINER_CPU_REQUEST)).addToRequests("memory", new Quantity(DEFAULT_JNLP_CONTAINER_MEMORY_REQUEST)).endResources();
 
             if (DEFAULT_JNLP_CONTAINER_CPU_LIMIT!=null) {
-                containerBuilder.editOrNewResources().addToLimits("cpu", new Quantity(DEFAULT_JNLP_CONTAINER_CPU_LIMIT));
+                containerBuilder.editOrNewResources().addToLimits("cpu", new Quantity(DEFAULT_JNLP_CONTAINER_CPU_LIMIT)).endResources();
             }
 
             if (DEFAULT_JNLP_CONTAINER_MEMORY_LIMIT!=null) {
-                containerBuilder.editOrNewResources().addToLimits("memory", new Quantity(DEFAULT_JNLP_CONTAINER_MEMORY_LIMIT))
+                containerBuilder.editOrNewResources().addToLimits("memory", new Quantity(DEFAULT_JNLP_CONTAINER_MEMORY_LIMIT)).endResources();
             }
 
-            jnlp.setResources(containerBuilder.endResources().build().getResources());
+            jnlp.setResources(containerBuilder.build().getResources());
 
         }
         

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -271,11 +271,11 @@ public class PodTemplateBuilder {
 
             if (DEFAULT_JNLP_CONTAINER_CPU_LIMIT!=null) {
                 containerBuilder.editOrNewResources().addToLimits("cpu", new Quantity(DEFAULT_JNLP_CONTAINER_CPU_LIMIT));
-            };
+            }
 
             if (DEFAULT_JNLP_CONTAINER_MEMORY_LIMIT!=null) {
                 containerBuilder.editOrNewResources().addToLimits("memory", new Quantity(DEFAULT_JNLP_CONTAINER_MEMORY_LIMIT))
-            };
+            }
 
             jnlp.setResources(containerBuilder.endResources().build().getResources());
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -260,7 +260,7 @@ public class PodTemplateBuilder {
         envVars.putAll(jnlp.getEnv().stream().collect(Collectors.toMap(EnvVar::getName, Function.identity())));
         jnlp.setEnv(new ArrayList<>(envVars.values()));
         if (jnlp.getResources() == null) {
-            jnlp.setResources(new ContainerBuilder().editOrNewResources().addToRequests("cpu", new Quantity(DEFAULT_JNLP_CONTAINER_CPU_REQUEST)).addToRequests("memory", new Quantity(DEFAULT_JNLP_CONTAINER_MEMORY_REQUEST)).endResources().build().getResources());
+            jnlp.setResources(new ContainerBuilder().editOrNewResources().addToRequests("cpu", new Quantity(DEFAULT_JNLP_CONTAINER_CPU_REQUEST)).addToRequests("memory", new Quantity(DEFAULT_JNLP_CONTAINER_MEMORY_REQUEST)).addToLimits("cpu", new Quantity(DEFAULT_JNLP_CONTAINER_CPU_REQUEST)).addToLimits("memory", new Quantity(DEFAULT_JNLP_CONTAINER_MEMORY_REQUEST)).endResources().build().getResources());
         }
         
         // If the volume mounts of any container has been set to null, set it to empty list.

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -68,6 +68,8 @@ import io.fabric8.kubernetes.api.model.PodFluent.SpecNested;
 import io.fabric8.kubernetes.api.model.Probe;
 import io.fabric8.kubernetes.api.model.ProbeBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeBuilder;
 import io.fabric8.kubernetes.api.model.VolumeMount;
@@ -105,9 +107,9 @@ public class PodTemplateBuilder {
             .getProperty(PodTemplateStepExecution.class.getName() + ".defaultContainer.defaultCpuRequest", "100m");
 
     static final String DEFAULT_JNLP_CONTAINER_MEMORY_LIMIT = System
-            .getProperty(PodTemplateStepExecution.class.getName() + ".defaultContainer.defaultMemoryLimit", null);
+            .getProperty(PodTemplateStepExecution.class.getName() + ".defaultContainer.defaultMemoryLimit");
     static final String DEFAULT_JNLP_CONTAINER_CPU_LIMIT = System
-            .getProperty(PodTemplateStepExecution.class.getName() + ".defaultContainer.defaultCpuLimit", null);
+            .getProperty(PodTemplateStepExecution.class.getName() + ".defaultContainer.defaultCpuLimit");
 
     private static final String JNLPMAC_REF = "\\$\\{computer.jnlpmac\\}";
     private static final String NAME_REF = "\\$\\{computer.name\\}";
@@ -268,7 +270,12 @@ public class PodTemplateBuilder {
         if (jnlp.getResources() == null) {
 
             ResourcesNested<ContainerBuilder> containerBuilder = new ContainerBuilder().withNewResources();
-            containerBuilder.addToRequests("cpu", new Quantity(DEFAULT_JNLP_CONTAINER_CPU_REQUEST)).addToRequests("memory", new Quantity(DEFAULT_JNLP_CONTAINER_MEMORY_REQUEST));
+            Map<String, Quantity> reqMap = new HashMap<>();
+            Map<String, Quantity> limMap = new HashMap<>();
+            reqMap.put("cpu", new Quantity(DEFAULT_JNLP_CONTAINER_CPU_REQUEST));
+            reqMap.put("memory", new Quantity(DEFAULT_JNLP_CONTAINER_MEMORY_REQUEST));
+
+            
 
             if (DEFAULT_JNLP_CONTAINER_CPU_LIMIT!=null) {
                 containerBuilder.addToLimits("cpu", new Quantity(DEFAULT_JNLP_CONTAINER_CPU_LIMIT));
@@ -278,7 +285,12 @@ public class PodTemplateBuilder {
                 containerBuilder.addToLimits("memory", new Quantity(DEFAULT_JNLP_CONTAINER_MEMORY_LIMIT));
             }
 
-            jnlp.setResources(containerBuilder.endResources().build().getResources());
+            ResourceRequirements reqs = new ResourceRequirementsBuilder()
+                        .withRequests(reqMap)
+                        .withLimits(limMap)
+                        .build();
+
+            jnlp.setResources(reqs);
 
         }
         

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -266,18 +266,18 @@ public class PodTemplateBuilder {
         jnlp.setEnv(new ArrayList<>(envVars.values()));
         if (jnlp.getResources() == null) {
 
-            ContainerBuilder containerBuilder = new ContainerBuilder();
-            containerBuilder.editOrNewResources().addToRequests("cpu", new Quantity(DEFAULT_JNLP_CONTAINER_CPU_REQUEST)).addToRequests("memory", new Quantity(DEFAULT_JNLP_CONTAINER_MEMORY_REQUEST)).endResources();
+            ResourcesNested<ContainerBuilder> containerResources = new ContainerBuilder().editOrNewResources();
+            containerResources.addToRequests("cpu", new Quantity(DEFAULT_JNLP_CONTAINER_CPU_REQUEST)).addToRequests("memory", new Quantity(DEFAULT_JNLP_CONTAINER_MEMORY_REQUEST));
 
             if (DEFAULT_JNLP_CONTAINER_CPU_LIMIT!=null) {
-                containerBuilder.editOrNewResources().addToLimits("cpu", new Quantity(DEFAULT_JNLP_CONTAINER_CPU_LIMIT)).endResources();
+                containerResources.addToLimits("cpu", new Quantity(DEFAULT_JNLP_CONTAINER_CPU_LIMIT));
             }
 
             if (DEFAULT_JNLP_CONTAINER_MEMORY_LIMIT!=null) {
-                containerBuilder.editOrNewResources().addToLimits("memory", new Quantity(DEFAULT_JNLP_CONTAINER_MEMORY_LIMIT)).endResources();
+                containerResources.addToLimits("memory", new Quantity(DEFAULT_JNLP_CONTAINER_MEMORY_LIMIT));
             }
 
-            jnlp.setResources(containerBuilder.build().getResources());
+            jnlp.setResources(containerResources.endResources().build().getResources());
 
         }
         

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -103,6 +103,11 @@ public class PodTemplateBuilder {
     static final String DEFAULT_JNLP_CONTAINER_CPU_REQUEST = System
             .getProperty(PodTemplateStepExecution.class.getName() + ".defaultContainer.defaultCpuRequest", "100m");
 
+    static final String DEFAULT_JNLP_CONTAINER_MEMORY_LIMIT = System
+            .getProperty(PodTemplateStepExecution.class.getName() + ".defaultContainer.defaultMemoryRequest", null);
+    static final String DEFAULT_JNLP_CONTAINER_CPU_LIMIT = System
+            .getProperty(PodTemplateStepExecution.class.getName() + ".defaultContainer.defaultCpuRequest", null);
+
     private static final String JNLPMAC_REF = "\\$\\{computer.jnlpmac\\}";
     private static final String NAME_REF = "\\$\\{computer.name\\}";
 
@@ -260,7 +265,15 @@ public class PodTemplateBuilder {
         envVars.putAll(jnlp.getEnv().stream().collect(Collectors.toMap(EnvVar::getName, Function.identity())));
         jnlp.setEnv(new ArrayList<>(envVars.values()));
         if (jnlp.getResources() == null) {
-            jnlp.setResources(new ContainerBuilder().editOrNewResources().addToRequests("cpu", new Quantity(DEFAULT_JNLP_CONTAINER_CPU_REQUEST)).addToRequests("memory", new Quantity(DEFAULT_JNLP_CONTAINER_MEMORY_REQUEST)).addToLimits("cpu", new Quantity(DEFAULT_JNLP_CONTAINER_CPU_REQUEST)).addToLimits("memory", new Quantity(DEFAULT_JNLP_CONTAINER_MEMORY_REQUEST)).endResources().build().getResources());
+            jnlp.setResources(new ContainerBuilder().editOrNewResources().addToRequests("cpu", new Quantity(DEFAULT_JNLP_CONTAINER_CPU_REQUEST)).addToRequests("memory", new Quantity(DEFAULT_JNLP_CONTAINER_MEMORY_REQUEST)).endResources().build().getResources());
+
+            if (DEFAULT_JNLP_CONTAINER_CPU_LIMIT!=null) {
+                jnlp.setResources(new ContainerBuilder().editOrNewResources().addToLimits("cpu", new Quantity(DEFAULT_JNLP_CONTAINER_CPU_LIMIT)).endResources().build().getResources());
+            }
+
+            if (DEFAULT_JNLP_CONTAINER_MEMORY_LIMIT!=null) {
+                jnlp.setResources(new ContainerBuilder().editOrNewResources().addToLimits("memory", new Quantity(DEFAULT_JNLP_CONTAINER_MEMORY_LIMIT)).endResources().build().getResources());
+            }
         }
         
         // If the volume mounts of any container has been set to null, set it to empty list.

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -266,18 +266,18 @@ public class PodTemplateBuilder {
         jnlp.setEnv(new ArrayList<>(envVars.values()));
         if (jnlp.getResources() == null) {
 
-            ResourcesNested<ContainerBuilder> containerResources = new ContainerBuilder().editOrNewResources();
-            containerResources.addToRequests("cpu", new Quantity(DEFAULT_JNLP_CONTAINER_CPU_REQUEST)).addToRequests("memory", new Quantity(DEFAULT_JNLP_CONTAINER_MEMORY_REQUEST));
+            ContainerBuilder containerBuilder = new ContainerBuilder();
+            containerBuilder.editOrNewResources().addToRequests("cpu", new Quantity(DEFAULT_JNLP_CONTAINER_CPU_REQUEST)).addToRequests("memory", new Quantity(DEFAULT_JNLP_CONTAINER_MEMORY_REQUEST)).endResources();
 
             if (DEFAULT_JNLP_CONTAINER_CPU_LIMIT!=null) {
-                containerResources.addToLimits("cpu", new Quantity(DEFAULT_JNLP_CONTAINER_CPU_LIMIT));
+                containerBuilder.editOrNewResources().addToLimits("cpu", new Quantity(DEFAULT_JNLP_CONTAINER_CPU_LIMIT)).endResources();
             }
 
             if (DEFAULT_JNLP_CONTAINER_MEMORY_LIMIT!=null) {
-                containerResources.addToLimits("memory", new Quantity(DEFAULT_JNLP_CONTAINER_MEMORY_LIMIT));
+                containerBuilder.editOrNewResources().addToLimits("memory", new Quantity(DEFAULT_JNLP_CONTAINER_MEMORY_LIMIT)).endResources();
             }
 
-            jnlp.setResources(containerResources.endResources().build().getResources());
+            jnlp.setResources(containerBuilder.build().getResources());
 
         }
         

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -72,6 +72,7 @@ import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeBuilder;
 import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
+import io.fabric8.kubernetes.api.model.ContainerFluent.ResourcesNested;
 import io.fabric8.kubernetes.client.utils.Serialization;
 
 import jenkins.model.Jenkins;
@@ -266,18 +267,18 @@ public class PodTemplateBuilder {
         jnlp.setEnv(new ArrayList<>(envVars.values()));
         if (jnlp.getResources() == null) {
 
-            ContainerBuilder containerBuilder = new ContainerBuilder();
-            containerBuilder.editOrNewResources().addToRequests("cpu", new Quantity(DEFAULT_JNLP_CONTAINER_CPU_REQUEST)).addToRequests("memory", new Quantity(DEFAULT_JNLP_CONTAINER_MEMORY_REQUEST)).endResources();
+            ResourcesNested<ContainerBuilder> containerBuilder = new ContainerBuilder().withNewResources();
+            containerBuilder.addToRequests("cpu", new Quantity(DEFAULT_JNLP_CONTAINER_CPU_REQUEST)).addToRequests("memory", new Quantity(DEFAULT_JNLP_CONTAINER_MEMORY_REQUEST));
 
             if (DEFAULT_JNLP_CONTAINER_CPU_LIMIT!=null) {
-                containerBuilder.editOrNewResources().addToLimits("cpu", new Quantity(DEFAULT_JNLP_CONTAINER_CPU_LIMIT)).endResources();
+                containerBuilder.addToLimits("cpu", new Quantity(DEFAULT_JNLP_CONTAINER_CPU_LIMIT));
             }
 
             if (DEFAULT_JNLP_CONTAINER_MEMORY_LIMIT!=null) {
-                containerBuilder.editOrNewResources().addToLimits("memory", new Quantity(DEFAULT_JNLP_CONTAINER_MEMORY_LIMIT)).endResources();
+                containerBuilder.addToLimits("memory", new Quantity(DEFAULT_JNLP_CONTAINER_MEMORY_LIMIT));
             }
 
-            jnlp.setResources(containerBuilder.build().getResources());
+            jnlp.setResources(containerBuilder.endResources().build().getResources());
 
         }
         

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -104,9 +104,9 @@ public class PodTemplateBuilder {
             .getProperty(PodTemplateStepExecution.class.getName() + ".defaultContainer.defaultCpuRequest", "100m");
 
     static final String DEFAULT_JNLP_CONTAINER_MEMORY_LIMIT = System
-            .getProperty(PodTemplateStepExecution.class.getName() + ".defaultContainer.defaultMemoryRequest", null);
+            .getProperty(PodTemplateStepExecution.class.getName() + ".defaultContainer.defaultMemoryLimit", null);
     static final String DEFAULT_JNLP_CONTAINER_CPU_LIMIT = System
-            .getProperty(PodTemplateStepExecution.class.getName() + ".defaultContainer.defaultCpuRequest", null);
+            .getProperty(PodTemplateStepExecution.class.getName() + ".defaultContainer.defaultCpuLimit", null);
 
     private static final String JNLPMAC_REF = "\\$\\{computer.jnlpmac\\}";
     private static final String NAME_REF = "\\$\\{computer.name\\}";
@@ -265,15 +265,20 @@ public class PodTemplateBuilder {
         envVars.putAll(jnlp.getEnv().stream().collect(Collectors.toMap(EnvVar::getName, Function.identity())));
         jnlp.setEnv(new ArrayList<>(envVars.values()));
         if (jnlp.getResources() == null) {
-            jnlp.setResources(new ContainerBuilder().editOrNewResources().addToRequests("cpu", new Quantity(DEFAULT_JNLP_CONTAINER_CPU_REQUEST)).addToRequests("memory", new Quantity(DEFAULT_JNLP_CONTAINER_MEMORY_REQUEST)).endResources().build().getResources());
+
+            containerBuilder = new ContainerBuilder();
+            containerBuilder.editOrNewResources().addToRequests("cpu", new Quantity(DEFAULT_JNLP_CONTAINER_CPU_REQUEST)).addToRequests("memory", new Quantity(DEFAULT_JNLP_CONTAINER_MEMORY_REQUEST));
 
             if (DEFAULT_JNLP_CONTAINER_CPU_LIMIT!=null) {
-                jnlp.setResources(new ContainerBuilder().editOrNewResources().addToLimits("cpu", new Quantity(DEFAULT_JNLP_CONTAINER_CPU_LIMIT)).endResources().build().getResources());
+                containerBuilder.editOrNewResources().addToLimits("cpu", new Quantity(DEFAULT_JNLP_CONTAINER_CPU_LIMIT));
             }
 
             if (DEFAULT_JNLP_CONTAINER_MEMORY_LIMIT!=null) {
-                jnlp.setResources(new ContainerBuilder().editOrNewResources().addToLimits("memory", new Quantity(DEFAULT_JNLP_CONTAINER_MEMORY_LIMIT)).endResources().build().getResources());
+                containerBuilder.editOrNewResources().addToLimits("memory", new Quantity(DEFAULT_JNLP_CONTAINER_MEMORY_LIMIT))
             }
+
+            jnlp.setResources(containerBuilder.endResources().build().getResources());
+
         }
         
         // If the volume mounts of any container has been set to null, set it to empty list.

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -275,7 +275,8 @@ public class PodTemplateBuilder {
             reqMap.put("cpu", new Quantity(DEFAULT_JNLP_CONTAINER_CPU_REQUEST));
             reqMap.put("memory", new Quantity(DEFAULT_JNLP_CONTAINER_MEMORY_REQUEST));
 
-            
+            limMap.put("cpu", new Quantity(DEFAULT_JNLP_CONTAINER_CPU_LIMIT));
+            limMap.put("memory", new Quantity(DEFAULT_JNLP_CONTAINER_MEMORY_LIMIT));
 
             if (DEFAULT_JNLP_CONTAINER_CPU_LIMIT!=null) {
                 containerBuilder.addToLimits("cpu", new Quantity(DEFAULT_JNLP_CONTAINER_CPU_LIMIT));

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -269,21 +269,17 @@ public class PodTemplateBuilder {
         jnlp.setEnv(new ArrayList<>(envVars.values()));
         if (jnlp.getResources() == null) {
 
-            ResourcesNested<ContainerBuilder> containerBuilder = new ContainerBuilder().withNewResources();
             Map<String, Quantity> reqMap = new HashMap<>();
             Map<String, Quantity> limMap = new HashMap<>();
             reqMap.put("cpu", new Quantity(DEFAULT_JNLP_CONTAINER_CPU_REQUEST));
             reqMap.put("memory", new Quantity(DEFAULT_JNLP_CONTAINER_MEMORY_REQUEST));
 
-            limMap.put("cpu", new Quantity(DEFAULT_JNLP_CONTAINER_CPU_LIMIT));
-            limMap.put("memory", new Quantity(DEFAULT_JNLP_CONTAINER_MEMORY_LIMIT));
-
             if (DEFAULT_JNLP_CONTAINER_CPU_LIMIT!=null) {
-                containerBuilder.addToLimits("cpu", new Quantity(DEFAULT_JNLP_CONTAINER_CPU_LIMIT));
+                limMap.put("cpu", new Quantity(DEFAULT_JNLP_CONTAINER_CPU_LIMIT));
             }
 
             if (DEFAULT_JNLP_CONTAINER_MEMORY_LIMIT!=null) {
-                containerBuilder.addToLimits("memory", new Quantity(DEFAULT_JNLP_CONTAINER_MEMORY_LIMIT));
+                limMap.put("memory", new Quantity(DEFAULT_JNLP_CONTAINER_MEMORY_LIMIT));
             }
 
             ResourceRequirements reqs = new ResourceRequirementsBuilder()

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -271,11 +271,11 @@ public class PodTemplateBuilder {
 
             if (DEFAULT_JNLP_CONTAINER_CPU_LIMIT!=null) {
                 containerBuilder.editOrNewResources().addToLimits("cpu", new Quantity(DEFAULT_JNLP_CONTAINER_CPU_LIMIT));
-            }
+            };
 
             if (DEFAULT_JNLP_CONTAINER_MEMORY_LIMIT!=null) {
                 containerBuilder.editOrNewResources().addToLimits("memory", new Quantity(DEFAULT_JNLP_CONTAINER_MEMORY_LIMIT))
-            }
+            };
 
             jnlp.setResources(containerBuilder.endResources().build().getResources());
 


### PR DESCRIPTION
This allows to specify jnlp container limits through system properties.

`org.csanchez.jenkins.plugins.kubernetes.PodTemplateStepExecution.defaultContainer.defaultMemoryLimit`
`org.csanchez.jenkins.plugins.kubernetes.PodTemplateStepExecution.defaultContainer.defaultCpuLimit`


Sometime need to set limits for jnlp.
Otherwise, we get an error

![image](https://user-images.githubusercontent.com/586025/94693318-ffdcf280-034c-11eb-8888-98dec3762887.png)
