### PR TITLE
[JENKINS-62502] Escaping double quotes, take 2

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -654,7 +654,8 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
 
         // BourneShellScript.launchWithCookie escapes $ as $$, we convert it to \$
         for (String cmd : starter.cmds()) {
-            String fixedCommand = cmd.replaceAll("\\$\\$", "\\\\\\$");
+            String fixedCommand = cmd.replaceAll("\\$\\$", Matcher.quoteReplacement("\\$"))
+                    .replaceAll("\\\"", Matcher.quoteReplacement("\\\""));
 
             String oldRemoteDir = null;
             FilePath oldRemoteDirFilepath = starter.pwd();

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -336,7 +336,7 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
                     }
                 }
                 return doLaunch(starter.quiet(), fixDoubleDollar(envVars), starter.stdout(), containerWorkingDirFilePath, starter.masks(),
-                        getCommands(starter, containerWorkingDirFilePathStr));
+                        getCommands(starter, containerWorkingDirFilePathStr, launcher.isUnix()));
             }
 
             private Proc doLaunch(boolean quiet, String[] cmdEnvs, OutputStream outputForCaller, FilePath pwd,
@@ -649,13 +649,16 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
         }
     }
 
-    static String[] getCommands(Launcher.ProcStarter starter, String containerWorkingDirStr) {
+    static String[] getCommands(Launcher.ProcStarter starter, String containerWorkingDirStr, boolean unix) {
         List<String> allCommands = new ArrayList<String>();
 
-        // BourneShellScript.launchWithCookie escapes $ as $$, we convert it to \$
+
         for (String cmd : starter.cmds()) {
-            String fixedCommand = cmd.replaceAll("\\$\\$", Matcher.quoteReplacement("\\$"))
-                    .replaceAll("\\\"", Matcher.quoteReplacement("\\\""));
+            // BourneShellScript.launchWithCookie escapes $ as $$, we convert it to \$
+            String fixedCommand = cmd.replaceAll("\\$\\$", Matcher.quoteReplacement("\\$"));
+            if (unix) {
+                fixedCommand = fixedCommand.replaceAll("\\\"", Matcher.quoteReplacement("\\\""));
+            }
 
             String oldRemoteDir = null;
             FilePath oldRemoteDirFilepath = starter.pwd();

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorTest.java
@@ -270,7 +270,17 @@ public class ContainerExecDecoratorTest {
     }
 
     @Test
-    public void testCommandExecutionOutput() throws Exception {
+    @Issue("JENKINS-62502")
+    public void testCommandExecutionEscapingDoubleQuotes() throws Exception {
+        ProcReturn r = execCommand(false, false, "sh", "-c", "cd /tmp; false; echo \"result is 1\" > test; cat /tmp/test");
+        assertTrue("Output should contain result: " + r.output,
+                Pattern.compile("^(result is 1)$", Pattern.MULTILINE).matcher(r.output).find());
+        assertEquals(0, r.exitCode);
+        assertFalse(r.proc.isAlive());
+    }
+	
+	@Test
+	public void testCommandExecutionOutput() throws Exception {
         String testString = "Should appear once";
 
         // Check output with quiet=false

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorTest.java
@@ -25,12 +25,18 @@
 package org.csanchez.jenkins.plugins.kubernetes.pipeline;
 
 import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.*;
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -56,6 +62,8 @@ import org.csanchez.jenkins.plugins.kubernetes.KubernetesClientProvider;
 import org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud;
 import org.csanchez.jenkins.plugins.kubernetes.KubernetesSlave;
 import org.csanchez.jenkins.plugins.kubernetes.PodTemplate;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.junit.After;
 import org.junit.Before;
@@ -253,11 +261,19 @@ public class ContainerExecDecoratorTest {
 
     @Test
     public void commandsEscaping() {
-        ProcStarter procStarter = new DummyLauncher(null).launch();
-        procStarter = procStarter.cmds("$$$$", "$$?");
-
-        String[] commands = ContainerExecDecorator.getCommands(procStarter, null);
-        assertArrayEquals(new String[] { "\\$\\$", "\\$?" }, commands);
+        DummyLauncher launcher = new DummyLauncher(null);
+        assertThat(
+                ContainerExecDecorator.getCommands(launcher.launch().cmds("$$$$", "$$?"), null, true),
+                arrayContaining("\\$\\$", "\\$?")
+        );
+        assertThat(
+                ContainerExecDecorator.getCommands(launcher.launch().cmds("\""), null, true),
+                arrayContaining("\\\"")
+        );
+        assertThat(
+                ContainerExecDecorator.getCommands(launcher.launch().cmds("\"\""), null, false),
+                arrayContaining("\"\"")
+        );
     }
 
     @Test


### PR DESCRIPTION
Double quotes need to be escaped with `\` only on unix environments.

When running on windows, escaping isn't the same (not sure whether there is even a problem), so leave it untouched.