### PR TITLE
[JENKINS-65415] Map listener on inheritance

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
@@ -460,6 +460,7 @@ public class PodTemplateUtils {
         List<String> yamls = new ArrayList<>(parent.getYamls());
         yamls.addAll(template.getYamls());
         podTemplate.setYamls(yamls);
+        podTemplate.setListener(template.getListener());
 
         LOGGER.log(Level.FINEST, "Pod templates combined: {0}", podTemplate);
         return podTemplate;

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
@@ -207,6 +207,7 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
         r.assertBuildStatusSuccess(r.waitForCompletion(b));
         r.assertLogContains("container=busybox", b);
         r.assertLogContains("script file contents: ", b);
+        r.assertLogContains("Created container jnlp", b);
         assertFalse("There are pods leftover after test execution, see previous logs",
                 deletePods(cloud.connect(), getLabels(cloud, this, name), true));
         assertThat("routine build should not issue warnings",
@@ -289,6 +290,15 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
     public void bourneShellElsewhereInPath() throws Exception {
         r.assertBuildStatusSuccess(r.waitForCompletion(b));
         r.assertLogContains("/kaniko:/busybox", b);
+    }
+
+    @Test
+    public void inheritFrom() throws Exception {
+        PodTemplate standard = new PodTemplate();
+        standard.setName("standard");
+        cloud.addTemplate(standard);
+        r.assertBuildStatusSuccess(r.waitForCompletion(b));
+        r.assertLogContains("Created container jnlp", b);
     }
 
     @Test

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/inheritFrom.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/inheritFrom.groovy
@@ -1,0 +1,5 @@
+podTemplate(inheritFrom: 'standard') {
+  node(POD_LABEL) {
+    sh 'true'
+  }
+}


### PR DESCRIPTION
Pod events streaming is not happening when using inheritance because the listener is not copied to the combined pod template.

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
