### PR TITLE
[JENKINS-62502] `ContainerExecDecorator` should escape double quotes

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -653,7 +653,8 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
 
         // BourneShellScript.launchWithCookie escapes $ as $$, we convert it to \$
         for (String cmd : starter.cmds()) {
-            String fixedCommand = cmd.replaceAll("\\$\\$", "\\\\\\$");
+            String fixedCommand = cmd.replaceAll("\\$\\$", "\\\\\\$")
+                    .replaceAll("\\\"", "\\\\\"");
 
             String oldRemoteDir = null;
             FilePath oldRemoteDirFilepath = starter.pwd();

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Matcher;
 
 import hudson.AbortException;
 import io.fabric8.kubernetes.api.model.Container;
@@ -653,8 +654,8 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
 
         // BourneShellScript.launchWithCookie escapes $ as $$, we convert it to \$
         for (String cmd : starter.cmds()) {
-            String fixedCommand = cmd.replaceAll("\\$\\$", "\\\\\\$")
-                    .replaceAll("\\\"", "\\\\\"");
+            String fixedCommand = cmd.replaceAll("\\$\\$", Matcher.quoteReplacement("\\$"))
+                    .replaceAll("\\\"", Matcher.quoteReplacement("\\\""));
 
             String oldRemoteDir = null;
             FilePath oldRemoteDirFilepath = starter.pwd();

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorTest.java
@@ -269,6 +269,16 @@ public class ContainerExecDecoratorTest {
     }
 
     @Test
+    @Issue("JENKINS-62502")
+    public void testCommandExecutionEscapingDoubleQuotes() throws Exception {
+        ProcReturn r = execCommand(false, "sh", "-c", "cd /tmp; false; echo \"result is 1\" > test; cat /tmp/test");
+        assertTrue("Output should contain result: " + r.output,
+                Pattern.compile("^(result is 1)$", Pattern.MULTILINE).matcher(r.output).find());
+        assertEquals(0, r.exitCode);
+        assertFalse(r.proc.isAlive());
+    }
+
+    @Test
     public void testCommandExecutionWithNohupAndError() throws Exception {
         ProcReturn r = execCommand(false, "nohup", "sh", "-c", "sleep 5; return 127");
         assertEquals(127, r.exitCode);


### PR DESCRIPTION
[JENKINS-62502](https://issues.jenkins.io/browse/JENKINS-62502)