### PR TITLE
Jenkins 61360

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgent.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgent.java
@@ -73,6 +73,8 @@ public class KubernetesDeclarativeAgent extends DeclarativeAgent<KubernetesDecla
     private String yaml;
     @CheckForNull
     private String yamlFile;
+    @CheckForNull
+    private Boolean showRawYaml;
     private YamlMergeStrategy yamlMergeStrategy;
     @CheckForNull
     private WorkspaceVolume workspaceVolume;
@@ -272,6 +274,15 @@ public class KubernetesDeclarativeAgent extends DeclarativeAgent<KubernetesDecla
     }
 
     @DataBoundSetter
+    public void setShowRawYaml(Boolean showRawYaml) {
+        this.showRawYaml = showRawYaml;
+    }
+
+    public Boolean getShowRawYaml() {
+        return showRawYaml;
+    }
+
+    @DataBoundSetter
     public void setYamlFile(String yamlFile) {
         this.yamlFile = yamlFile;
     }
@@ -327,6 +338,9 @@ public class KubernetesDeclarativeAgent extends DeclarativeAgent<KubernetesDecla
         if (!StringUtils.isEmpty(yaml)) {
             argMap.put("yaml", yaml);
         }
+        if (showRawYaml != null) {
+            argMap.put("showRawYaml", showRawYaml);
+        }
         if (yamlMergeStrategy != null) {
             argMap.put("yamlMergeStrategy", yamlMergeStrategy);
         }
@@ -377,7 +391,7 @@ public class KubernetesDeclarativeAgent extends DeclarativeAgent<KubernetesDecla
     @Symbol("kubernetes")
     public static class DescriptorImpl extends DeclarativeAgentDescriptor<KubernetesDeclarativeAgent> {
 
-        static final String[] POD_TEMPLATE_FIELDS = {"namespace", "inheritFrom", "yaml", "instanceCap", "podRetention", "supplementalGroups", "idleMinutes", "activeDeadlineSeconds", "serviceAccount", "nodeSelector", "workingDir", "workspaceVolume"};
+        static final String[] POD_TEMPLATE_FIELDS = {"namespace", "inheritFrom", "yaml", "showRawYaml", "instanceCap", "podRetention", "supplementalGroups", "idleMinutes", "activeDeadlineSeconds", "serviceAccount", "nodeSelector", "workingDir", "workspaceVolume"};
 
         public DescriptorImpl() {
             for (String field: new String[] {"cloud", "label"}) {

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgentTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgentTest.java
@@ -169,4 +169,12 @@ public class KubernetesDeclarativeAgentTest extends AbstractKubernetesPipelineTe
         r.assertBuildStatus(Result.FAILURE, r.waitForCompletion(b));
         r.assertLogContains("ERROR: Unable to pull Docker image", b);
     }
+
+    @Issue("JENKINS-61360")
+    @Test
+    public void declarativeShowRawYamlFalse() throws Exception {
+        assertNotNull(createJobThenScheduleRun());
+        r.assertBuildStatusSuccess(r.waitForCompletion(b));
+        r.assertLogContains("CONTAINER_ENV_VAR = jnlp\n", b);
+    }
 }

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/declarativeShowRawYamlFalse.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/declarativeShowRawYamlFalse.groovy
@@ -1,0 +1,29 @@
+pipeline {
+  agent {
+    kubernetes {
+      showRawYaml false
+      yaml '''
+metadata:
+  labels:
+    some-label: some-label-value
+    class: KubernetesDeclarativeAgentTest
+spec:
+  containers:
+  - name: jnlp
+    env:
+    - name: CONTAINER_ENV_VAR
+      value: jnlp
+'''
+    }
+  }
+  stages {
+    stage('Run') {
+      steps {
+        sh 'set'
+        container('jnlp') {
+          sh 'echo CONTAINER_ENV_VAR = ${CONTAINER_ENV_VAR}'
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Added ShowRawYaml support for declarative pipelines: [JENKINS-61360](https://issues.jenkins.io/browse/JENKINS-61360)

Modified org.csanchez.jenkins.plugins.kubernetes.pipeline.KubernetesDeclarativeAgent with boolean showRawYaml, that allow to set the value in declarative pipeline. Same class, change the method getAsArgs() to pass new var value to PodTemplate field.

New test created at KubernetesDeclarativeAgentTest.declarativeShowRawYamlFalse() with associated resource declarativeShowRawYamlFalse.groovy, that contains a declarative pipeline with new param showRawYaml to false and a yaml agent. If the kubernetes agent not crash, the new variable do the job and hide the pod yaml.

