### PR TITLE
Kubernetes Pod Template Labels are not known to Jenkins.

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -421,7 +421,11 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
     }
 
     public Set<LabelAtom> getLabelSet() {
-        return Label.parse(label);
+        Set<LabelAtom> labelAtoms = Label.parse(label);
+        if (name != null) {
+            labelAtoms.add(LabelAtom.get(name));
+        }
+        return labelAtoms;
     }
 
     public Map<String, String> getLabelsMap() {
@@ -455,6 +459,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
     @DataBoundSetter
     public void setLabel(String label) {
         this.label = Util.fixEmptyAndTrim(label);
+        getLabelSet();
     }
 
     public String getLabel() {
@@ -850,6 +855,8 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
             // Use the label and a digest of the current object representation to get the same value every restart if the object isn't saved.
             id = getLabel() + "-" + Util.getDigestOf(toString());
         }
+        // Eagerly Instantiate LabelAtoms
+        getLabelSet();
 
         return this;
     }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateJenkinsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateJenkinsTest.java
@@ -1,13 +1,17 @@
 package org.csanchez.jenkins.plugins.kubernetes;
 
+import hudson.model.Label;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.csanchez.jenkins.plugins.kubernetes.PodTemplate.LABEL_DIGEST_FUNCTION;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
 
 public class PodTemplateJenkinsTest {
@@ -42,5 +46,17 @@ public class PodTemplateJenkinsTest {
         Map<String, String> labelsMap = podTemplate.getLabelsMap();
         assertEquals("slave-default", labelsMap.get("jenkins/label"));
         assertEquals("0", labelsMap.get("jenkins/label-digest"));
+    }
+
+    @Test
+    public void jenkinsLabels() {
+        KubernetesCloud kubernetesCloud = new KubernetesCloud("kubernetes");
+        j.jenkins.clouds.add(kubernetesCloud);
+        PodTemplate podTemplate = new PodTemplate();
+        kubernetesCloud.addTemplate(podTemplate);
+        podTemplate.setName("foo");
+        podTemplate.setLabel("bar baz");
+        assertThat(j.jenkins.getLabels().stream().map(Label::getName).collect(Collectors.toSet()),
+                containsInAnyOrder("master", "foo", "bar", "baz"));
     }
 }


### PR DESCRIPTION
Labels used to be parsed only at the first call to KubernetesCloud canProvision/provision. I meant they were not immediately available in the label autocompletes or any other features relying on `Jenkins#getLabels()`. Parsing this labels in the readResolve and field setter should make them immediately available.