### PR TITLE
Update jackson2-api to 2.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jackson2-api</artifactId>
-      <version>2.11.3</version>
+      <version>2.12.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
@@ -687,6 +687,11 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
         r.assertLogContains("xxx" + home + "xxx", b);
     }
 
+    @Test
+    public void octalPermissions() throws Exception {
+        r.assertBuildStatusSuccess(r.waitForCompletion(b));
+    }
+
     private <R extends Run> R assertBuildStatus(R run, Result... status) throws Exception {
         for (Result s : status) {
             if (s == run.getResult()) {

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/octalPermissions.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/octalPermissions.groovy
@@ -2,9 +2,14 @@ podTemplate(yaml: '''
 spec:
   volumes:
   - name: jenkins-agent
-    configMap:
-      name: jenkins-agent
-      defaultMode: 0777
+    projected:
+      sources:
+      - secret:
+          name: container-secret
+          items:
+            - key: password
+              path: my-group/my-password
+              mode: 0777
 ''') {
   node(POD_LABEL){
     sh 'true'

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/octalPermissions.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/octalPermissions.groovy
@@ -1,0 +1,12 @@
+podTemplate(yaml: '''
+spec:
+  volumes:
+  - name: jenkins-agent
+    configMap:
+      name: jenkins-agent
+      defaultMode: 0777
+''') {
+  node(POD_LABEL){
+    sh 'true'
+  }
+}


### PR DESCRIPTION
This brings support for octal numbers for fields specified through the `yaml` field.