### PR TITLE
fix: getPodRetention throws IllegalArgumentException

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
@@ -258,7 +258,7 @@ public class KubernetesSlave extends AbstractCloudSlave {
 
     public PodRetention getPodRetention(KubernetesCloud cloud) {
         PodRetention retentionPolicy = cloud.getPodRetention();
-        PodTemplate template = getTemplate();
+        PodTemplate template = getTemplateOrNull();
         if (template != null) {
             PodRetention pr = template.getPodRetention();
             // https://issues.jenkins-ci.org/browse/JENKINS-53260


### PR DESCRIPTION
Some exception I've seen being raised when the calling code already takes into account the template being unresolved

