### PR TITLE
Add more logs to tests in order to diagnose flakiness

### DIFF
--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/AbstractKubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/AbstractKubernetesPipelineTest.java
@@ -32,8 +32,10 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
 
+import hudson.slaves.NodeProvisioner;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.jenkins.plugins.kubernetes.NoDelayProvisionerStrategy;
 import org.csanchez.jenkins.plugins.kubernetes.ContainerEnvVar;
 import org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate;
 import org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud;
@@ -72,7 +74,10 @@ public abstract class AbstractKubernetesPipelineTest {
     @Rule
     public JenkinsRuleNonLocalhost r = new JenkinsRuleNonLocalhost();
     @Rule
-    public LoggerRule logs = new LoggerRule().recordPackage(KubernetesCloud.class, Level.FINE);
+    public LoggerRule logs = new LoggerRule()
+            .recordPackage(KubernetesCloud.class, Level.FINE)
+            .recordPackage(NoDelayProvisionerStrategy.class, Level.FINE)
+            .record(NodeProvisioner.class, Level.FINE);
 
     @BeforeClass
     public static void isKubernetesConfigured() throws Exception {

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
@@ -49,7 +49,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 import hudson.model.Computer;
 import com.gargoylesoftware.htmlunit.html.DomNodeUtil;
@@ -59,6 +58,7 @@ import hudson.model.Label;
 import hudson.model.Run;
 import hudson.slaves.SlaveComputer;
 import hudson.util.VersionNumber;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.client.KubernetesClientException;
@@ -85,6 +85,8 @@ import org.jvnet.hudson.test.LoggerRule;
 
 import hudson.model.Result;
 import java.util.Locale;
+import java.util.stream.Collectors;
+
 import org.jenkinsci.plugins.workflow.flow.FlowDurabilityHint;
 import org.jenkinsci.plugins.workflow.flow.GlobalDefaultFlowDurabilityLevel;
 import org.junit.Ignore;
@@ -431,7 +433,7 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
         PodList pods = cloud.connect().pods().withLabels(labels).list();
         assertThat(
                 "Expected one pod with labels " + labels + " but got: "
-                        + pods.getItems().stream().map(pod -> pod.getMetadata()).collect(Collectors.toList()),
+                        + pods.getItems().stream().map(Pod::getMetadata).map(ObjectMeta::getName).collect(Collectors.toList()),
                 pods.getItems(), hasSize(1));
         SemaphoreStep.success("pod/1", null);
         r.assertBuildStatusSuccess(r.waitForCompletion(b));


### PR DESCRIPTION
I'm suspecting `KubernetesPipelineTest#podTemplateWithMultipleLabels` to be flaky because of the clock-based provisioning strategy.