### PR TITLE
[JENKINS-58463] Allow maxConcurrentRequests to go above 64

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFactoryAdapter.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFactoryAdapter.java
@@ -116,6 +116,7 @@ public class KubernetesFactoryAdapter {
 
         builder = builder.withRequestTimeout(readTimeout * 1000).withConnectionTimeout(connectTimeout * 1000);
         builder.withMaxConcurrentRequestsPerHost(maxRequestsPerHost);
+        builder.withMaxConcurrentRequests(maxRequestsPerHost);
 
         if (!StringUtils.isBlank(namespace)) {
             builder.withNamespace(namespace);


### PR DESCRIPTION
![max-concurrent-requests-config](https://user-images.githubusercontent.com/11740869/95361457-be8f9a00-089a-11eb-8d2d-85f7034f86d2.png)

We found that `maxConcurrentRequests` in the K8s Client was always 64 no matter what the above number was set to. 

The config was properly setting `maxConcurrentRequestsPerHost` on the client, but one can still hit the bottleneck described in [JENKINS-58463](https://issues.jenkins-ci.org/browse/JENKINS-58463) after setting it, because testing showed that `maxConcurrentRequests` plays an equal role in limiting the number of concurrent requests allowed.