### PR TITLE
Clarify how various concurrency limit values are used

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -390,7 +390,7 @@ public class KubernetesCloud extends Cloud {
     }
 
     public void setContainerCap(Integer containerCap) {
-        this.containerCap = (containerCap != null && containerCap >= 0) ? containerCap : null;
+        this.containerCap = containerCap;
     }
 
     public String getContainerCapStr() {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -574,8 +574,8 @@ public class KubernetesCloud extends Cloud {
      *
      */
     private boolean addProvisionedSlave(@Nonnull PodTemplate template, @CheckForNull Label label, int scheduledCount) throws Exception {
-        int containerCap = getContainerCap();
-        if (containerCap == 0) {
+        int containerCap = getContainerCap(); // a null/empty "Concurrency Limit" field defaults to "unlimited" (Integer.MAX_VALUE).
+        if (containerCap <= 0) { // A user-specified "Concurrency Limit" number less than 1 effectively disables provisioning.
             return false;
         }
 

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/help-containerCapStr.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/help-containerCapStr.html
@@ -1,4 +1,4 @@
 <div>
     The maximum number of concurrently running agent pods that are permitted in this Kubernetes Cloud.
-    If set to empty it means no limit. Set to 0 means no pod will ever be started.
+    If set to empty it means no limit. Set to a negative number or 0 means no pod will ever be started.
 </div>

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudTest.java
@@ -218,14 +218,23 @@ public class KubernetesCloudTest {
         Label test = Label.get("test");
         assertTrue(cloud.canProvision(test));
 
+        // an unset containerCap a.k.a. "concurrency limit" means unlimited, or 200 in this case
         Collection<NodeProvisioner.PlannedNode> plannedNodes = cloud.provision(test, 200);
         assertEquals(200, plannedNodes.size());
 
+        // set to "0" means disabled
         cloud.setContainerCapStr("0");
         podTemplate.setInstanceCap(20);
         plannedNodes = cloud.provision(test, 200);
         assertEquals(0, plannedNodes.size());
 
+        // set to negative also means disabled
+        cloud.setContainerCapStr("-42");
+        podTemplate.setInstanceCap(20);
+        plannedNodes = cloud.provision(test, 200);
+        assertEquals(0, plannedNodes.size());
+
+        // set to a positive number sets the concurrency limit
         cloud.setContainerCapStr("10");
         podTemplate.setInstanceCap(20);
         plannedNodes = cloud.provision(test, 200);


### PR DESCRIPTION
Follow-on to https://github.com/jenkinsci/kubernetes-plugin/pull/863.

A few clarifying comments, and treat negative numbers the same as `0` (zero concurrency i.e. provisioning disabled).