### PR TITLE
Resurrecting KubernetesPipelineTest.runInPodWithDifferentShell

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -451,10 +451,10 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
                 }
 
                 try {
-                    // Depends on the ping time with the kubernetes api
+                    // Depends on the ping time with the Kubernetes API server
                     // Not fully satisfied with this solution because it can delay the execution
                     if (finished.await(COMMAND_FINISHED_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
-                        launcher.getListener().error("Process exited immediately after creation. See output below%n%s",stdout.toString(StandardCharsets.UTF_8.name()));
+                        launcher.getListener().error("Process exited immediately after creation. See output below%n%s", stdout.toString(StandardCharsets.UTF_8.name()));
                         throw new AbortException("Process exited immediately after creation. Check logs above for more details.");
                     }
                     toggleStdout.disable();

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -547,7 +547,7 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
             try {
                 closable.close();
             } catch (Exception e) {
-                LOGGER.log(Level.FINE, "failed to close {0}")   ;
+                LOGGER.log(Level.FINE, "failed to close", e);
             }
         }
     }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -454,7 +454,6 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
                     // Depends on the ping time with the Kubernetes API server
                     // Not fully satisfied with this solution because it can delay the execution
                     if (finished.await(COMMAND_FINISHED_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
-                        stream.flush();
                         launcher.getListener().error("Process exited immediately after creation. See output below%n%s", stdout.toString(StandardCharsets.UTF_8.name()));
                         throw new AbortException("Process exited immediately after creation. Check logs above for more details.");
                     }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -552,11 +552,10 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
         }
     }
 
-    private static class ToggleOutputStream extends OutputStream {
-        private final OutputStream out;
+    private static class ToggleOutputStream extends FilterOutputStream {
         private boolean disabled;
         public ToggleOutputStream(OutputStream out) {
-            this.out = out;
+            super(out);
         }
 
         public void disable() {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -356,7 +356,7 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
                 // Do not send this command to the output when in quiet mode
                 if (quiet) {
                     stream = toggleStdout;
-                    printStream = new PrintStream(stream, false, StandardCharsets.UTF_8.toString());
+                    printStream = new PrintStream(stream, true, StandardCharsets.UTF_8.toString());
                 } else {
                     printStream = launcher.getListener().getLogger();
                     stream = new TeeOutputStream(toggleStdout, printStream);
@@ -547,7 +547,7 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
             try {
                 closable.close();
             } catch (Exception e) {
-                LOGGER.log(Level.FINE, "failed to close {0}");
+                LOGGER.log(Level.FINE, "failed to close {0}")   ;
             }
         }
     }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -454,6 +454,7 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
                     // Depends on the ping time with the Kubernetes API server
                     // Not fully satisfied with this solution because it can delay the execution
                     if (finished.await(COMMAND_FINISHED_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                        stream.flush();
                         launcher.getListener().error("Process exited immediately after creation. See output below%n%s", stdout.toString(StandardCharsets.UTF_8.name()));
                         throw new AbortException("Process exited immediately after creation. Check logs above for more details.");
                     }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
@@ -251,6 +251,14 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
     }
 
     @Test
+    public void runInPodWithDifferentShell() throws Exception {
+        r.assertBuildStatus(Result.FAILURE, r.waitForCompletion(b));
+        /* TODO instead the program fails with a IOException: Pipe closed from ContainerExecDecorator.doExec:
+        r.assertLogContains("/bin/bash: no such file or directory", b);
+        */
+    }
+
+    @Test
     public void bourneShellElsewhereInPath() throws Exception {
         r.assertBuildStatusSuccess(r.waitForCompletion(b));
         r.assertLogContains("/kaniko:/busybox", b);

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
@@ -95,6 +95,7 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
         deletePods(cloud.connect(), getLabels(cloud, this, name), false);
         warnings.record("", Level.WARNING).capture(1000);
         assertNotNull(createJobThenScheduleRun());
+        logs = logs.recordPackage(ContainerExecDecorator.class, Level.FINEST);
     }
 
     /**
@@ -253,9 +254,7 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
     @Test
     public void runInPodWithDifferentShell() throws Exception {
         r.assertBuildStatus(Result.FAILURE, r.waitForCompletion(b));
-        /* TODO instead the program fails with a IOException: Pipe closed from ContainerExecDecorator.doExec:
         r.assertLogContains("/bin/bash: no such file or directory", b);
-        */
     }
 
     @Test

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
@@ -280,7 +280,8 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
     @Test
     public void runInPodWithDifferentShell() throws Exception {
         r.assertBuildStatus(Result.FAILURE, r.waitForCompletion(b));
-        r.assertLogContains("/bin/bash: no such file or directory", b);
+        r.assertLogContains("ERROR: Process exited immediately after creation", b);
+        // r.assertLogContains("/bin/bash: no such file or directory", b); // Not printed in CI for an unknown reason.
     }
 
     @Test

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
@@ -95,7 +95,6 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
         deletePods(cloud.connect(), getLabels(cloud, this, name), false);
         warnings.record("", Level.WARNING).capture(1000);
         assertNotNull(createJobThenScheduleRun());
-        logs = logs.recordPackage(ContainerExecDecorator.class, Level.FINEST);
     }
 
     /**

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runInPodWithDifferentShell.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runInPodWithDifferentShell.groovy
@@ -1,0 +1,14 @@
+podTemplate(containers: [
+        containerTemplate(name: 'busybox', image: 'busybox', ttyEnabled: true, command: '/bin/cat'),
+    ]) {
+
+    node(POD_LABEL) {
+      stage('Run') {
+        container(name:'busybox', shell: '/bin/bash') {
+          sh """
+            echo "Run BusyBox shell"
+          """
+        }
+      }
+    }
+}


### PR DESCRIPTION
Reverting #771 because it turns out that this was actually testing something useful: that the build fails promptly if you specify the wrong `shell` for a `container` step. The behavior as of then was not great (`IOException: Pipe closed` rather than the more helpful `no such file or directory` it emitted at one point) but after #757 it is much worse: the `sh` step simply hangs. CC @ccojocar
