### PR TITLE
Adding zero as "no limit value" for cap

### DIFF
--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/help-instanceCap.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/help-instanceCap.html
@@ -1,5 +1,5 @@
 <p>
 The maximum number of concurrently running agent pods created from this template that are permitted in the Kubernetes Cloud.<br/>
 The number of running agents will never exceed the global concurrency limit sets at the Cloud Configuration level.<br/>
-If set to empty or negative number it means no limit.
+If set to empty, zero or negative number it means no limit.
 </p>


### PR DESCRIPTION
According to this fix (https://github.com/jenkinsci/kubernetes-plugin/commit/a3227ae0df8310edfe2fbb4273d68ca7e6191678) the inline help should include zero (0) with the ranges of values which means no limits

