### PR TITLE
[bugfix] Retry Exec Commands

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>org.csanchez.jenkins.plugins</groupId>
   <artifactId>kubernetes</artifactId>
-  <version>1.28.6</version>
+  <version>1.28.6-fastly</version>
   <name>Kubernetes plugin</name>
   <description>Jenkins plugin to run dynamic agents in a Kubernetes cluster</description>
   <packaging>hpi</packaging>


### PR DESCRIPTION
GKE has some magic with how ssh-tunnels are built into the node-pool,
many of which fail for a number of reasons (connection gets
interrupted). Since EXEC operations now happen via an API call, add
retry logic to catch (ProxyException) and re-attempt the call
(re-establish new ssh-tunnel to nodepool)

