### PR TITLE
[JENKINS-66049] Prevent NPE on cancelQueueItemFor

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
@@ -145,7 +145,10 @@ public class KubernetesLauncher extends JNLPLauncher {
                     }
                     else {
                         runListener.getLogger().printf("ERROR: Unable to create pod %s %s/%s.%n%s%n", cloudName, namespace, pod.getMetadata().getName(), e.getMessage());
-                        PodUtils.cancelQueueItemFor(pod, e.getMessage());
+                        // Only pod template originating from a pod template step have the sufficient annotations to filter the tasks
+                        if (pod.getMetadata().getAnnotations() != null) {
+                            PodUtils.cancelQueueItemFor(pod, e.getMessage());
+                        }
                     }
                 } else if (500 <= httpCode && httpCode < 600) { // 5xx
                     LOGGER.log(FINE,"Kubernetes returned HTTP code {0} {1}. Retrying...", new Object[] {e.getCode(), e.getStatus()});


### PR DESCRIPTION
[JENKINS-66049](https://issues.jenkins.io/browse/JENKINS-66049) Check that `pod.getMetadata().getAnnotations()` is not null before calling `cancelQueueItemFor` to avoid NPEs for pod launched from global templates rather than PodTemplateStepExecutions.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue