### PR TITLE
Limits: fix some cases where unregistration doesn't happen

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -568,10 +568,6 @@ public class KubernetesCloud extends Cloud {
         return Collections.emptyList();
     }
 
-    public void onTerminate(@NonNull KubernetesSlave slave) {
-        KubernetesProvisioningLimits.get().unregister(slave.getKubernetesCloud(), slave.getTemplate(), slave.getNumExecutors());
-    }
-
     @Override
     public boolean canProvision(@NonNull Cloud.CloudState state) {
         return getTemplate(state.getLabel()) != null;

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
@@ -293,7 +293,6 @@ public class KubernetesSlave extends AbstractCloudSlave {
             LOGGER.log(Level.SEVERE, String.format("Unable to terminate agent %s. Cloud may have been removed. There may be leftover resources on the Kubernetes cluster.", name));
             return;
         }
-        cloud.onTerminate(this);
 
         KubernetesClient client;
         try {


### PR DESCRIPTION
Following some issues reported in https://github.com/jenkinsci/kubernetes-plugin/pull/939, I noticed some calls to `Jenkins.get().removeNode(...)` which were not caught, and actually a better way is probably to listen directly to deletion events.