### PR TITLE
Fix 'unlimited' for users who have concurrency limit set to 0

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -984,6 +984,10 @@ public class KubernetesCloud extends Cloud {
             setPodLabels(PodLabel.fromMap(labels));
         }
 
+        if (containerCap == 0) { // old "unlimited"
+            setContainerCap(null); // new "unlimited" (see getter)
+        }
+
         return this;
     }
 


### PR DESCRIPTION
Follow-on to https://github.com/jenkinsci/kubernetes-plugin/pull/828, https://github.com/jenkinsci/kubernetes-plugin/pull/863, and https://github.com/jenkinsci/kubernetes-plugin/pull/864.

For those who have a persisted "Concurrency Limit" of `0` (the old meaning of "unlimited"), this PR converts the `0` to `null` (the new meaning for "unlimited") during an upgrade.