### PR TITLE
feat: Allow override of scheduler name spec field

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -124,6 +124,8 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
 
     private String serviceAccount;
 
+    private String schedulerName;
+
     private String nodeSelector;
 
     private Node.Mode nodeUsageMode;
@@ -565,6 +567,15 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
     @DataBoundSetter
     public void setServiceAccount(String serviceAccount) {
         this.serviceAccount = Util.fixEmpty(serviceAccount);
+    }
+
+    public String getSchedulerName() {
+        return schedulerName;
+    }
+
+    @DataBoundSetter
+    public void setSchedulerName(String schedulerName) {
+        this.schedulerName = Util.fixEmpty(schedulerName);
     }
 
     @Deprecated
@@ -1018,6 +1029,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
                 (activeDeadlineSeconds == 0 ? "" : ", activeDeadlineSeconds=" + activeDeadlineSeconds) +
                 (label == null ? "" : ", label='" + label + '\'') +
                 (serviceAccount == null ? "" : ", serviceAccount='" + serviceAccount + '\'') +
+                (schedulerName == null ? "" : ", schedulerName='" + schedulerName + '\'') +
                 (nodeSelector == null ? "" : ", nodeSelector='" + nodeSelector + '\'') +
                 (nodeUsageMode == null ? "" : ", nodeUsageMode=" + nodeUsageMode) +
                 (resourceRequestCpu == null ? "" : ", resourceRequestCpu='" + resourceRequestCpu + '\'') +

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -215,6 +215,9 @@ public class PodTemplateBuilder {
         if (template.getServiceAccount() != null) {
             builder.withServiceAccountName(substituteEnv(template.getServiceAccount()));
         }
+        if (template.getSchedulerName() != null) {
+            builder.withSchedulerName(substituteEnv(template.getSchedulerName()));
+        }
 
         List<LocalObjectReference> imagePullSecrets = template.getImagePullSecrets().stream()
                 .map((x) -> x.toLocalObjectReference()).collect(Collectors.toList());

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
@@ -250,6 +250,9 @@ public class PodTemplateUtils {
         String serviceAccountName = Strings.isNullOrEmpty(template.getSpec().getServiceAccountName())
                 ? parent.getSpec().getServiceAccountName()
                 : template.getSpec().getServiceAccountName();
+        String schedulerName = Strings.isNullOrEmpty(template.getSpec().getSchedulerName())
+                ? parent.getSpec().getSchedulerName()
+                 : template.getSpec().getSchedulerName();
 
         Boolean hostNetwork = template.getSpec().getHostNetwork() != null
                 ? template.getSpec().getHostNetwork()
@@ -298,6 +301,7 @@ public class PodTemplateUtils {
                 .withNodeSelector(nodeSelector) //
                 .withServiceAccount(serviceAccount) //
                 .withServiceAccountName(serviceAccountName) //
+                .withSchedulerName(schedulerName)
                 .withHostNetwork(hostNetwork) //
                 .withContainers(combinedContainers) //
                 .withInitContainers(combinedInitContainers) //
@@ -371,6 +375,7 @@ public class PodTemplateUtils {
         String label = template.getLabel();
         String nodeSelector = Strings.isNullOrEmpty(template.getNodeSelector()) ? parent.getNodeSelector() : template.getNodeSelector();
         String serviceAccount = Strings.isNullOrEmpty(template.getServiceAccount()) ? parent.getServiceAccount() : template.getServiceAccount();
+        String schedulerName = Strings.isNullOrEmpty(template.getSchedulerName()) ? parent.getSchedulerName() : template.getSchedulerName();
         Node.Mode nodeUsageMode = template.getNodeUsageMode() == null ? parent.getNodeUsageMode() : template.getNodeUsageMode();
 
         Set<PodAnnotation> podAnnotations = new LinkedHashSet<>();
@@ -406,6 +411,7 @@ public class PodTemplateUtils {
         podTemplate.setLabel(label);
         podTemplate.setNodeSelector(nodeSelector);
         podTemplate.setServiceAccount(serviceAccount);
+        podTemplate.setSchedulerName(schedulerName);
         podTemplate.setEnvVars(combineEnvVars(parent, template));
         podTemplate.setContainers(new ArrayList<>(combinedContainers.values()));
         podTemplate.setWorkspaceVolume(workspaceVolume);
@@ -433,6 +439,9 @@ public class PodTemplateUtils {
 
         podTemplate.setServiceAccount(!Strings.isNullOrEmpty(template.getServiceAccount()) ?
                                       template.getServiceAccount() : parent.getServiceAccount());
+
+        podTemplate.setSchedulerName(!Strings.isNullOrEmpty(template.getSchedulerName()) ?
+                                      template.getSchedulerName() : parent.getSchedulerName());
 
         podTemplate.setPodRetention(template.getPodRetention());
         podTemplate.setShowRawYaml(template.isShowRawYamlSet() ? template.isShowRawYaml() : parent.isShowRawYaml());

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgent.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgent.java
@@ -53,6 +53,8 @@ public class KubernetesDeclarativeAgent extends DeclarativeAgent<KubernetesDecla
     @CheckForNull
     private String serviceAccount;
     @CheckForNull
+    private String schedulerName;
+    @CheckForNull
     private String nodeSelector;
     @CheckForNull
     private String namespace;
@@ -161,6 +163,15 @@ public class KubernetesDeclarativeAgent extends DeclarativeAgent<KubernetesDecla
     @DataBoundSetter
     public void setServiceAccount(String serviceAccount) {
         this.serviceAccount = serviceAccount;
+    }
+
+    public String getSchedulerName() {
+        return schedulerName;
+    }
+
+    @DataBoundSetter
+    public void setSchedulerName(String schedulerName) {
+        this.schedulerName = schedulerName;
     }
 
     public String getNodeSelector() {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep.java
@@ -79,6 +79,9 @@ public class PodTemplateStep extends Step implements Serializable {
     private String serviceAccount;
 
     @CheckForNull
+    private String schedulerName;
+
+    @CheckForNull
     private String nodeSelector;
 
     private Node.Mode nodeUsageMode = Node.Mode.EXCLUSIVE;
@@ -267,6 +270,14 @@ public class PodTemplateStep extends Step implements Serializable {
     @DataBoundSetter
     public void setServiceAccount(@CheckForNull String serviceAccount) {
         this.serviceAccount = Util.fixEmpty(serviceAccount);
+    }
+
+    @CheckForNull
+    public String getSchedulerName() { return schedulerName; }
+
+    @DataBoundSetter
+    public void setSchedulerName(@CheckForNull String schedulerName) {
+        this.schedulerName = Util.fixEmpty(schedulerName);
     }
 
     @CheckForNull

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
@@ -107,6 +107,7 @@ public class PodTemplateStepExecution extends AbstractStepExecutionImpl {
         newTemplate.setNodeSelector(step.getNodeSelector());
         newTemplate.setNodeUsageMode(step.getNodeUsageMode());
         newTemplate.setServiceAccount(step.getServiceAccount());
+        newTemplate.setSchedulerName(step.getSchedulerName());
         newTemplate.setRunAsUser(step.getRunAsUser());
         newTemplate.setRunAsGroup(step.getRunAsGroup());
         if (step.getHostNetwork() != null) {

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
@@ -636,6 +636,31 @@ public class PodTemplateBuilderTest {
     }
 
     @Test
+    public void yamlOverrideSchedulerName() {
+        PodTemplate parent = new PodTemplate();
+        parent.setYaml(
+                "apiVersion: v1\n" +
+                "kind: Pod\n" +
+                "metadata:\n" +
+                "  labels:\n" +
+                "    some-label: some-label-value\n" +
+                "spec:\n" +
+                "  schedulerName: default-scheduler\n"
+        );
+
+        PodTemplate child = new PodTemplate();
+        child.setYaml(
+                "spec:\n" +
+                "  schedulerName: custom-scheduler\n"
+        );
+        child.setInheritFrom("parent");
+        child.setYamlMergeStrategy(merge());
+        PodTemplate result = combine(parent, child);
+        Pod pod = new PodTemplateBuilder(result, slave).build();
+        assertEquals("custom-scheduler", pod.getSpec().getSchedulerName());
+    }
+
+    @Test
     public void yamlOverrideSecurityContext() {
         PodTemplate parent = new PodTemplate();
         parent.setYaml(


### PR DESCRIPTION
I have a small cluster with nodes of varying capabilities where a custom scheduler is required. I'm able to set the `spec.schedulerName` field in my Jenkinsfile however the value is ignored (verified by checking the resultant YAML contents in the Jenkins logs). I've also tried adding the field to the pod template raw YAML config but this also seemed to be ignored.

This change will read the scheduler name field, if supplied, and add it to the final YAML output.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
