### PR TITLE
Don't set nodeSelector when `.spec.runtimeClassName` is set

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -237,7 +237,8 @@ public class PodTemplateBuilder {
         }
 
         // default OS: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
-        if ((pod.getSpec().getNodeSelector() == null || pod.getSpec().getNodeSelector().isEmpty()) &&
+        if (pod.getSpec().getRuntimeClassName() == null &&
+                (pod.getSpec().getNodeSelector() == null || pod.getSpec().getNodeSelector().isEmpty()) &&
                 (pod.getSpec().getAffinity() == null || pod.getSpec().getAffinity().getNodeAffinity() == null)) {
             pod.getSpec().setNodeSelector(Collections.singletonMap("kubernetes.io/os", "linux"));
         }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
@@ -34,6 +34,7 @@ import org.csanchez.jenkins.plugins.kubernetes.volumes.PodVolume;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.workspace.DynamicPVCWorkspaceVolume;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.workspace.EmptyDirWorkspaceVolume;
 import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -714,6 +715,17 @@ public class PodTemplateBuilderTest {
         Container jnlp = containers.get("jnlp");
 		assertEquals("Wrong number of volume mounts: " + jnlp.getVolumeMounts(), 1, jnlp.getVolumeMounts().size());
         validateContainers(pod, slave, directConnection);
+    }
+
+    @Test
+    public void whenRuntimeClassNameIsSetDoNotSetDefaultNodeSelector() {
+        setupStubs();
+        PodTemplate pt = new PodTemplate();
+        pt.setYaml("spec:\n" +
+                "  runtimeClassName: windows");
+        Pod pod = new PodTemplateBuilder(pt).withSlave(slave).build();
+        assertEquals("windows", pod.getSpec().getRuntimeClassName());
+        assertThat(pod.getSpec().getNodeSelector(), anEmptyMap());
     }
 
     private Map<String, Container> toContainerMap(Pod pod) {


### PR DESCRIPTION
cf. https://kubernetes.io/docs/setup/production-environment/windows/user-guide-windows-containers/#simplifying-with-runtimeclass