### PR TITLE
Mask dots in generated pod names

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
@@ -182,7 +182,7 @@ public class PodTemplateStepExecution extends AbstractStepExecutionImpl {
         if (input.length() > max) {
             input = input.substring(input.length() - max);
         }
-        input = input.replaceAll("[^_.a-zA-Z0-9-]", "_").replaceFirst("^[^a-zA-Z0-9]", "x");
+        input = input.replaceAll("[^_a-zA-Z0-9-]", "_").replaceFirst("^[^a-zA-Z0-9]", "x");
         String label = input + "-" + RandomStringUtils.random(5, "bcdfghjklmnpqrstvwxz0123456789");
         assert PodTemplateUtils.validateLabel(label) : label;
         return label;


### PR DESCRIPTION
I've hit some issue while executing tests - the problem was that `java.net.URI` was not parsing the `host` part for some urls like:

```
    URI u3 = URI.create("http://asd-7.1-asd:15002");
    System.out.println(u3.getHost()); // this will be null
```

the issue was that there is a special check in the URI parser - which requires that the last uri part must start with an alpha
https://github.com/frohoff/jdk8u-jdk/blob/master/src/share/classes/java/net/URI.java#L3395

This caused an issue because I left the name of the `podTemplate` empty - and let the plugin name the pods ; and since I had a version number in the job name this have sparked the above issue.

Tracking down this was hard; but fixing it is easy - also mask dots with underscores; as it is done for other chars.



- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
