### PR TITLE
[JENKINS-63847] Use line separator from agent OS instead of master OS

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -44,6 +44,7 @@ import java.util.Set;
 
 import hudson.AbortException;
 import io.fabric8.kubernetes.api.model.Container;
+import jenkins.security.MasterToSlaveCallable;
 import org.apache.commons.io.output.TeeOutputStream;
 import org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate;
 import org.csanchez.jenkins.plugins.kubernetes.KubernetesSlave;
@@ -459,7 +460,13 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
                     }
                     toggleStdout.disable();
                     OutputStream stdin = watch.getInput();
-                    PrintStream in = new PrintStream(stdin, true, StandardCharsets.UTF_8.name());
+                    // Initialize a PrintStream with line separator from agent
+                    PrintStream in = pwd.getChannel().call(new MasterToSlaveCallable<PrintStream, UnsupportedEncodingException>() {
+                        @Override
+                        public PrintStream call() throws UnsupportedEncodingException {
+                            return new PrintStream(stdin, true, StandardCharsets.UTF_8.name());
+                        }
+                    });
                     if (pwd != null) {
                         // We need to get into the project workspace.
                         // The workspace is not known in advance, so we have to execute a cd command.

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -460,12 +460,11 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
                     toggleStdout.disable();
                     OutputStream stdin = watch.getInput();
                     PrintStream in = new PrintStream(stdin, true, StandardCharsets.UTF_8.name());
-                    boolean windows = sh.equals("cmd");
                     if (pwd != null) {
                         // We need to get into the project workspace.
                         // The workspace is not known in advance, so we have to execute a cd command.
                         in.print(String.format("cd \"%s\"", pwd));
-                        in.print(newLine(windows));
+                        in.print(newLine(!launcher.isUnix()));
                     }
 
                     EnvVars envVars = new EnvVars();
@@ -492,9 +491,9 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
 
                     LOGGER.log(Level.FINEST, "Launching with env vars: {0}", envVars.toString());
 
-                    setupEnvironmentVariable(envVars, in, windows);
+                    setupEnvironmentVariable(envVars, in, !launcher.isUnix());
 
-                    doExec(in, windows, printStream, masks, commands);
+                    doExec(in, !launcher.isUnix(), printStream, masks, commands);
 
                     LOGGER.log(Level.INFO, "Created process inside pod: [" + getPodName() + "], container: ["
                             + containerName + "]" + "[" + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startMethod) + " ms]");

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -44,7 +44,6 @@ import java.util.Set;
 
 import hudson.AbortException;
 import io.fabric8.kubernetes.api.model.Container;
-import jenkins.security.MasterToSlaveCallable;
 import org.apache.commons.io.output.TeeOutputStream;
 import org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate;
 import org.csanchez.jenkins.plugins.kubernetes.KubernetesSlave;
@@ -460,13 +459,7 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
                     }
                     toggleStdout.disable();
                     OutputStream stdin = watch.getInput();
-                    // Initialize a PrintStream with line separator from agent
-                    PrintStream in = pwd.getChannel().call(new MasterToSlaveCallable<PrintStream, UnsupportedEncodingException>() {
-                        @Override
-                        public PrintStream call() throws UnsupportedEncodingException {
-                            return new PrintStream(stdin, true, StandardCharsets.UTF_8.name());
-                        }
-                    });
+                    PrintStream in = new PrintStream(stdin, true, StandardCharsets.UTF_8.name());
                     if (pwd != null) {
                         // We need to get into the project workspace.
                         // The workspace is not known in advance, so we have to execute a cd command.


### PR DESCRIPTION
[JENKINS-63847](https://issues.jenkins.io/browse/JENKINS-63847)

Regression probably caused by #757. Before, it always used `\n`, which seemed to work on Windows.

Under `PrintStream`, `BufferedWriter` captures current line separator on initialization, and this behaviour can't be tuned.

This avoid using `println` and uses an eol character depending on the agent OS.