### PR TITLE
`PodTemplateUtils#combine` shouldn't have a side-effect on the parent pod template

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
@@ -28,6 +28,7 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
 import com.google.common.annotations.VisibleForTesting;
+import hudson.slaves.NodeProperty;
 import org.apache.commons.lang.StringUtils;
 import org.csanchez.jenkins.plugins.kubernetes.model.TemplateEnvVar;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.PodVolume;
@@ -373,8 +374,8 @@ public class PodTemplateUtils {
         WorkspaceVolume workspaceVolume = WorkspaceVolume.merge(parent.getWorkspaceVolume(), template.getWorkspaceVolume());
 
         //Tool location node properties
-        PodTemplateToolLocation toolLocationNodeProperties = parent.getNodeProperties();
-        toolLocationNodeProperties.addAll(template.getNodeProperties());
+        List<NodeProperty<?>> nodeProperties = new ArrayList<>(parent.getNodeProperties());
+        nodeProperties.addAll(template.getNodeProperties());
 
         PodTemplate podTemplate = new PodTemplate(template.getId());
         podTemplate.setName(name);
@@ -388,7 +389,7 @@ public class PodTemplateUtils {
         podTemplate.setVolumes(new ArrayList<>(combinedVolumes.values()));
         podTemplate.setImagePullSecrets(new ArrayList<>(imagePullSecrets));
         podTemplate.setAnnotations(new ArrayList<>(podAnnotations));
-        podTemplate.setNodeProperties(toolLocationNodeProperties);
+        podTemplate.setNodeProperties(nodeProperties);
         podTemplate.setNodeUsageMode(nodeUsageMode);
         podTemplate.setYamlMergeStrategy(template.getYamlMergeStrategy());
         podTemplate.setInheritFrom(!Strings.isNullOrEmpty(template.getInheritFrom()) ?

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
@@ -27,6 +27,7 @@ package org.csanchez.jenkins.plugins.kubernetes;
 import static java.util.Arrays.*;
 import static java.util.Collections.*;
 import static org.csanchez.jenkins.plugins.kubernetes.PodTemplateUtils.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
@@ -688,17 +689,21 @@ public class PodTemplateUtilsTest {
 
         PodTemplate podTemplate1 = new PodTemplate();
         List<ToolLocationNodeProperty> nodeProperties1 = new ArrayList<>();
-        nodeProperties1.add(new ToolLocationNodeProperty(new ToolLocationNodeProperty.ToolLocation("toolKey1@Test","toolHome1")));
+        ToolLocationNodeProperty toolHome1 = new ToolLocationNodeProperty(new ToolLocationNodeProperty.ToolLocation("toolKey1@Test", "toolHome1"));
+        nodeProperties1.add(toolHome1);
         podTemplate1.setNodeProperties(nodeProperties1);
 
         PodTemplate podTemplate2 = new PodTemplate();
         List<ToolLocationNodeProperty> nodeProperties2 = new ArrayList<>();
-        nodeProperties2.add(new ToolLocationNodeProperty(new ToolLocationNodeProperty.ToolLocation("toolKey2@Test","toolHome2")));
+        ToolLocationNodeProperty toolHome2 = new ToolLocationNodeProperty(new ToolLocationNodeProperty.ToolLocation("toolKey2@Test", "toolHome2"));
+        nodeProperties2.add(toolHome2);
         podTemplate2.setNodeProperties(nodeProperties2);
 
         PodTemplate result = combine(podTemplate1,podTemplate2);
 
-        assertThat(result.getNodeProperties(), hasItems(nodeProperties1.get(0),nodeProperties2.get(0)));
+        assertThat(podTemplate1.getNodeProperties(), contains(toolHome1));
+        assertThat(podTemplate2.getNodeProperties(), contains(toolHome2));
+        assertThat(result.getNodeProperties(), contains(toolHome1, toolHome2));
 
     }
 


### PR DESCRIPTION
Problem introduced in #318: https://github.com/jenkinsci/kubernetes-plugin/pull/318/files#diff-eff844000c9e60765310e70fa8c8a71cL308-L310