### PR TITLE
Avoid streaming to 2 similar OutputStreams

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -363,7 +363,7 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
                 }
 
                 // Send to proc caller as well if they sent one
-                if (outputForCaller != null && !outputForCaller.equals(stream)) {
+                if (outputForCaller != null && !outputForCaller.equals(printStream)) {
                     stream = new TeeOutputStream(outputForCaller, stream);
                 }
                 ByteArrayOutputStream error = new ByteArrayOutputStream();

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorTest.java
@@ -50,6 +50,7 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watch;
 import org.apache.commons.io.output.TeeOutputStream;
 import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang.StringUtils;
 import org.csanchez.jenkins.plugins.kubernetes.AllContainersRunningPodWatcher;
 import org.csanchez.jenkins.plugins.kubernetes.KubernetesClientProvider;
 import org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud;
@@ -212,7 +213,7 @@ public class ContainerExecDecoratorTest {
     private void command(List<ProcReturn> results, int i) {
         ProcReturn r;
         try {
-            r = execCommand(false, "sh", "-c", "cd /tmp; echo ["+i+"] pid is $$$$ > test; cat /tmp/test");
+            r = execCommand(false, false, "sh", "-c", "cd /tmp; echo ["+i+"] pid is $$$$ > test; cat /tmp/test");
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -221,21 +222,21 @@ public class ContainerExecDecoratorTest {
 
     @Test
     public void testCommandExecutionFailure() throws Exception {
-        ProcReturn r = execCommand(false, "false");
+        ProcReturn r = execCommand(false, false, "false");
         assertEquals(1, r.exitCode);
         assertFalse(r.proc.isAlive());
     }
 
     @Test
     public void testCommandExecutionFailureHighError() throws Exception {
-        ProcReturn r = execCommand(false, "sh", "-c", "return 127");
+        ProcReturn r = execCommand(false, false, "sh", "-c", "return 127");
         assertEquals(127, r.exitCode);
         assertFalse(r.proc.isAlive());
     }
 
     @Test
     public void testQuietCommandExecution() throws Exception {
-        ProcReturn r = execCommand(true, "echo", "pid is 9999");
+        ProcReturn r = execCommand(true, false, "echo", "pid is 9999");
         assertFalse("Output should not contain command: " + r.output, PID_PATTERN.matcher(r.output).find());
         assertEquals(0, r.exitCode);
         assertFalse(r.proc.isAlive());
@@ -243,7 +244,7 @@ public class ContainerExecDecoratorTest {
 
     @Test
     public void testCommandExecutionWithNohup() throws Exception {
-        ProcReturn r = execCommand(false, "nohup", "sh", "-c",
+        ProcReturn r = execCommand(false, false, "nohup", "sh", "-c",
                 "sleep 5; cd /tmp; echo pid is $$$$ > test; cat /tmp/test");
         assertTrue("Output should contain pid: " + r.output, PID_PATTERN.matcher(r.output).find());
         assertEquals(0, r.exitCode);
@@ -261,7 +262,7 @@ public class ContainerExecDecoratorTest {
 
     @Test
     public void testCommandExecutionWithEscaping() throws Exception {
-        ProcReturn r = execCommand(false, "sh", "-c", "cd /tmp; false; echo result is $$? > test; cat /tmp/test");
+        ProcReturn r = execCommand(false, false, "sh", "-c", "cd /tmp; false; echo result is $$? > test; cat /tmp/test");
         assertTrue("Output should contain result: " + r.output,
                 Pattern.compile("^(result is 1)$", Pattern.MULTILINE).matcher(r.output).find());
         assertEquals(0, r.exitCode);
@@ -269,8 +270,35 @@ public class ContainerExecDecoratorTest {
     }
 
     @Test
+    public void testCommandExecutionOutput() throws Exception {
+        String testString = "Should appear once";
+
+        // Check output with quiet=false
+        ProcReturn r = execCommand(false, false, "sh", "-c", "echo " + testString);
+        assertEquals(0, r.exitCode);
+        String output = StringUtils.substringAfter(r.output, "exit");
+        assertEquals(testString, output.trim());
+
+        // Check output with quiet=false and outputForCaller same as launcher output
+        r = execCommand(false, true, "sh", "-c", "echo " + testString);
+        assertEquals(0, r.exitCode);
+        output = StringUtils.substringAfter(r.output, "exit");
+        assertEquals(testString, output.trim());
+
+        // Check output with quiet=true
+        r = execCommand(true, false, "sh", "-c", "echo " + testString);
+        assertEquals(0, r.exitCode);
+        assertEquals("", r.output.trim());
+
+        // Check output with quiet=true and outputForCaller same as launcher output
+        r = execCommand(true, true, "sh", "-c", "echo " + testString);
+        assertEquals(0, r.exitCode);
+        assertEquals(testString, r.output.trim());
+    }
+
+    @Test
     public void testCommandExecutionWithNohupAndError() throws Exception {
-        ProcReturn r = execCommand(false, "nohup", "sh", "-c", "sleep 5; return 127");
+        ProcReturn r = execCommand(false, false, "nohup", "sh", "-c", "sleep 5; return 127");
         assertEquals(127, r.exitCode);
         assertFalse(r.proc.isAlive());
     }
@@ -281,16 +309,16 @@ public class ContainerExecDecoratorTest {
         decorator.setContainerName("doesNotExist");
         exception.expect(KubernetesClientException.class);
         exception.expectMessage(containsString("container doesNotExist is not valid for pod"));
-        execCommand(false, "nohup", "sh", "-c", "sleep 5; return 127");
+        execCommand(false, false, "nohup", "sh", "-c", "sleep 5; return 127");
     }
 
     /**
      * Reproduce JENKINS-55392
-     * 
+     *
      * Caused by: java.util.concurrent.RejectedExecutionException: Task okhttp3.RealCall$AsyncCall@30f55c9f rejected
      * from java.util.concurrent.ThreadPoolExecutor@25634758[Terminated, pool size = 0, active threads = 0, queued tasks
      * = 0, completed tasks = 0]
-     * 
+     *
      * @throws Exception
      */
     @Test
@@ -310,7 +338,7 @@ public class ContainerExecDecoratorTest {
                 try {
                     System.out.println(name + " Connection count: " + httpClient.connectionPool().connectionCount()
                             + " - " + httpClient.connectionPool().idleConnectionCount());
-                    ProcReturn r = execCommand(false, "echo", "test");
+                    ProcReturn r = execCommand(false, false, "echo", "test");
                 } catch (Exception e) {
                     errors.incrementAndGet();
                     System.out.println(e.getMessage());
@@ -340,7 +368,7 @@ public class ContainerExecDecoratorTest {
     @Issue("JENKINS-50429")
     public void testContainerExecPerformance() throws Exception {
         for (int i = 0; i < 10; i++) {
-            ProcReturn r = execCommand(false, "ls");
+            ProcReturn r = execCommand(false, false, "ls");
         }
     }
 
@@ -348,7 +376,7 @@ public class ContainerExecDecoratorTest {
     @Issue("JENKINS-58975")
     public void testContainerExecOnCustomWorkingDir() throws Exception {
         doReturn(null).when((Node)agent).toComputer();
-        ProcReturn r = execCommandInContainer("busybox1", agent, false, "env");
+        ProcReturn r = execCommandInContainer("busybox1", agent, false, false, "env");
         assertTrue("Environment variable workingDir1 should be changed to /home/jenkins/agent1",
                 r.output.contains("workingDir1=/home/jenkins/agent1"));
         assertEquals(0, r.exitCode);
@@ -365,7 +393,7 @@ public class ContainerExecDecoratorTest {
         doReturn(computeEnvVars).when(computer).getEnvironment();
 
         doReturn(computer).when((Node)agent).toComputer();
-        ProcReturn r = execCommandInContainer("busybox1", agent, false, "env");
+        ProcReturn r = execCommandInContainer("busybox1", agent, false, false, "env");
         assertTrue("Environment variable workingDir1 should be changed to /home/jenkins/agent1",
                 r.output.contains("workingDir1=/home/jenkins/agent1"));
         assertTrue("Environment variable MyCustomDir should be changed to /home/jenkins/agent1",
@@ -374,25 +402,28 @@ public class ContainerExecDecoratorTest {
         assertFalse(r.proc.isAlive());
     }
 
-    private ProcReturn execCommand(boolean quiet, String... cmd) throws Exception {
-        return execCommandInContainer(null, null, quiet, cmd);
+    private ProcReturn execCommand(boolean quiet, boolean launcherStdout, String... cmd) throws Exception {
+        return execCommandInContainer(null, null, quiet, launcherStdout, cmd);
     }
 
-    private ProcReturn execCommandInContainer(String containerName, Node node, boolean quiet, String... cmd) throws Exception {
-        if (containerName != null && ! containerName.isEmpty()) {
+    private ProcReturn execCommandInContainer(String containerName, Node node, boolean quiet, boolean launcherStdout, String... cmd) throws Exception {
+        if (containerName != null && !containerName.isEmpty()) {
             decorator.setContainerName(containerName);
         }
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        Launcher launcher = decorator
-                .decorate(new DummyLauncher(new StreamTaskListener(new TeeOutputStream(out, System.out))), node);
+        DummyLauncher dummyLauncher = new DummyLauncher(new StreamTaskListener(new TeeOutputStream(out, System.out)));
+        Launcher launcher = decorator.decorate(dummyLauncher, node);
         Map<String, String> envs = new HashMap<>(100);
         for (int i = 0; i < 50; i++) {
             envs.put("aaaaaaaa" + i, "bbbbbbbb");
         }
         envs.put("workingDir1", "/home/jenkins/agent");
 
-        ContainerExecProc proc = (ContainerExecProc) launcher
-                .launch(launcher.new ProcStarter().pwd("/tmp").cmds(cmd).envs(envs).quiet(quiet));
+        ProcStarter procStarter = launcher.new ProcStarter().pwd("/tmp").cmds(cmd).envs(envs).quiet(quiet);
+        if (launcherStdout) {
+            procStarter.stdout(dummyLauncher.getListener());
+        }
+        ContainerExecProc proc = (ContainerExecProc) launcher.launch(procStarter);
         // wait for proc to finish (shouldn't take long)
         for (int i = 0; proc.isAlive() && i < 200; i++) {
             Thread.sleep(100);


### PR DESCRIPTION
I have an issue when running launcher.launch().stdout(listener) from a different plugin. 

**Background**: 
ContainerExecDecorator decorates the launcher. 

**The issue:**
ContainerExecDecorator's `doLaunch()` gets an OutputStream and splits the output to both the outputForCaller and launcher's logger. In my case, outputForCaller and launcher's logger are the same.

**Expected:** 
All lines printed properly in job's log

**Actual:** 
Lines are printed twice in job's log

**Reconstruction:**
Run [this line](https://github.com/jfrog/project-examples/blob/master/jenkins-examples/pipeline-examples/scripted-examples/maven-example/Jenkinsfile#L18) inside a pod:
```
container('maven') {
    rtMaven.run pom: 'maven-example/pom.xml', goals: 'clean install', buildInfo: buildInfo
}
```

This issue is resolved in 2018 by https://github.com/jenkinsci/kubernetes-plugin/pull/356 and probably reintroduced by https://github.com/jenkinsci/kubernetes-plugin/commit/59a32abad3f5587b8574cb5f28a4139077140ef6.
For more information see: https://github.com/jfrog/project-examples/issues/249