### PR TITLE
[JENKINS-61931] Add ability to set docker registry prefix for default JNLP image

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -42,6 +42,7 @@ import java.util.stream.Collectors;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import hudson.Util;
 import io.fabric8.kubernetes.api.model.PodSpecFluent;
 import org.apache.commons.lang.StringUtils;
 import org.csanchez.jenkins.plugins.kubernetes.model.TemplateEnvVar;
@@ -97,8 +98,8 @@ public class PodTemplateBuilder {
 
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "tests")
     @VisibleForTesting
-    static String DOCKER_REGISTRY_PREFIX = System
-            .getProperty(PodTemplateStepExecution.class.getName() + ".dockerRegistryPrefix", "");
+    static String DEFAULT_JNLP_DOCKER_REGISTRY_PREFIX = System
+            .getProperty(PodTemplateStepExecution.class.getName() + ".dockerRegistryPrefix");
     @VisibleForTesting
     static final String DEFAULT_JNLP_IMAGE = System
             .getProperty(PodTemplateStepExecution.class.getName() + ".defaultImage", "jenkins/inbound-agent:4.3-4");
@@ -259,9 +260,8 @@ public class PodTemplateBuilder {
         pod.getSpec().getContainers().stream().filter(c -> c.getWorkingDir() == null).forEach(c -> c.setWorkingDir(jnlp.getWorkingDir()));
         if (StringUtils.isBlank(jnlp.getImage())) {
             String jnlpImage = DEFAULT_JNLP_IMAGE;
-            if (StringUtils.isNotEmpty(DOCKER_REGISTRY_PREFIX)) {
-                String registryPrefix = DOCKER_REGISTRY_PREFIX.endsWith("/") ? DOCKER_REGISTRY_PREFIX : DOCKER_REGISTRY_PREFIX + "/";
-                jnlpImage = registryPrefix + jnlpImage;
+            if (StringUtils.isNotEmpty(DEFAULT_JNLP_DOCKER_REGISTRY_PREFIX)) {
+                jnlpImage = Util.ensureEndsWith(DEFAULT_JNLP_DOCKER_REGISTRY_PREFIX, "/") + jnlpImage;
             }
             jnlp.setImage(jnlpImage);
         }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -41,6 +41,7 @@ import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.fabric8.kubernetes.api.model.PodSpecFluent;
 import org.apache.commons.lang.StringUtils;
 import org.csanchez.jenkins.plugins.kubernetes.model.TemplateEnvVar;
@@ -94,8 +95,9 @@ public class PodTemplateBuilder {
 
     private static final String WORKSPACE_VOLUME_NAME = "workspace-volume";
 
+    @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "tests")
     @VisibleForTesting
-    static final String DOCKER_REGISTRY_PREFIX = System
+    static String DOCKER_REGISTRY_PREFIX = System
             .getProperty(PodTemplateStepExecution.class.getName() + ".dockerRegistryPrefix", "");
     @VisibleForTesting
     static final String DEFAULT_JNLP_IMAGE = System

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -95,6 +95,9 @@ public class PodTemplateBuilder {
     private static final String WORKSPACE_VOLUME_NAME = "workspace-volume";
 
     @VisibleForTesting
+    static final String DOCKER_REGISTRY_PREFIX = System
+            .getProperty(PodTemplateStepExecution.class.getName() + ".dockerRegistryPrefix", "");
+    @VisibleForTesting
     static final String DEFAULT_JNLP_IMAGE = System
             .getProperty(PodTemplateStepExecution.class.getName() + ".defaultImage", "jenkins/inbound-agent:4.3-4");
 
@@ -253,7 +256,12 @@ public class PodTemplateBuilder {
         }
         pod.getSpec().getContainers().stream().filter(c -> c.getWorkingDir() == null).forEach(c -> c.setWorkingDir(jnlp.getWorkingDir()));
         if (StringUtils.isBlank(jnlp.getImage())) {
-            jnlp.setImage(DEFAULT_JNLP_IMAGE);
+            String jnlpImage = DEFAULT_JNLP_IMAGE;
+            if (StringUtils.isNotEmpty(DOCKER_REGISTRY_PREFIX)) {
+                String registryPrefix = DOCKER_REGISTRY_PREFIX.endsWith("/") ? DOCKER_REGISTRY_PREFIX : DOCKER_REGISTRY_PREFIX + "/";
+                jnlpImage = registryPrefix + jnlpImage;
+            }
+            jnlp.setImage(jnlpImage);
         }
         Map<String, EnvVar> envVars = new HashMap<>();
         envVars.putAll(jnlpEnvVars(jnlp.getWorkingDir()));

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
@@ -38,6 +38,7 @@ import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.jvnet.hudson.test.FlagRule;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.LoggerRule;
@@ -81,6 +82,9 @@ public class PodTemplateBuilderTest {
     @Rule
     public LoggerRule logs = new LoggerRule().record(Logger.getLogger(KubernetesCloud.class.getPackage().getName()),
             Level.ALL);
+
+    @Rule
+    public FlagRule<String> dockerPrefix = new FlagRule<>(() -> DOCKER_REGISTRY_PREFIX, prefix -> DOCKER_REGISTRY_PREFIX = prefix);
 
     @Spy
     private KubernetesCloud cloud = new KubernetesCloud("test");
@@ -160,7 +164,6 @@ public class PodTemplateBuilderTest {
     @Parameters({ "true", "false" })
     public void testValidateDockerRegistryPrefixOverride(boolean directConnection) throws Exception {
         cloud.setDirectConnection(directConnection);
-        String origDockerRegistryPrefix = DOCKER_REGISTRY_PREFIX;
         DOCKER_REGISTRY_PREFIX = "jenkins.docker.com/docker-hub";
         PodTemplate template = new PodTemplate();
         template.setYaml(loadYamlFile("pod-busybox.yaml"));
@@ -173,7 +176,6 @@ public class PodTemplateBuilderTest {
         assertEquals("busybox", containers.get("busybox").getImage());
         assertEquals(DOCKER_REGISTRY_PREFIX + "/" + DEFAULT_JNLP_IMAGE, containers.get("jnlp").getImage());
         assertThat(pod.getMetadata().getLabels(), hasEntry("jenkins", "slave"));
-        DOCKER_REGISTRY_PREFIX = origDockerRegistryPrefix;
     }
 
     @Test
@@ -181,7 +183,6 @@ public class PodTemplateBuilderTest {
     @Parameters({ "true", "false" })
     public void testValidateDockerRegistryPrefixOverrideWithSlashSuffix(boolean directConnection) throws Exception {
         cloud.setDirectConnection(directConnection);
-        String origDockerRegistryPrefix = DOCKER_REGISTRY_PREFIX;
         DOCKER_REGISTRY_PREFIX = "jenkins.docker.com/docker-hub/";
         PodTemplate template = new PodTemplate();
         template.setYaml(loadYamlFile("pod-busybox.yaml"));
@@ -194,7 +195,6 @@ public class PodTemplateBuilderTest {
         assertEquals("busybox", containers.get("busybox").getImage());
         assertEquals(DOCKER_REGISTRY_PREFIX + DEFAULT_JNLP_IMAGE, containers.get("jnlp").getImage());
         assertThat(pod.getMetadata().getLabels(), hasEntry("jenkins", "slave"));
-        DOCKER_REGISTRY_PREFIX = origDockerRegistryPrefix;
     }
 
     @Test

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
@@ -34,7 +34,6 @@ import org.csanchez.jenkins.plugins.kubernetes.volumes.PodVolume;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.workspace.DynamicPVCWorkspaceVolume;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.workspace.EmptyDirWorkspaceVolume;
 import org.hamcrest.Matcher;
-import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -84,7 +83,7 @@ public class PodTemplateBuilderTest {
             Level.ALL);
 
     @Rule
-    public FlagRule<String> dockerPrefix = new FlagRule<>(() -> DOCKER_REGISTRY_PREFIX, prefix -> DOCKER_REGISTRY_PREFIX = prefix);
+    public FlagRule<String> dockerPrefix = new FlagRule<>(() -> DEFAULT_JNLP_DOCKER_REGISTRY_PREFIX, prefix -> DEFAULT_JNLP_DOCKER_REGISTRY_PREFIX = prefix);
 
     @Spy
     private KubernetesCloud cloud = new KubernetesCloud("test");
@@ -164,7 +163,7 @@ public class PodTemplateBuilderTest {
     @Parameters({ "true", "false" })
     public void testValidateDockerRegistryPrefixOverride(boolean directConnection) throws Exception {
         cloud.setDirectConnection(directConnection);
-        DOCKER_REGISTRY_PREFIX = "jenkins.docker.com/docker-hub";
+        DEFAULT_JNLP_DOCKER_REGISTRY_PREFIX = "jenkins.docker.com/docker-hub";
         PodTemplate template = new PodTemplate();
         template.setYaml(loadYamlFile("pod-busybox.yaml"));
         setupStubs();
@@ -174,7 +173,7 @@ public class PodTemplateBuilderTest {
         assertEquals(2, containers.size());
 
         assertEquals("busybox", containers.get("busybox").getImage());
-        assertEquals(DOCKER_REGISTRY_PREFIX + "/" + DEFAULT_JNLP_IMAGE, containers.get("jnlp").getImage());
+        assertEquals(DEFAULT_JNLP_DOCKER_REGISTRY_PREFIX + "/" + DEFAULT_JNLP_IMAGE, containers.get("jnlp").getImage());
         assertThat(pod.getMetadata().getLabels(), hasEntry("jenkins", "slave"));
     }
 
@@ -183,7 +182,7 @@ public class PodTemplateBuilderTest {
     @Parameters({ "true", "false" })
     public void testValidateDockerRegistryPrefixOverrideWithSlashSuffix(boolean directConnection) throws Exception {
         cloud.setDirectConnection(directConnection);
-        DOCKER_REGISTRY_PREFIX = "jenkins.docker.com/docker-hub/";
+        DEFAULT_JNLP_DOCKER_REGISTRY_PREFIX = "jenkins.docker.com/docker-hub/";
         PodTemplate template = new PodTemplate();
         template.setYaml(loadYamlFile("pod-busybox.yaml"));
         setupStubs();
@@ -193,7 +192,7 @@ public class PodTemplateBuilderTest {
         assertEquals(2, containers.size());
 
         assertEquals("busybox", containers.get("busybox").getImage());
-        assertEquals(DOCKER_REGISTRY_PREFIX + DEFAULT_JNLP_IMAGE, containers.get("jnlp").getImage());
+        assertEquals(DEFAULT_JNLP_DOCKER_REGISTRY_PREFIX + DEFAULT_JNLP_IMAGE, containers.get("jnlp").getImage());
         assertThat(pod.getMetadata().getLabels(), hasEntry("jenkins", "slave"));
     }
 


### PR DESCRIPTION
For security reasons most enterprises mandates all docker image pulls are proxied through enterprise docker registry. Prior to this change, only possible mechanism will be to set the entire image with proxy prefix as system property. Though it works, it comes with huge maintenance overhead as the property value needs to be frequently changed to use newer version of inbound agents. This change allows to set the docker registry prefix once and inherit the default JNLP image defined in the ode.

- Fixes [JENKINS-61931](https://issues.jenkins-ci.org/browse/JENKINS-61931).
- Added ability to set docker registry prefix for default JNLP image using System Property

Looks like its not possible to test this change via unit tests, hence tested locally to ensure the changes work.