### PR TITLE
Simplify caching by removing the close logic

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesClientProvider.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesClientProvider.java
@@ -118,7 +118,7 @@ public class KubernetesClientProvider {
                 for (KubernetesCloud cloud : jenkins.clouds.getAll(KubernetesCloud.class)) {
                     String displayName = cloud.getDisplayName();
                     Client client = clients.getIfPresent(displayName);
-                    if (client == null || client != null && client.getValidity() == getValidity(cloud)) {
+                    if (client == null || client.getValidity() == getValidity(cloud)) {
                         cloudDisplayNames.remove(displayName);
                     }
                 }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesClientProvider.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesClientProvider.java
@@ -118,16 +118,13 @@ public class KubernetesClientProvider {
                 for (KubernetesCloud cloud : jenkins.clouds.getAll(KubernetesCloud.class)) {
                     String displayName = cloud.getDisplayName();
                     Client client = clients.getIfPresent(displayName);
-                    if (client != null && client.getValidity() == getValidity(cloud)) {
+                    if (client == null || client != null && client.getValidity() == getValidity(cloud)) {
                         cloudDisplayNames.remove(displayName);
-                    } else {
-                        LOGGER.log(Level.INFO, "Invalidating Kubernetes client: {0} {1}",
-                                new Object[] { displayName, client });
                     }
                 }
                 // Remove missing / invalid clients
                 for (String displayName : cloudDisplayNames) {
-                    LOGGER.log(Level.INFO, "Invalidating Kubernetes client: {0}", displayName);
+                    LOGGER.log(Level.INFO, () -> "Invalidating Kubernetes client: " + displayName + clients.getIfPresent(displayName));
                     invalidate(displayName);
                 }
             }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesClientProvider.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesClientProvider.java
@@ -43,6 +43,12 @@ public class KubernetesClientProvider {
 
     private static final Cache<String, Client> clients = CacheBuilder.newBuilder()
             .expireAfterWrite(CACHE_EXPIRATION, TimeUnit.SECONDS)
+            .removalListener(rl -> {
+                Client client = (Client) rl.getValue();
+                if (client != null) {
+                    LOGGER.log(Level.FINE, () -> "Expiring Kubernetes client " + rl.getKey() + " " + client.client);
+                }
+            })
             .build();
 
     private KubernetesClientProvider() {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesClientProvider.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesClientProvider.java
@@ -1,18 +1,12 @@
 package org.csanchez.jenkins.plugins.kubernetes;
 
 import java.io.IOException;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Queue;
 import java.util.Set;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import hudson.model.PeriodicWork;
 import org.jenkinsci.plugins.kubernetes.auth.KubernetesAuthException;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -23,15 +17,10 @@ import com.google.common.cache.CacheBuilder;
 
 import hudson.Extension;
 import hudson.XmlFile;
-import hudson.model.AsyncPeriodicWork;
 import hudson.model.Saveable;
-import hudson.model.TaskListener;
 import hudson.model.listeners.SaveableListener;
-import io.fabric8.kubernetes.client.HttpClientAware;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import jenkins.model.Jenkins;
-import okhttp3.Dispatcher;
-import okhttp3.OkHttpClient;
 
 /**
  * Manages the Kubernetes client creation per cloud
@@ -47,20 +36,6 @@ public class KubernetesClientProvider {
             .getInteger(KubernetesClientProvider.class.getPackage().getName() + ".clients.cacheSize", 10);
 
     /**
-     * Time in seconds after which we will close the unused clients.
-     *
-     * Defaults to 5 minutes.
-     */
-    private static final Long EXPIRED_CLIENTS_PURGE_TIME = Long.getLong(
-            KubernetesClientProvider.class.getPackage().getName() + ".clients.expiredClientsPurgeTime", TimeUnit.MINUTES.toSeconds(5));
-    /**
-     * How often to check if we need to close clients, default to {@link #EXPIRED_CLIENTS_PURGE_TIME}/2
-     */
-    private static final Long EXPIRED_CLIENTS_PURGE_PERIOD = Long.getLong(
-            KubernetesClientProvider.class.getPackage().getName() + ".clients.expiredClientsPurgePeriod",
-            EXPIRED_CLIENTS_PURGE_TIME / 2);
-
-    /**
      * Client expiration in seconds.
      *
      * Some providers such as Amazon EKS use a token with 15 minutes expiration, so expire clients after 10 minutes.
@@ -68,21 +43,8 @@ public class KubernetesClientProvider {
     private static final long CACHE_EXPIRATION = Long.getLong(
             KubernetesClientProvider.class.getPackage().getName() + ".clients.cacheExpiration", TimeUnit.MINUTES.toSeconds(10));
 
-    private static final Queue<Client> expiredClients = new ConcurrentLinkedQueue<>();
-
-    private static final Cache<String, Client> clients = CacheBuilder.newBuilder() //
-            .maximumSize(CACHE_SIZE) //
-            .expireAfterWrite(CACHE_EXPIRATION, TimeUnit.SECONDS) //
-            .removalListener(rl -> {
-                LOGGER.log(Level.FINE, "{0} cache : Removing entry for {1}",
-                        new Object[] { KubernetesClient.class.getSimpleName(), rl.getKey() });
-                Client client = (Client) rl.getValue();
-                if (client != null) {
-                    client.expired = Instant.now();
-                    expiredClients.add(client);
-                }
-
-            }) //
+    private static final Cache<String, Client> clients = CacheBuilder.newBuilder()
+            .expireAfterWrite(CACHE_EXPIRATION, TimeUnit.SECONDS)
             .build();
 
     private KubernetesClientProvider() {
@@ -111,7 +73,6 @@ public class KubernetesClientProvider {
     private static class Client {
         private final KubernetesClient client;
         private final int validity;
-        private Instant expired;
 
         public Client(int validity, KubernetesClient client) {
             this.client = client;
@@ -125,98 +86,6 @@ public class KubernetesClientProvider {
         public int getValidity() {
             return validity;
         }
-
-        public Instant getExpired() {
-            return expired;
-        }
-    }
-
-    @Extension
-    public static class PurgeExpiredKubernetesClients extends AsyncPeriodicWork {
-
-        public PurgeExpiredKubernetesClients() {
-            super("Purge expired KubernetesClients");
-        }
-
-        @Override
-        public long getRecurrencePeriod() {
-            return TimeUnit.SECONDS.toMillis(EXPIRED_CLIENTS_PURGE_PERIOD);
-        }
-
-        @Override
-        protected Level getNormalLoggingLevel() {
-            return Level.FINEST;
-        }
-
-        @Override
-        protected void execute(TaskListener listener) {
-            closeExpiredClients();
-        }
-    }
-
-    /**
-     * Gracefully close expired clients
-     * 
-     * @return whether some clients have been closed or not
-     */
-    @Restricted(NoExternalUse.class) // testing only
-    public static boolean closeExpiredClients() {
-        boolean b = false;
-        if (expiredClients.isEmpty()) {
-            return b;
-        }
-        LOGGER.log(Level.FINE, "Closing {0} expired clients",
-                new Object[] { expiredClients.size() });
-        for (Iterator<Client> it = expiredClients.iterator(); it.hasNext();) {
-            Client expiredClient = it.next();
-            // only purge it if the EXPIRED_CLIENTS_PURGE time has elapsed
-            if (Instant.now().minus(EXPIRED_CLIENTS_PURGE_TIME, ChronoUnit.SECONDS)
-                    .isBefore(expiredClient.getExpired())) {
-                break;
-            }
-            KubernetesClient client = expiredClient.client;
-            if (client instanceof HttpClientAware) {
-                if (gracefulClose(client, ((HttpClientAware) client).getHttpClient())) {
-                    it.remove();
-                    b = true;
-                }
-            } else {
-                LOGGER.log(Level.WARNING, "{0} is not {1}, forcing close",
-                        new Object[] { client.toString(), HttpClientAware.class.getSimpleName() });
-                client.close();
-                it.remove();
-                b = true;
-            }
-        }
-        return b;
-    }
-
-    @Restricted(NoExternalUse.class) // testing only
-    public static boolean gracefulClose(KubernetesClient client, OkHttpClient httpClient) {
-        Dispatcher dispatcher = httpClient.dispatcher();
-        // Remove the client if there are no more users
-        int runningCallsCount = dispatcher.runningCallsCount();
-        int queuedCallsCount = dispatcher.queuedCallsCount();
-        if (runningCallsCount == 0 && queuedCallsCount == 0) {
-            LOGGER.log(Level.FINE, "Closing {0}", client.toString());
-            client.close();
-            return true;
-        } else {
-            LOGGER.log(Level.INFO, "Not closing {0}: there are still running ({1}) or queued ({2}) calls",
-                    new Object[] { client.toString(), runningCallsCount, queuedCallsCount });
-            return false;
-        }
-    }
-
-    private static volatile int runningCallsCount;
-    private static volatile int queuedCallsCount;
-
-    public static int getRunningCallsCount() {
-        return runningCallsCount;
-    }
-
-    public static int getQueuedCallsCount() {
-        return queuedCallsCount;
     }
 
     @Restricted(NoExternalUse.class) // testing only
@@ -248,32 +117,6 @@ public class KubernetesClientProvider {
                 }
             }
             super.onChange(o, file);
-        }
-    }
-
-    @Extension
-    public static class UpdateConnectionCount extends PeriodicWork {
-
-        @Override
-        public long getRecurrencePeriod() {
-            return TimeUnit.SECONDS.toMillis(5);
-        }
-
-        @Override
-        protected void doRun() {
-            int runningCallsCount = 0;
-            int queuedCallsCount = 0;
-            for (Client client : KubernetesClientProvider.clients.asMap().values()) {
-                KubernetesClient kClient = client.getClient();
-                if (kClient instanceof HttpClientAware) {
-                    OkHttpClient httpClient = ((HttpClientAware) kClient).getHttpClient();
-                    Dispatcher dispatcher = httpClient.dispatcher();
-                    runningCallsCount += dispatcher.runningCallsCount();
-                    queuedCallsCount += dispatcher.queuedCallsCount();
-                }
-            }
-            KubernetesClientProvider.runningCallsCount = runningCallsCount;
-            KubernetesClientProvider.queuedCallsCount = queuedCallsCount;
         }
     }
 }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesClientProvider.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesClientProvider.java
@@ -34,12 +34,6 @@ public class KubernetesClientProvider {
     private static final Logger LOGGER = Logger.getLogger(KubernetesClientProvider.class.getName());
 
     /**
-     * How many clouds can we connect to, default to 10
-     */
-    private static final Integer CACHE_SIZE = Integer
-            .getInteger(KubernetesClientProvider.class.getPackage().getName() + ".clients.cacheSize", 10);
-
-    /**
      * Client expiration in seconds.
      *
      * Some providers such as Amazon EKS use a token with 15 minutes expiration, so expire clients after 10 minutes.


### PR DESCRIPTION
As per
https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/#shutdown-isnt-necessary

As the kubernetes client only close the underlying client, and it is not necessary to explicitly close http clients,
it should be safe to leave as is once it is expired.

If some calling code is holding to old instances, they can still use them provided the token-based authentication still works.

Ultimately, this should prevent occurrences such as

```
2020-11-04 06:49:56.143+0000 [id=329776]    WARNING
i.f.k.c.d.i.WatchConnectionManager$1#onFailure: Exec Failure
java.util.concurrent.RejectedExecutionException: Task
okhttp3.RealCall$AsyncCall@556ba43e rejected from
java.util.concurrent.ThreadPoolExecutor@217680e3[Terminated, pool size =
0, active threads = 0, queued tasks = 0, completed tasks = 30]
```

which denote some calling code trying to make a call using an http client instance which has been closed.