### PR TITLE
Use linked hashmap to keep container order as defined in pod template

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
@@ -346,9 +346,9 @@ public class PodTemplateUtils {
     private static List<Container> combineContainers(List<Container> parent, List<Container> child) {
         LinkedHashMap<String, Container> combinedContainers = new LinkedHashMap<>(); // Need to retain insertion order
         Map<String, Container> parentContainers = parent.stream()
-                .collect(toMap(Container::getName, c -> c));
+                .collect(toMap(Container::getName, c -> c, throwingMerger(), LinkedHashMap::new));
         Map<String, Container> childContainers = child.stream()
-                .collect(toMap(Container::getName, c -> combine(parentContainers.get(c.getName()), c)));
+                .collect(toMap(Container::getName, c -> combine(parentContainers.get(c.getName()), c), throwingMerger(), LinkedHashMap::new));
         combinedContainers.putAll(parentContainers);
         combinedContainers.putAll(childContainers);
         return new ArrayList<>(combinedContainers.values());

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
@@ -36,6 +36,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar;
 import org.csanchez.jenkins.plugins.kubernetes.model.SecretEnvVar;
@@ -608,6 +609,21 @@ public class PodTemplateUtilsTest {
         assertQuantity("2Gi", result.getResources().getLimits().get("memory"));
         assertQuantity("200m", result.getResources().getRequests().get("cpu"));
         assertQuantity("256Mi", result.getResources().getRequests().get("memory"));
+    }
+
+    @Test
+    public void shouldCombineContainersInOrder() {
+        Container container1 = containerBuilder().withName("mysql").build();
+        Container container2 = containerBuilder().withName("jnlp").build();
+        Pod pod1 = podBuilder().withContainers(container1, container2).endSpec().build();
+        
+        Container container3 = containerBuilder().withName("alpine").build();
+        Container container4 = containerBuilder().withName("node").build();
+        Container container5 = containerBuilder().withName("mvn").build();
+        Pod pod2 = podBuilder().withContainers(container3, container4, container5).endSpec().build();
+        
+        Pod result = combine(pod1, pod2);
+        assertEquals(Arrays.asList("mysql", "jnlp", "alpine", "node", "mvn"), result.getSpec().getContainers().stream().map(Container::getName).collect(Collectors.toList()));
     }
 
     /**


### PR DESCRIPTION
This pr uses linked hashmap so that the containers can be started in the order specified by the template. This is useful in scenarios where backing services needs to be started first.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
