### PR TITLE
Resolve cloud when removing dynamic template

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
@@ -253,10 +253,14 @@ public class PodTemplateStepExecution extends AbstractStepExecutionImpl {
          * Remove the template after step is done
          */
         protected void finished(StepContext context) throws Exception {
-            KubernetesCloud cloud = resolveCloud();
-            LOGGER.log(Level.FINE, () -> "Removing pod template " + podTemplate.getName()
-                    + " from cloud " + cloud.name);
-            cloud.removeDynamicTemplate(podTemplate);
+            try {
+                KubernetesCloud cloud = resolveCloud();
+                LOGGER.log(Level.FINE, () -> "Removing pod template " + podTemplate.getName()
+                        + " from cloud " + cloud.name);
+                cloud.removeDynamicTemplate(podTemplate);
+            } catch (AbortException e) {
+                LOGGER.log(Level.WARNING, () -> "Unable to resolve cloud for " + podTemplate.getName() + ". Maybe the cloud was removed while running the build?");
+            }
         }
     }
 }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
@@ -253,21 +253,10 @@ public class PodTemplateStepExecution extends AbstractStepExecutionImpl {
          * Remove the template after step is done
          */
         protected void finished(StepContext context) throws Exception {
-            Cloud cloud = Jenkins.get().getCloud(cloudName);
-            if (cloud == null) {
-                LOGGER.log(Level.FINE, "Cloud {0} no longer exists, cannot delete pod template {1}",
-                        new Object[] { cloudName, podTemplate.getName() });
-                return;
-            }
-            if (cloud instanceof KubernetesCloud) {
-                LOGGER.log(Level.FINE, "Removing pod template {1} from cloud {0}",
-                        new Object[] { cloud.name, podTemplate.getName() });
-                KubernetesCloud kubernetesCloud = (KubernetesCloud) cloud;
-                kubernetesCloud.removeDynamicTemplate(podTemplate);
-            } else {
-                LOGGER.log(Level.WARNING, "Cloud is not a KubernetesCloud: {0} {1}",
-                        new String[] { cloud.name, cloud.getClass().getName() });
-            }
+            KubernetesCloud cloud = resolveCloud();
+            LOGGER.log(Level.FINE, () -> "Removing pod template " + podTemplate.getName()
+                    + " from cloud " + cloud.name);
+            cloud.removeDynamicTemplate(podTemplate);
         }
     }
 }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
@@ -259,7 +259,7 @@ public class PodTemplateStepExecution extends AbstractStepExecutionImpl {
                         + " from cloud " + cloud.name);
                 cloud.removeDynamicTemplate(podTemplate);
             } catch (AbortException e) {
-                LOGGER.log(Level.WARNING, () -> "Unable to resolve cloud for " + podTemplate.getName() + ". Maybe the cloud was removed while running the build?");
+                LOGGER.log(Level.WARNING, e, () -> "Unable to resolve cloud for " + podTemplate.getName() + ". Maybe the cloud was removed while running the build?");
             }
         }
     }

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runInPod.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runInPod.groovy
@@ -17,3 +17,4 @@ podTemplate(label: '$NAME', containers: [
       }
     }
 }
+semaphore 'after-podtemplate'


### PR DESCRIPTION
Fixes removal of ephemeral pod templates when they don't specify an explicit `cloudName`

Replaces #878 

