### PR TITLE
Create labels on pod template creation

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -210,6 +210,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
         } else {
             this.id = id;
         }
+        recomputeLabelDerivedFields();
     }
 
     public PodTemplate(PodTemplate from) {
@@ -217,6 +218,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
         xs.unmarshal(XStream2.getDefaultDriver().createReader(new StringReader(xs.toXML(from))), this);
         this.yamls = from.yamls;
         this.listener = from.listener;
+        recomputeLabelDerivedFields();
     }
 
     @Deprecated

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateJenkinsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateJenkinsTest.java
@@ -1,13 +1,17 @@
 package org.csanchez.jenkins.plugins.kubernetes;
 
+import hudson.model.Label;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.csanchez.jenkins.plugins.kubernetes.PodTemplate.LABEL_DIGEST_FUNCTION;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
 
 public class PodTemplateJenkinsTest {
@@ -42,5 +46,19 @@ public class PodTemplateJenkinsTest {
         Map<String, String> labelsMap = podTemplate.getLabelsMap();
         assertEquals("slave-default", labelsMap.get("jenkins/label"));
         assertEquals("0", labelsMap.get("jenkins/label-digest"));
+    }
+
+    @Test
+    public void jenkinsLabels() {
+        KubernetesCloud kubernetesCloud = new KubernetesCloud("kubernetes");
+        j.jenkins.clouds.add(kubernetesCloud);
+        PodTemplate podTemplate = new PodTemplate();
+        kubernetesCloud.addTemplate(podTemplate);
+        podTemplate.setLabel("foo bar");
+        assertThat(j.jenkins.getLabels().stream()
+                .map(Label::getName)
+                .collect(Collectors.toSet()),
+                containsInAnyOrder("master", "foo", "bar")
+        );
     }
 }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar;
 import org.csanchez.jenkins.plugins.kubernetes.model.SecretEnvVar;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.HostPathVolume;
+import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
@@ -62,8 +63,12 @@ import io.fabric8.kubernetes.api.model.SecretEnvSource;
 import io.fabric8.kubernetes.api.model.Toleration;
 import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
+import org.jvnet.hudson.test.JenkinsRule;
 
 public class PodTemplateUtilsTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
 
     private static final PodImagePullSecret SECRET_1 = new PodImagePullSecret("secret1");
     private static final PodImagePullSecret SECRET_2 = new PodImagePullSecret("secret2");


### PR DESCRIPTION
Based on #961

* `labelSet` and `labelMap` are now updated every time `label` is updated.
* Jenkins indexes `Label` instances on creation. Since the `Cloud` doesn't offer a `getLabels` method, this is the only way to provide intel to Jenkins that labels can be satisfied.