### PR TITLE
Increase default connection timeout to 1000 seconds.

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -67,10 +67,10 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
     private static final Logger LOGGER = Logger.getLogger(PodTemplate.class.getName());
 
     /**
-     * Connection timeout expiration in seconds, default to 100 seconds
+     * Connection timeout expiration in seconds, default to 1000 seconds
      */
     public static final Integer DEFAULT_SLAVE_JENKINS_CONNECTION_TIMEOUT = Integer
-            .getInteger(PodTemplate.class.getName() + ".connectionTimeout", 100);
+            .getInteger(PodTemplate.class.getName() + ".connectionTimeout", 1000);
 
     /**
      * Digest function that is used to compute the kubernetes label "jenkins/label-digest"


### PR DESCRIPTION
100 seconds is too low to handle pulling windows images which can be very large (~10G). Also helps those with slow network.

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
