### PR TITLE
change pod template entrypoint from sleep to null

### DIFF
--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/config.jelly
@@ -23,11 +23,11 @@
   </f:entry>
 
   <f:entry field="command" title="${%Command to run}">
-    <f:textbox default="sleep"/>
+    <f:textbox/>
   </f:entry>
 
   <f:entry field="args" title="${%Arguments to pass to the command}">
-    <f:textbox default="9999999"/>
+    <f:textbox/>
   </f:entry>
 
   <f:entry field="ttyEnabled" title="${%Allocate pseudo-TTY}">


### PR DESCRIPTION
change pod template entrypoint from sleep to null, which let it using default entrypoint by image.
jenkins ci agent always using jnlp, which have default entrypoint(and a lot of docker images do) , but this sleep can cover default entrypoint , and cause problems.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
