### PR TITLE
[JENKINS-64675] Revert "[JENKINS-62502] `ContainerExecDecorator` should escape double quotes"

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -654,8 +654,7 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
 
         // BourneShellScript.launchWithCookie escapes $ as $$, we convert it to \$
         for (String cmd : starter.cmds()) {
-            String fixedCommand = cmd.replaceAll("\\$\\$", Matcher.quoteReplacement("\\$"))
-                    .replaceAll("\\\"", Matcher.quoteReplacement("\\\""));
+            String fixedCommand = cmd.replaceAll("\\$\\$", "\\\\\\$");
 
             String oldRemoteDir = null;
             FilePath oldRemoteDirFilepath = starter.pwd();

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorTest.java
@@ -270,17 +270,7 @@ public class ContainerExecDecoratorTest {
     }
 
     @Test
-    @Issue("JENKINS-62502")
-    public void testCommandExecutionEscapingDoubleQuotes() throws Exception {
-        ProcReturn r = execCommand(false, false, "sh", "-c", "cd /tmp; false; echo \"result is 1\" > test; cat /tmp/test");
-        assertTrue("Output should contain result: " + r.output,
-                Pattern.compile("^(result is 1)$", Pattern.MULTILINE).matcher(r.output).find());
-        assertEquals(0, r.exitCode);
-        assertFalse(r.proc.isAlive());
-    }
-	
-	@Test
-	public void testCommandExecutionOutput() throws Exception {
+    public void testCommandExecutionOutput() throws Exception {
         String testString = "Should appear once";
 
         // Check output with quiet=false


### PR DESCRIPTION
Reverts jenkinsci/kubernetes-plugin#924

Caused [JENKINS-64675](https://issues.jenkins.io/browse/JENKINS-62502), breaking windows nodes