### PR TITLE
Fix: Concurrency limit 0 must mean unlimited for upgradeability

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -575,9 +575,6 @@ public class KubernetesCloud extends Cloud {
      */
     private boolean addProvisionedSlave(@Nonnull PodTemplate template, @CheckForNull Label label, int scheduledCount) throws Exception {
         int containerCap = getContainerCap();
-        if (containerCap == Integer.MAX_VALUE) { // don't check concurrency limits when set to "unlimited."
-            return true;
-        }
 
         KubernetesClient client = connect();
         String templateNamespace = template.getNamespace();

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -576,7 +576,7 @@ public class KubernetesCloud extends Cloud {
     private boolean addProvisionedSlave(@Nonnull PodTemplate template, @CheckForNull Label label, int scheduledCount) throws Exception {
         int containerCap = getContainerCap();
         if (containerCap == 0) {
-            return false;
+            return true;
         }
 
         KubernetesClient client = connect();

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -390,12 +390,12 @@ public class KubernetesCloud extends Cloud {
     }
 
     public void setContainerCap(Integer containerCap) {
-        this.containerCap = (containerCap != null && containerCap >= 0) ? containerCap : null;
+        this.containerCap = (containerCap != null && containerCap > 0) ? containerCap : null;
     }
 
     public String getContainerCapStr() {
-        // serialized Integer.MAX_VALUE means no limit
-        return (containerCap == null || containerCap == Integer.MAX_VALUE) ? "" : String.valueOf(containerCap);
+        // null, serialized Integer.MAX_VALUE, or 0 means no limit
+        return (containerCap == null || containerCap == Integer.MAX_VALUE || containerCap == 0) ? "" : String.valueOf(containerCap);
     }
 
     public int getReadTimeout() {
@@ -575,8 +575,8 @@ public class KubernetesCloud extends Cloud {
      */
     private boolean addProvisionedSlave(@Nonnull PodTemplate template, @CheckForNull Label label, int scheduledCount) throws Exception {
         int containerCap = getContainerCap();
-        if (containerCap == 0) {
-            return true; // 0 means unlimited
+        if (containerCap == Integer.MAX_VALUE) { // don't check concurrency limits when set to "unlimited."
+            return true;
         }
 
         KubernetesClient client = connect();

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -576,7 +576,7 @@ public class KubernetesCloud extends Cloud {
     private boolean addProvisionedSlave(@Nonnull PodTemplate template, @CheckForNull Label label, int scheduledCount) throws Exception {
         int containerCap = getContainerCap();
         if (containerCap == 0) {
-            return true;
+            return true; // 0 means unlimited
         }
 
         KubernetesClient client = connect();

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/help-containerCapStr.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/help-containerCapStr.html
@@ -1,4 +1,4 @@
 <div>
     The maximum number of concurrently running agent pods that are permitted in this Kubernetes Cloud.
-    If set to empty it means no limit. Set to 0 means no pod will ever be started.
+    If set to empty or 0 it means no limit.
 </div>

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudTest.java
@@ -218,13 +218,15 @@ public class KubernetesCloudTest {
         Label test = Label.get("test");
         assertTrue(cloud.canProvision(test));
 
+        // null/empty means unlimited
         Collection<NodeProvisioner.PlannedNode> plannedNodes = cloud.provision(test, 200);
         assertEquals(200, plannedNodes.size());
 
+        // 0 also means unlimited
         cloud.setContainerCapStr("0");
         podTemplate.setInstanceCap(20);
         plannedNodes = cloud.provision(test, 200);
-        assertEquals(0, plannedNodes.size());
+        assertEquals(200, plannedNodes.size());
 
         cloud.setContainerCapStr("10");
         podTemplate.setInstanceCap(20);

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudTest.java
@@ -226,13 +226,13 @@ public class KubernetesCloudTest {
         cloud.setContainerCapStr("0");
         podTemplate.setInstanceCap(20);
         plannedNodes = cloud.provision(test, 200);
-        assertEquals(200, plannedNodes.size());
+        assertEquals(20, plannedNodes.size());
 
         // negative number also unlimited
         cloud.setContainerCapStr("-42");
         podTemplate.setInstanceCap(20);
         plannedNodes = cloud.provision(test, 200);
-        assertEquals(200, plannedNodes.size());
+        assertEquals(20, plannedNodes.size());
 
         cloud.setContainerCapStr("10");
         podTemplate.setInstanceCap(20);

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudTest.java
@@ -218,21 +218,8 @@ public class KubernetesCloudTest {
         Label test = Label.get("test");
         assertTrue(cloud.canProvision(test));
 
-        // null/empty means unlimited
         Collection<NodeProvisioner.PlannedNode> plannedNodes = cloud.provision(test, 200);
         assertEquals(200, plannedNodes.size());
-
-        // 0 also means unlimited
-        cloud.setContainerCapStr("0");
-        podTemplate.setInstanceCap(20);
-        plannedNodes = cloud.provision(test, 200);
-        assertEquals(20, plannedNodes.size());
-
-        // negative number also unlimited
-        cloud.setContainerCapStr("-42");
-        podTemplate.setInstanceCap(20);
-        plannedNodes = cloud.provision(test, 200);
-        assertEquals(20, plannedNodes.size());
 
         cloud.setContainerCapStr("10");
         podTemplate.setInstanceCap(20);

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudTest.java
@@ -228,6 +228,12 @@ public class KubernetesCloudTest {
         plannedNodes = cloud.provision(test, 200);
         assertEquals(200, plannedNodes.size());
 
+        // negative number also unlimited
+        cloud.setContainerCapStr("-42");
+        podTemplate.setInstanceCap(20);
+        plannedNodes = cloud.provision(test, 200);
+        assertEquals(200, plannedNodes.size());
+
         cloud.setContainerCapStr("10");
         podTemplate.setInstanceCap(20);
         plannedNodes = cloud.provision(test, 200);


### PR DESCRIPTION
Reverts the logical part of https://github.com/jenkinsci/kubernetes-plugin/pull/828, improves the help text, and amends the test which proves that `0` means unlimited.

I tried hard in https://github.com/jenkinsci/kubernetes-plugin/pull/864 and https://github.com/jenkinsci/kubernetes-plugin/pull/865 to have `0` become "disabled," because that's what made sense to me when https://github.com/jenkinsci/kubernetes-plugin/pull/828 was filed, but for upgradeability reasons `0` must keep its original meaning of "unlimited."