### PR TITLE
readme: add instructions for running with OpenShift 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,6 +586,8 @@ Also see the online help and [examples/containerLog.groovy](examples/containerLo
 
 # Running on OpenShift
 
+## Random UID problem
+
 OpenShift runs containers using a 'random' UID that is overriding what is specified in Docker images.
 For this reason, you may end up with the following warning in your build
 
@@ -600,6 +602,15 @@ This issue can be circumvented in various ways:
 * override HOME environment variable in the pod spec to use `/home/jenkins` and mount a volume to `/home/jenkins` to ensure the user running the container can write to it
 
 See this [example](examples/openshift-home-yaml.groovy) configuration.
+
+## Running with OpenShift 3
+
+OpenShift 3 is based on an older version of Kubernetes, which is not anymore directly supported since Kubernetes plugin version 1.26.0.
+
+To get agents working for Openshift 3, add this `Node Selector` to your Pod Templates:
+```
+beta.kubernetes.io/os=linux
+```
 
 # Windows support
 


### PR DESCRIPTION
Release 1.26.0 introduced an update [1], which made older versions of Kubernetes
fail rather obscurely, and with them, OpenShift 3 too. The instruction provided
in the issue discussion and release notes might be hard to find for new users
of the plugin, thus adding them to the readme.

As OpenShift 3.11 will still be maintained until June 2022 [2], many
users might be hitting this issue for a while still.

[1] https://github.com/jenkinsci/kubernetes-plugin/pull/790
[2] https://access.redhat.com/support/policy/updates/openshift_noncurrent