### PR TITLE
JENKINS-64793 Support pvc volume per job to benefit of caching

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodAnnotationProvider.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodAnnotationProvider.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 Falco Nikolas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import javax.annotation.Nonnull;
+
+import hudson.EnvVars;
+import hudson.ExtensionList;
+import hudson.ExtensionPoint;
+import hudson.model.Run;
+
+public class PodAnnotationProvider implements ExtensionPoint {
+
+    @Nonnull
+    public Collection<PodAnnotation> buildFor(Run<?, ?> run) {
+        return Collections.emptyList();
+    }
+
+    @Nonnull
+    public Collection<PodAnnotation> buildFor(EnvVars environment) {
+        return Collections.emptyList();
+    }
+
+    /**
+     * All the registered {@link PodAnnotationProvider}s.
+     */
+    public static ExtensionList<PodAnnotationProvider> all() {
+        return ExtensionList.lookup(PodAnnotationProvider.class);
+    }
+
+}

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -175,6 +175,9 @@ public class PodTemplateBuilder {
             }
         }
 
+        // initialise WorkspaceVolume
+        template.getWorkspaceVolume().processAnnotations(template.getAnnotations());
+
         volumes.put(WORKSPACE_VOLUME_NAME, template.getWorkspaceVolume().buildVolume(WORKSPACE_VOLUME_NAME, agent != null ? agent.getPodName() : null));
 
         Map<String, Container> containers = new HashMap<>();

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes/workspace/WorkspaceVolume.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes/workspace/WorkspaceVolume.java
@@ -25,6 +25,12 @@
 package org.csanchez.jenkins.plugins.kubernetes.volumes.workspace;
 
 import java.io.Serializable;
+import java.util.Collection;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.csanchez.jenkins.plugins.kubernetes.PodAnnotation;
 
 import hudson.model.AbstractDescribableImpl;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
@@ -51,7 +57,17 @@ public abstract class WorkspaceVolume extends AbstractDescribableImpl<WorkspaceV
     // Builds a Volume model with the given name.require podName to generate pvc name
     public Volume buildVolume(String volumeName, String podName){
         return buildVolume(volumeName);
-    };
+    }
+
+    /**
+     * This method is called as first thing to process pod annotations that could have
+     * required informations to build this volume.
+     * 
+     * @param annotations a list of pod annotations defined by template or by
+     *        providers
+     */
+    public void processAnnotations(@Nonnull Collection<PodAnnotation> annotations) {
+    }
 
     // Builds a Volume model with the given name.
     @Deprecated
@@ -62,4 +78,5 @@ public abstract class WorkspaceVolume extends AbstractDescribableImpl<WorkspaceV
     public PersistentVolumeClaim createVolume(KubernetesClient client, ObjectMeta podMetaData) {
         return null;
     }
+
 }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/TestJobAnnotationProvider.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/TestJobAnnotationProvider.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 Falco Nikolas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import hudson.Extension;
+import hudson.model.Run;
+
+@Extension
+public class TestJobAnnotationProvider extends PodAnnotationProvider {
+
+    @Override
+    public Collection<PodAnnotation> buildFor(Run<?, ?> run) {
+        return Arrays.asList(new PodAnnotation("job", run.getParent().getFullName()));
+    }
+
+}

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/TestJobPVCWorkspaceVolume.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/TestJobPVCWorkspaceVolume.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2021 Falco Nikolas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import static java.util.logging.Level.INFO;
+import static org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud.DEFAULT_POD_LABELS;
+import static org.csanchez.jenkins.plugins.kubernetes.PodTemplateUtils.substituteEnv;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
+import org.csanchez.jenkins.plugins.kubernetes.volumes.workspace.WorkspaceVolume;
+import org.jenkinsci.Symbol;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.interceptor.RequirePOST;
+
+import com.google.common.collect.ImmutableMap;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import hudson.util.ListBoxModel;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimBuilder;
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+
+@SuppressWarnings("serial")
+public class TestJobPVCWorkspaceVolume extends WorkspaceVolume {
+    private static final Logger LOGGER = Logger.getLogger(TestJobPVCWorkspaceVolume.class.getName());
+
+    private final String storageClassName;
+    private final String requestsSize;
+    private final String accessModes;
+    private String jobName;
+
+    @DataBoundConstructor
+    public TestJobPVCWorkspaceVolume(String storageClassName,
+                                 @Nonnull String requestsSize,
+                                 String accessModes) {
+        this.storageClassName = storageClassName;
+        this.requestsSize = requestsSize;
+        this.accessModes = accessModes;
+    }
+
+    @CheckForNull
+    public String getAccessModes() {
+        return accessModes;
+    }
+
+    @CheckForNull
+    public String getRequestsSize() {
+        return requestsSize;
+    }
+
+    @CheckForNull
+    public String getStorageClassName() {
+        return storageClassName;
+    }
+
+    @Override
+    public void processAnnotations(Collection<PodAnnotation> annotations) {
+        jobName = annotations.stream() //
+                .filter(a -> "job".equals(a.getKey())) //
+                .findFirst() //
+                .orElseThrow(() -> new IllegalArgumentException("job name not found")) //
+                .getValue();
+    }
+
+    @Override
+    public Volume buildVolume(String volumeName, String podName) {
+        return new VolumeBuilder() //
+                .withName(volumeName) //
+                .withNewPersistentVolumeClaim() //
+                .withClaimName(getPVCName()) //
+                .withReadOnly(true) //
+                .and() //
+                .build();
+    }
+
+    private String getPVCName() {
+        return "pvc-" + jobName.trim().replace(' ', '-').replace('/', '-').toLowerCase();
+    }
+
+    @Override
+    public PersistentVolumeClaim createVolume(KubernetesClient client, ObjectMeta podMetaData) {
+        String namespace = podMetaData.getNamespace();
+        String podId = podMetaData.getName();
+        String pvcName = getPVCName();
+        LOGGER.log(Level.FINE, "Adding workspace volume {0} from pod: {1}/{2}", new Object[] { pvcName, namespace, podId });
+
+        List<PersistentVolumeClaim> pvcs = client.persistentVolumeClaims().list().getItems();
+        PersistentVolumeClaim pvc = pvcs.stream().filter(p -> Objects.equals(p.getMetadata().getName(), pvcName)).findFirst().orElse(null);
+        if (pvc == null) {
+            pvc = new PersistentVolumeClaimBuilder() //
+                    .withNewMetadata() //
+                        .withName(pvcName) //
+                        .withLabels(DEFAULT_POD_LABELS) //
+                    .endMetadata() //
+                    .withNewSpec() //
+                        .withAccessModes(getAccessModesOrDefault()) //
+                        .withNewResources() //
+                            .withRequests(getResourceMap()) //
+                        .endResources() //
+                        .withStorageClassName(getStorageClassNameOrDefault()) //
+                    .endSpec() //
+                    .build();
+            pvc = client.persistentVolumeClaims().inNamespace(podMetaData.getNamespace()).create(pvc);
+            LOGGER.log(INFO, "Created PVC: {0}/{1}", new Object[] { namespace, pvc.getMetadata().getName() });
+        }
+        return pvc;
+    }
+
+    public String getStorageClassNameOrDefault() {
+        if (getStorageClassName() != null) {
+            return getStorageClassName();
+        }
+        return null;
+    }
+
+    public String getAccessModesOrDefault() {
+        if (getAccessModes() != null) {
+            return getAccessModes();
+        }
+        return "ReadWriteOnce";
+    }
+
+    public String getRequestsSizeOrDefault() {
+        if (getRequestsSize() != null) {
+            return getRequestsSize();
+        }
+        return "10Gi";
+    }
+
+    protected Map<String, Quantity> getResourceMap() {
+        ImmutableMap.Builder<String, Quantity> builder = ImmutableMap.<String, Quantity> builder();
+        String actualStorage = substituteEnv(getRequestsSizeOrDefault());
+        Quantity storageQuantity = new Quantity(actualStorage);
+        builder.put("storage", storageQuantity);
+        return builder.build();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        TestJobPVCWorkspaceVolume that = (TestJobPVCWorkspaceVolume) o;
+        return Objects.equals(storageClassName, that.storageClassName) //
+                && Objects.equals(requestsSize, that.requestsSize) //
+                && Objects.equals(accessModes, that.accessModes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(storageClassName, requestsSize, accessModes);
+    }
+
+    @Extension
+    @Symbol("jobPVC")
+    public static class DescriptorImpl extends Descriptor<WorkspaceVolume> {
+
+        private static final ListBoxModel ACCESS_MODES_BOX = new ListBoxModel() //
+                .add("ReadWriteOnce") //
+                .add("ReadOnlyMany") //
+                .add("ReadWriteMany");
+
+        @Override
+        public String getDisplayName() {
+            return "Per Job Persistent Volume Claim Workspace Volume";
+        }
+
+        @RequirePOST
+        @Restricted(DoNotUse.class) // stapler only
+        public ListBoxModel doFillAccessModesItems() {
+            return ACCESS_MODES_BOX;
+        }
+    }
+}


### PR DESCRIPTION
With this PR I would be able WorkspaceVolume extension to get additional information than podName to create a PVC based on logic different than actual, for example create a PVC per job to gain the caching of downloaded tools, partial GIT checkout, maven local repository or npm packages....from a build and the next one.
I proposed two commits
* the first a proposal of change that if you agree I I will also provide a test case.
* the second contains a **partial sample implementation** to create PVCs per job