### PR TITLE
Add dropwizard metrics to track status of pods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,11 @@
       <artifactId>workflow-cps</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>metrics</artifactId>
+      <version>4.0.2.6</version>
+    </dependency>
 
     <!-- for testing -->
     <dependency>

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
@@ -20,13 +20,13 @@ import hudson.Util;
 import hudson.slaves.SlaveComputer;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.client.utils.Serialization;
+import jenkins.metrics.api.Metrics;
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.Validate;
 import org.csanchez.jenkins.plugins.kubernetes.pod.retention.PodRetention;
 import org.jenkinsci.plugins.durabletask.executors.OnceRetentionStrategy;
 import org.jenkinsci.plugins.kubernetes.auth.KubernetesAuthException;
-import org.jvnet.localizer.Localizable;
 import org.jvnet.localizer.ResourceBundleHolder;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -334,6 +334,7 @@ public class KubernetesSlave extends AbstractCloudSlave {
 
         if (deletePod) {
             deleteSlavePod(listener, client);
+            Metrics.metricRegistry().counter("k8s.cloud.pods.terminated").inc();
         } else {
             // Log warning, as the slave pod may still be running
             LOGGER.log(Level.WARNING, "Slave pod {0} was not deleted due to retention policy {1}.",

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
@@ -334,7 +334,7 @@ public class KubernetesSlave extends AbstractCloudSlave {
 
         if (deletePod) {
             deleteSlavePod(listener, client);
-            Metrics.metricRegistry().counter("k8s.cloud.pods.terminated").inc();
+            Metrics.metricRegistry().counter(MetricNames.PODS_TERMINATED).inc();
         } else {
             // Log warning, as the slave pod may still be running
             LOGGER.log(Level.WARNING, "Slave pod {0} was not deleted due to retention policy {1}.",

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/MetricNames.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/MetricNames.java
@@ -1,0 +1,28 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import hudson.model.Label;
+
+public class MetricNames {
+    private static final String PREFIX = "kubernetes.cloud";
+
+    public static final String CREATION_FAILED = PREFIX + ".pods.creation.failed";
+    public static final String PODS_CREATED = PREFIX + ".pods.created";
+    public static final String LAUNCH_FAILED = PREFIX + ".pods.launch.failed";
+    public static final String PODS_TERMINATED = PREFIX + ".pods.terminated";
+    public static final String REACHED_POD_CAP = PREFIX + ".provision.reached.pod.cap";
+    public static final String FAILED_TIMEOUT = PREFIX + ".pods.launch.failed.timeout";
+    public static final String PROVISION_NODES = PREFIX + ".provision.nodes";
+    public static final String PROVISION_FAILED = PREFIX + ".provision.failed";
+    public static final String REACHED_TOTAL_CAP = PREFIX + ".provision.reached.total.cap";
+    public static final String PODS_LAUNCHED = PREFIX + ".pods.launched";
+
+    public static String metricNameForPodStatus(String status) {
+        String formattedStatus = status == null ? "null" : status.toLowerCase();
+        return PREFIX + ".pods.launch.status." + formattedStatus;
+    }
+
+    public static String metricNameForLabel(Label label) {
+        String labelText = (label == null) ? "nolabel" : label.getDisplayName();
+        return String.format("%s.%s.provision.request", PREFIX, labelText);
+    }
+}

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/MetricNamesTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/MetricNamesTest.java
@@ -1,0 +1,50 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import antlr.ANTLRException;
+import hudson.model.Label;
+import hudson.model.labels.LabelAtom;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MetricNamesTest {
+
+    @Test
+    public void metricNameForPodStatusAddsNullWhenStatusIsNull() {
+        String expected = "kubernetes.cloud.pods.launch.status.null";
+        String actual = MetricNames.metricNameForPodStatus(null);
+
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void metricNameForPodStatusAddsStatusValueIfNotNull() {
+        String expected = "kubernetes.cloud.pods.launch.status.running";
+        String actual = MetricNames.metricNameForPodStatus("RUNNING");
+
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void metricNameForPodStatusChangeStatusToLowercase() {
+        String expected = "kubernetes.cloud.pods.launch.status.failed";
+        String actual = MetricNames.metricNameForPodStatus("FaIlEd");
+
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void metricNameForLabelAddsNoLabelIfLabelIsNull() {
+        String expected = "kubernetes.cloud.nolabel.provision.request";
+        String actual = MetricNames.metricNameForLabel(null);
+
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void metricNameForLabelAddsLabelValue() {
+        String expected = "kubernetes.cloud.java.provision.request";
+        String actual = MetricNames.metricNameForLabel(new LabelAtom("java"));
+
+        Assert.assertEquals(expected, actual);
+    }
+}

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
@@ -54,6 +54,7 @@ import jenkins.metrics.api.Metrics;
 import jenkins.model.Jenkins;
 import org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate;
 import org.csanchez.jenkins.plugins.kubernetes.KubernetesSlave;
+import org.csanchez.jenkins.plugins.kubernetes.MetricNames;
 import org.csanchez.jenkins.plugins.kubernetes.PodAnnotation;
 import org.csanchez.jenkins.plugins.kubernetes.PodTemplate;
 import org.hamcrest.MatcherAssert;
@@ -190,8 +191,8 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
                 map(lr -> lr.getSourceClassName() + "." + lr.getSourceMethodName() + ": " + lr.getMessage()).collect(Collectors.toList()), // LogRecord does not override toString
             emptyIterable());
 
-        assertTrue(Metrics.metricRegistry().counter("k8s.cloud.pods.launched").getCount() > 0);
-        assertTrue(Metrics.metricRegistry().meter("k8s.cloud.runInPod.provision.request").getCount() > 0);
+        assertTrue(Metrics.metricRegistry().counter(MetricNames.PODS_LAUNCHED).getCount() > 0);
+        assertTrue(Metrics.metricRegistry().meter(MetricNames.metricNameForLabel(Label.parseExpression("runInPod"))).getCount() > 0);
     }
 
     @Test

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
@@ -50,6 +50,7 @@ import hudson.util.VersionNumber;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.client.KubernetesClientException;
+import jenkins.metrics.api.Metrics;
 import jenkins.model.Jenkins;
 import org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate;
 import org.csanchez.jenkins.plugins.kubernetes.KubernetesSlave;
@@ -61,7 +62,6 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.support.steps.ExecutorStepExecution;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -189,6 +189,9 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
                 filter(lr -> lr.getLevel().intValue() >= Level.WARNING.intValue()). // TODO .record(…, WARNING) does not accomplish this
                 map(lr -> lr.getSourceClassName() + "." + lr.getSourceMethodName() + ": " + lr.getMessage()).collect(Collectors.toList()), // LogRecord does not override toString
             emptyIterable());
+
+        assertTrue(Metrics.metricRegistry().counter("k8s.cloud.pods.launched").getCount() > 0);
+        assertTrue(Metrics.metricRegistry().meter("k8s.cloud.runInPod.provision.request").getCount() > 0);
     }
 
     @Test


### PR DESCRIPTION
This PR is to add some basic dropwizard metrics to track status of provisioned pods.

I migrated Jenkins instances from Mesos to Kubernetes recently and noticed that the kube plugin doesn't provide metrics related to builder nodes provisioning like the [mesos plugin does](https://github.com/jenkinsci/mesos-plugin/blob/mesos-0.18.1/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java#L412).
These metrics become useful at scale when the number of Jenkins instance is quite big and they help to spot issues with Jenkins -> cloud provider as early as possible.
I took the same approach as the mesos plugin and use [dropwizard metrics](https://metrics.dropwizard.io/4.1.2/) (and [the metrics plugin](https://plugins.jenkins.io/metrics/)), however, I personally not a big fan of them as they don't have labels like [the prometheus metrics](https://plugins.jenkins.io/prometheus/) client. [Micrometer](https://micrometer.io) can be an alternative, it's like slf4j for logs. Any help with the metrics and what's the current stance in the jenkins world on them would be great.