### PR TITLE
Hacktoberfest - Fixup docker image name and tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Find more examples in the [examples dir](examples).
 The default jnlp agent image used can be customized by adding it to the template
 
 ```groovy
-containerTemplate(name: 'jnlp', image: 'jenkins/jnlp-slave:3.35-5-alpine', args: '${computer.jnlpmac} ${computer.name}'),
+containerTemplate(name: 'jnlp', image: 'jenkins/inbound-agent:4.3-4-alpine', args: '${computer.jnlpmac} ${computer.name}'),
 ```
 
 or with the yaml syntax
@@ -131,7 +131,7 @@ kind: Pod
 spec:
   containers:
   - name: jnlp
-    image: 'jenkins/jnlp-slave:3.35-5-alpine'
+    image: 'jenkins/inbound-agent:4.3-4-alpine'
     args: ['\$(JENKINS_SECRET)', '\$(JENKINS_NAME)']
 ```
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -17,7 +17,7 @@ For that some environment variables are automatically injected:
 * `JENKINS_NAME`: Jenkins 节点的名称（已废弃，保持向后兼容）
 
 使用镜像 [`jenkins/jnlp-slave`](https://hub.docker.com/r/jenkins/jnlp-slave) 做的测试。
-查看[Docker 镜像源码](https://github.com/jenkinsci/docker-jnlp-slave)。
+查看[Docker 镜像源码](https://github.com/jenkinsci/docker-inbound-slave)。
 
 Jenkins master 可以不在 Kubernetes 上运行。
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -17,7 +17,7 @@ For that some environment variables are automatically injected:
 * `JENKINS_NAME`: Jenkins 节点的名称（已废弃，保持向后兼容）
 
 使用镜像 [`jenkins/inbound-agent`](https://hub.docker.com/r/jenkins/inbound-agent) 做的测试。
-查看[Docker 镜像源码](https://github.com/jenkinsci/docker-inbound-slave)。
+查看[Docker 镜像源码](https://github.com/jenkinsci/docker-inbound-agent)。
 
 Jenkins master 可以不在 Kubernetes 上运行。
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -16,7 +16,7 @@ For that some environment variables are automatically injected:
 * `JENKINS_AGENT_NAME`: Jenkins 节点的名称
 * `JENKINS_NAME`: Jenkins 节点的名称（已废弃，保持向后兼容）
 
-使用镜像 [`jenkins/jnlp-slave`](https://hub.docker.com/r/jenkins/jnlp-slave) 做的测试。
+使用镜像 [`jenkins/inbound-agent`](https://hub.docker.com/r/jenkins/inbound-agent) 做的测试。
 查看[Docker 镜像源码](https://github.com/jenkinsci/docker-inbound-slave)。
 
 Jenkins master 可以不在 Kubernetes 上运行。
@@ -76,7 +76,7 @@ podTemplate(label: label) {
 可以在模板中自定义 `jnlp` 节点镜像
 
 ```groovy
-containerTemplate(name: 'jnlp', image: 'jenkins/jnlp-slave:3.35-5-alpine', args: '${computer.jnlpmac} ${computer.name}'),
+containerTemplate(name: 'jnlp', image: 'jenkins/inbound-agent:4.3-4-alpine', args: '${computer.jnlpmac} ${computer.name}'),
 ```
 
 或者使用 `yaml` 语法
@@ -87,7 +87,7 @@ kind: Pod
 spec:
   containers:
   - name: jnlp
-    image: 'jenkins/jnlp-slave:3.35-5-alpine'
+    image: 'jenkins/inbound-agent:4.3-4-alpine'
     args: ['\$(JENKINS_SECRET)', '\$(JENKINS_NAME)']
 ```
 
@@ -724,7 +724,7 @@ This can be done checking _Enable proxy compatibility_ under Manage Jenkins -> C
 
 使用下面的方式添加一个镜像：
 
-* Docker 镜像：`jenkins/jnlp-slave`
+* Docker 镜像：`jenkins/inbound-agent`
 * Jenkins 节点根目录：`/home/jenkins`
 
 ![image](configuration.png)

--- a/examples/dood.groovy
+++ b/examples/dood.groovy
@@ -20,7 +20,7 @@ spec:
 """
   ) {
 
-  def image = "jenkins/jnlp-slave"
+  def image = "jenkins/inbound-agent"
   node(POD_LABEL) {
     stage('Build Docker image') {
       git 'https://github.com/jenkinsci/docker-inbound-slave.git'

--- a/examples/dood.groovy
+++ b/examples/dood.groovy
@@ -23,7 +23,7 @@ spec:
   def image = "jenkins/jnlp-slave"
   node(POD_LABEL) {
     stage('Build Docker image') {
-      git 'https://github.com/jenkinsci/docker-jnlp-slave.git'
+      git 'https://github.com/jenkinsci/docker-inbound-slave.git'
       container('docker') {
         sh "docker build -t ${image} ."
       }

--- a/examples/dood.groovy
+++ b/examples/dood.groovy
@@ -23,7 +23,7 @@ spec:
   def image = "jenkins/inbound-agent"
   node(POD_LABEL) {
     stage('Build Docker image') {
-      git 'https://github.com/jenkinsci/docker-inbound-slave.git'
+      git 'https://github.com/jenkinsci/docker-inbound-agent.git'
       container('docker') {
         sh "docker build -t ${image} ."
       }

--- a/examples/kaniko-declarative.groovy
+++ b/examples/kaniko-declarative.groovy
@@ -44,7 +44,7 @@ spec:
   stages {
     stage('Build with Kaniko') {
       steps {
-        git 'https://github.com/jenkinsci/docker-jnlp-slave.git'
+        git 'https://github.com/jenkinsci/docker-inbound-slave.git'
         sh '/kaniko/executor -f `pwd`/Dockerfile -c `pwd` --insecure --skip-tls-verify --cache=true --destination=mydockerregistry:5000/myorg/myimage'
       }
     }

--- a/examples/kaniko-declarative.groovy
+++ b/examples/kaniko-declarative.groovy
@@ -44,7 +44,7 @@ spec:
   stages {
     stage('Build with Kaniko') {
       steps {
-        git 'https://github.com/jenkinsci/docker-inbound-slave.git'
+        git 'https://github.com/jenkinsci/docker-inbound-agent.git'
         sh '/kaniko/executor -f `pwd`/Dockerfile -c `pwd` --insecure --skip-tls-verify --cache=true --destination=mydockerregistry:5000/myorg/myimage'
       }
     }

--- a/examples/kaniko-gcr.groovy
+++ b/examples/kaniko-gcr.groovy
@@ -33,7 +33,7 @@ spec:
 
   node(POD_LABEL) {
     stage('Build with Kaniko') {
-      git 'https://github.com/jenkinsci/docker-inbound-slave.git'
+      git 'https://github.com/jenkinsci/docker-inbound-agent.git'
       container('kaniko') {
         sh '/kaniko/executor -c `pwd` --cache=true --destination=gcr.io/myprojectid/myimage'
       }

--- a/examples/kaniko-gcr.groovy
+++ b/examples/kaniko-gcr.groovy
@@ -33,7 +33,7 @@ spec:
 
   node(POD_LABEL) {
     stage('Build with Kaniko') {
-      git 'https://github.com/jenkinsci/docker-jnlp-slave.git'
+      git 'https://github.com/jenkinsci/docker-inbound-slave.git'
       container('kaniko') {
         sh '/kaniko/executor -c `pwd` --cache=true --destination=gcr.io/myprojectid/myimage'
       }

--- a/examples/kaniko.groovy
+++ b/examples/kaniko.groovy
@@ -35,7 +35,7 @@ spec:
 
   node(POD_LABEL) {
     stage('Build with Kaniko') {
-      git 'https://github.com/jenkinsci/docker-inbound-slave.git'
+      git 'https://github.com/jenkinsci/docker-inbound-agent.git'
       container('kaniko') {
         sh '/kaniko/executor -f `pwd`/Dockerfile -c `pwd` --insecure --skip-tls-verify --cache=true --destination=mydockerregistry:5000/myorg/myimage'
       }

--- a/examples/kaniko.groovy
+++ b/examples/kaniko.groovy
@@ -35,7 +35,7 @@ spec:
 
   node(POD_LABEL) {
     stage('Build with Kaniko') {
-      git 'https://github.com/jenkinsci/docker-jnlp-slave.git'
+      git 'https://github.com/jenkinsci/docker-inbound-slave.git'
       container('kaniko') {
         sh '/kaniko/executor -f `pwd`/Dockerfile -c `pwd` --insecure --skip-tls-verify --cache=true --destination=mydockerregistry:5000/myorg/myimage'
       }

--- a/examples/openshift-home-yaml.groovy
+++ b/examples/openshift-home-yaml.groovy
@@ -9,7 +9,7 @@ podTemplate(yaml:'''
 spec:
   containers:
   - name: jnlp
-    image: jenkins/jnlp-slave:4.0.1-1
+    image: jenkins/inbound-agent:4.3-4
     volumeMounts:
     - name: home-volume
       mountPath: /home/jenkins

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/help-directConnection.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/help-directConnection.html
@@ -29,6 +29,7 @@
   <p>
     <b>Note:</b> In <i>Direct Connection</i> mode agents will not be able to reconnect to a restarted master if a <i>Random</i> 'TCP port for inbound agents' is configured!<br/>
     <b>Note:</b> <i>Direct Connection</i> requires a <a target="_blank" href="https://hub.docker.com/r/jenkins/jnlp-slave/tags">jnlp-slave</a> image with a version equal or higher than 3.35-5.
+    <br/><b>Note:</b> Images <a target="_blank" href="https://hub.docker.com/r/jenkinsci/jnlp-slave">jenkinsci/jnlp-slave</a> and <a target="_blank" href="https://hub.docker.com/r/jenkins/jnlp-slave">jenkins/jnlp-slave</a> are deprecated, use <a target="_blank" href="https://hub.docker.com/r/jenkins/inbound-agent/">jenkins/inbound-agent</a>.
     <br/><b>Note:</b> <i>Direct Connection</i> does not work with the currently available <code>jenkins/inbound-agent:windowsservercore-1809</code> image.
   </p>
 

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest.java
@@ -203,7 +203,7 @@ public class KubernetesTest {
         assertEquals(Integer.MAX_VALUE, podTemplate.getInstanceCap());
         assertEquals(1, podTemplate.getContainers().size());
         ContainerTemplate containerTemplate = podTemplate.getContainers().get(0);
-        assertEquals("jenkins/jnlp-slave", containerTemplate.getImage());
+        assertEquals("jenkins/inbound-agent", containerTemplate.getImage());
         assertEquals("jnlp", containerTemplate.getName());
         assertEquals(Arrays.asList(new KeyValueEnvVar("a", "b"), new KeyValueEnvVar("c", "d")),
                 containerTemplate.getEnvVars());

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
@@ -583,7 +583,7 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
     @Test
     public void basicWindows() throws Exception {
         assumeWindows();
-        cloud.setDirectConnection(false); // not yet supported by https://github.com/jenkinsci/docker-inbound-slave/blob/517ccd68fd1ce420e7526ca6a40320c9a47a2c18/jenkins-agent.ps1
+        cloud.setDirectConnection(false); // not yet supported by https://github.com/jenkinsci/docker-inbound-agent/blob/517ccd68fd1ce420e7526ca6a40320c9a47a2c18/jenkins-agent.ps1
         r.assertBuildStatusSuccess(r.waitForCompletion(b));
         r.assertLogContains("Directory of C:\\home\\jenkins\\agent\\workspace\\basic Windows", b); // bat
         r.assertLogContains("C:\\Program Files (x86)", b); // powershell

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
@@ -259,7 +259,7 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
     @Test
     public void runInPodWithMultipleContainers() throws Exception {
         r.assertBuildStatusSuccess(r.waitForCompletion(b));
-        r.assertLogContains("image: \"jenkins/jnlp-slave:3.35-5-alpine\"", b);
+        r.assertLogContains("image: \"jenkins/inbound-agent:4.3-4-alpine\"", b);
         r.assertLogContains("image: \"maven:3.3.9-jdk-8-alpine\"", b);
         r.assertLogContains("image: \"golang:1.6.3-alpine\"", b);
         r.assertLogContains("My Kubernetes Pipeline", b);
@@ -397,7 +397,7 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
         PodTemplate pt = new PodTemplate();
         pt.setName("podTemplate");
         pt.setLabel("label1 label2");
-        ContainerTemplate jnlp = new ContainerTemplate("jnlp", "jenkins/jnlp-slave:3.35-5-alpine");
+        ContainerTemplate jnlp = new ContainerTemplate("jnlp", "jenkins/inbound-agent:4.3-4-alpine");
         pt.setContainers(Collections.singletonList(jnlp));
         cloud.addTemplate(pt);
         SemaphoreStep.waitForStart("pod/1", b);

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
@@ -583,7 +583,7 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
     @Test
     public void basicWindows() throws Exception {
         assumeWindows();
-        cloud.setDirectConnection(false); // not yet supported by https://github.com/jenkinsci/docker-jnlp-slave/blob/517ccd68fd1ce420e7526ca6a40320c9a47a2c18/jenkins-agent.ps1
+        cloud.setDirectConnection(false); // not yet supported by https://github.com/jenkinsci/docker-inbound-slave/blob/517ccd68fd1ce420e7526ca6a40320c9a47a2c18/jenkins-agent.ps1
         r.assertBuildStatusSuccess(r.waitForCompletion(b));
         r.assertLogContains("Directory of C:\\home\\jenkins\\agent\\workspace\\basic Windows", b); // bat
         r.assertLogContains("C:\\Program Files (x86)", b); // powershell

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest/upgradeFrom_0_12/config.xml
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest/upgradeFrom_0_12/config.xml
@@ -51,7 +51,7 @@
           <containers>
             <org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
               <name>jnlp</name>
-              <image>jenkins/jnlp-slave</image>
+              <image>jenkins/inbound-agent</image>
               <privileged>false</privileged>
               <alwaysPullImage>false</alwaysPullImage>
               <workingDir>/home/jenkins</workingDir>

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest/upgradeFrom_0_8/config.xml
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest/upgradeFrom_0_8/config.xml
@@ -23,7 +23,7 @@
       <templates>
         <org.csanchez.jenkins.plugins.kubernetes.PodTemplate>
           <name>java</name>
-          <image>jenkins/jnlp-slave</image>
+          <image>jenkins/inbound-agent</image>
           <privileged>false</privileged>
           <alwaysPullImage>false</alwaysPullImage>
           <command></command>

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest/upgradeFrom_1_10/config.xml
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest/upgradeFrom_1_10/config.xml
@@ -54,7 +54,7 @@
           <containers>
             <org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
               <name>jnlp</name>
-              <image>jenkins/jnlp-slave</image>
+              <image>jenkins/inbound-agent</image>
               <privileged>false</privileged>
               <alwaysPullImage>false</alwaysPullImage>
               <workingDir>/home/jenkins</workingDir>

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest/upgradeFrom_1_15_1/config.xml
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest/upgradeFrom_1_15_1/config.xml
@@ -51,7 +51,7 @@
           <containers>
             <org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
               <name>jnlp</name>
-              <image>jenkins/jnlp-slave</image>
+              <image>jenkins/inbound-agent</image>
               <privileged>false</privileged>
               <alwaysPullImage>false</alwaysPullImage>
               <workingDir>/home/jenkins</workingDir>

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest/upgradeFrom_1_15_9/config.xml
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest/upgradeFrom_1_15_9/config.xml
@@ -51,7 +51,7 @@
           <containers>
             <org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
               <name>jnlp</name>
-              <image>jenkins/jnlp-slave</image>
+              <image>jenkins/inbound-agent</image>
               <privileged>false</privileged>
               <alwaysPullImage>false</alwaysPullImage>
               <workingDir>/home/jenkins</workingDir>

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest/upgradeFrom_1_15_9_invalid/config.xml
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest/upgradeFrom_1_15_9_invalid/config.xml
@@ -51,7 +51,7 @@
           <containers>
             <org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
               <name>jnlp</name>
-              <image>jenkins/jnlp-slave</image>
+              <image>jenkins/inbound-agent</image>
               <privileged>false</privileged>
               <alwaysPullImage>false</alwaysPullImage>
               <workingDir>/home/jenkins</workingDir>

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest/upgradeFrom_1_17_2/config.xml
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest/upgradeFrom_1_17_2/config.xml
@@ -51,7 +51,7 @@
           <containers>
             <org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
               <name>jnlp</name>
-              <image>jenkins/jnlp-slave</image>
+              <image>jenkins/inbound-agent</image>
               <privileged>false</privileged>
               <alwaysPullImage>false</alwaysPullImage>
               <workingDir>/home/jenkins</workingDir>

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/dynamicPVC.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/dynamicPVC.groovy
@@ -1,5 +1,5 @@
 podTemplate(workspaceVolume: dynamicPVC(requestsSize: "10Gi"), containers: [
-        containerTemplate(name: 'jnlp', image: 'jenkins/jnlp-slave:3.35-5-alpine', args: '${computer.jnlpmac} ${computer.name}')
+        containerTemplate(name: 'jnlp', image: 'jenkins/inbound-agent:4.3-4-alpine', args: '${computer.jnlpmac} ${computer.name}')
 ], yaml:'''
 spec:
   securityContext:

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runInDynamicallyCreatedContainer.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runInDynamicallyCreatedContainer.groovy
@@ -9,7 +9,7 @@ spec:
 ''',
         containers: [
             containerTemplate(name: 'jnlp',
-                image: 'jenkins/jnlp-slave:latest',
+                image: 'jenkins/inbound-agent:latest',
                 alwaysPullImage: true,
                 args: '${computer.jnlpmac} ${computer.name}',
             ),

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runInPodWithLivenessProbe.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runInPodWithLivenessProbe.groovy
@@ -1,5 +1,5 @@
 podTemplate(volumes: [emptyDirVolume(mountPath: '/my-mount')], containers: [
-        containerTemplate(name: 'jnlp', image: 'jenkins/jnlp-slave:3.35-5-alpine', args: '${computer.jnlpmac} ${computer.name}'),
+        containerTemplate(name: 'jnlp', image: 'jenkins/inbound-agent:4.3-4-alpine', args: '${computer.jnlpmac} ${computer.name}'),
         containerTemplate(name: 'busybox', image: 'busybox', ttyEnabled: true, command: 'cat', livenessProbe: containerLivenessProbe( execArgs: 'uname -a', initialDelaySeconds: 5, timeoutSeconds: 1, failureThreshold: 3, periodSeconds: 10, successThreshold: 1))
 ]) {
 

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runInPodWithMultipleContainers.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runInPodWithMultipleContainers.groovy
@@ -1,5 +1,5 @@
 podTemplate(volumes: [emptyDirVolume(mountPath: '/my-mount')], containers: [
-        containerTemplate(name: 'jnlp', image: 'jenkins/jnlp-slave:3.35-5-alpine', args: '${computer.jnlpmac} ${computer.name}'),
+        containerTemplate(name: 'jnlp', image: 'jenkins/inbound-agent:4.3-4-alpine', args: '${computer.jnlpmac} ${computer.name}'),
         containerTemplate(name: 'maven', image: 'maven:3.3.9-jdk-8-alpine', ttyEnabled: true, command: 'cat'),
         containerTemplate(name: 'golang', image: 'golang:1.6.3-alpine', ttyEnabled: true, command: 'cat')
 ]) {

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runWithCloudOverriddenNamespace.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runWithCloudOverriddenNamespace.groovy
@@ -1,5 +1,5 @@
 podTemplate(volumes: [emptyDirVolume(mountPath: '/my-mount')], containers: [
-        containerTemplate(name: 'jnlp', image: 'jenkins/jnlp-slave:3.35-5-alpine', args: '${computer.jnlpmac} ${computer.name}')
+        containerTemplate(name: 'jnlp', image: 'jenkins/inbound-agent:4.3-4-alpine', args: '${computer.jnlpmac} ${computer.name}')
 ]) {
 
     node(POD_LABEL) {

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runWithStepOverriddenNamespace.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runWithStepOverriddenNamespace.groovy
@@ -3,7 +3,7 @@ podTemplate(
     namespace: '$OVERRIDDEN_NAMESPACE',
     volumes: [emptyDirVolume(mountPath: '/my-mount')], 
     containers: [
-      containerTemplate(name: 'jnlp', image: 'jenkins/jnlp-slave:3.35-5-alpine', args: '${computer.jnlpmac} ${computer.name}')
+      containerTemplate(name: 'jnlp', image: 'jenkins/inbound-agent:4.3-4-alpine', args: '${computer.jnlpmac} ${computer.name}')
     ]) {
 
     node(POD_LABEL) {


### PR DESCRIPTION
As mentioned in https://www.jenkins.io/blog/2020/05/06/docker-agent-image-renaming/ and https://issues.jenkins-ci.org/browse/JENKINS-42846

Additional change old tag version from 3.35-5-alpine to 4.3-4-alpine (like commit 278798c02)