### PR TITLE
Merge security fixes from 1.27.4 back into master

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>org.csanchez.jenkins.plugins</groupId>
   <artifactId>kubernetes</artifactId>
-  <version>${revision}${changelist}</version>
+  <version>1.27.4</version>
   <name>Kubernetes plugin</name>
   <description>Jenkins plugin to run dynamic agents in a Kubernetes cluster</description>
   <packaging>hpi</packaging>
@@ -19,7 +19,7 @@
     <connection>scm:git:https://github.com/jenkinsci/kubernetes-plugin.git</connection>
     <developerConnection>scm:git:https://github.com/jenkinsci/kubernetes-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/kubernetes-plugin</url>
-    <tag>${scmTag}</tag>
+    <tag>kubernetes-1.27.4</tag>
   </scm>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>org.csanchez.jenkins.plugins</groupId>
   <artifactId>kubernetes</artifactId>
-  <version>1.27.4</version>
+  <version>${revision}${changelist}</version>
   <name>Kubernetes plugin</name>
   <description>Jenkins plugin to run dynamic agents in a Kubernetes cluster</description>
   <packaging>hpi</packaging>
@@ -19,7 +19,7 @@
     <connection>scm:git:https://github.com/jenkinsci/kubernetes-plugin.git</connection>
     <developerConnection>scm:git:https://github.com/jenkinsci/kubernetes-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/kubernetes-plugin</url>
-    <tag>kubernetes-1.27.4</tag>
+    <tag>${scmTag}</tag>
   </scm>
 
   <licenses>
@@ -39,7 +39,7 @@
   </developers>
 
   <properties>
-    <revision>1.27.4</revision>
+    <revision>1.27.5</revision>
     <changelist>-SNAPSHOT</changelist>
     <!-- in minikube
     minikube ip | sed -e 's/\([0-9]*\.[0-9]*\.[0-9]*\).*/\1.1/' -->

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubectlBuildWrapper.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubectlBuildWrapper.java
@@ -19,6 +19,7 @@ import hudson.security.ACL;
 import hudson.tasks.BuildWrapperDescriptor;
 import hudson.util.ListBoxModel;
 import jenkins.authentication.tokens.api.AuthenticationTokens;
+import jenkins.model.Jenkins;
 import jenkins.tasks.SimpleBuildWrapper;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.kubernetes.auth.KubernetesAuthConfig;
@@ -126,7 +127,12 @@ public class KubectlBuildWrapper extends SimpleBuildWrapper {
             return "Setup Kubernetes CLI (kubectl)";
         }
 
-        public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Item item, @QueryParameter String serverUrl) {
+        public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Item item, @QueryParameter String serverUrl, @QueryParameter String credentialsId) {
+            if (item == null
+                    ? !Jenkins.get().hasPermission(Jenkins.ADMINISTER)
+                    : !item.hasPermission(Item.EXTENDED_READ)) {
+                return new StandardListBoxModel().includeCurrentValue(credentialsId);
+            }
             StandardListBoxModel result = new StandardListBoxModel();
             result.includeEmptyValue();
             result.includeMatchingAs(

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
@@ -75,6 +75,8 @@ public class PodTemplateUtils {
 
     private static final Pattern LABEL_VALIDATION = Pattern.compile("[a-zA-Z0-9]([_\\.\\-a-zA-Z0-9]*[a-zA-Z0-9])?");
 
+    private static /*nonfinal*/ boolean SUBSTITUTE_ENV = Boolean.getBoolean(PodTemplateUtils.class.getName() + ".SUBSTITUTE_ENV");
+
     /**
      * Combines a {@link ContainerTemplate} with its parent.
      * @param parent        The parent container template (nullable).
@@ -519,21 +521,11 @@ public class PodTemplateUtils {
      * Substitutes a placeholder with a value found in the environment.
      * @param s     The placeholder. Should be use the format: ${placeholder}.
      * @return      The substituted value if found, or the input value otherwise.
-     */
-    public static String substituteEnv(String s) {
-        return replaceMacro(s, System.getenv());
-    }
-
-    /**
-     * Substitutes a placeholder with a value found in the environment.
-     * @deprecated check if it is null or empty in the caller method, then use {@link #substituteEnv(String)}
-     * @param s             The placeholder. Should be use the format: ${placeholder}.
-     * @param defaultValue  The default value to return if no match is found.
-     * @return              The substituted value if found, or the default value otherwise.
+     * @deprecated Potentially insecure; a no-op by default.
      */
     @Deprecated
-    public static String substituteEnv(String s, String defaultValue) {
-        return substitute(s, System.getenv(), defaultValue);
+    public static String substituteEnv(String s) {
+        return SUBSTITUTE_ENV ? replaceMacro(s, System.getenv()) : s;
     }
 
     /**

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep.java
@@ -403,6 +403,9 @@ public class PodTemplateStep extends Step implements Serializable {
         public ListBoxModel doFillCloudItems() {
             ListBoxModel result = new ListBoxModel();
             result.add("—any—", "");
+            if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) { // TODO track use of SYSTEM_READ and/or MANAGE in GlobalCloudConfiguration
+                return result;
+            }
             Jenkins.get().clouds
                     .getAll(KubernetesCloud.class)
                     .forEach(cloud -> result.add(cloud.name));
@@ -415,6 +418,9 @@ public class PodTemplateStep extends Step implements Serializable {
             ListBoxModel result = new ListBoxModel();
             result.add("—Default inheritance—", "<default>");
             result.add("—Disable inheritance—", " ");
+            if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) { // TODO track use of SYSTEM_READ and/or MANAGE in GlobalCloudConfiguration
+                return result;
+            }
             Cloud cloud;
             if (cloudName == null) {
                 cloud = Jenkins.get().clouds.get(KubernetesCloud.class);


### PR DESCRIPTION
This should be merged using _merge commit_ to retain the release-related commits in the history of `master`.