### PR TITLE
JENKINS-66484 - Tentative fix of a race condition in KubernetesProvisioningLimits

### DIFF
--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesProvisioningLimitsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesProvisioningLimitsTest.java
@@ -1,21 +1,24 @@
 package org.csanchez.jenkins.plugins.kubernetes;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.LoggerRule;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.logging.Level;
-
-import static org.junit.Assert.assertEquals;
-
 public class KubernetesProvisioningLimitsTest {
+
     @Rule
     public JenkinsRule j = new JenkinsRule();
 
@@ -25,40 +28,63 @@ public class KubernetesProvisioningLimitsTest {
     @Test
     public void lotsOfCloudsAndTemplates() throws InterruptedException {
         ThreadLocalRandom testRandom = ThreadLocalRandom.current();
-        for (int i = 1; i <= 10; i++) {
+        for (int i = 1; i < 4; i++) {
             KubernetesCloud cloud = new KubernetesCloud("kubernetes-" + i);
-            cloud.setContainerCap(testRandom.nextInt(40)+1);
-            for (int j = 1; j < 10; j++) {
+            cloud.setContainerCap(testRandom.nextInt(4)+1);
+            for (int j = 1; j < 4; j++) {
                 PodTemplate pt = new PodTemplate();
+                pt.setName(cloud.name + "-podTemplate-" + j);
                 pt.setInstanceCap(testRandom.nextInt(4)+1);
                 cloud.addTemplate(pt);
             }
             j.jenkins.clouds.add(cloud);
         }
-        ExecutorService EXEC = Executors.newFixedThreadPool(100);
-        List<Callable<Void>> tasks = new ArrayList<>();
+
+        ExecutorService threadPool = Executors.newCachedThreadPool();
+        System.out.println(threadPool.getClass().getName());
+        CompletionService<Void> ecs = new ExecutorCompletionService<>(threadPool);
+        KubernetesProvisioningLimits kubernetesProvisioningLimits = KubernetesProvisioningLimits.get();
+
+        List<KubernetesCloud> clouds = j.jenkins.clouds.getAll(KubernetesCloud.class);
         for (int k = 0 ; k < 1000; k++) {
-            Callable<Void> c = () -> {
+            ecs.submit(() -> {
                 ThreadLocalRandom random = ThreadLocalRandom.current();
-                List<KubernetesCloud> clouds = j.jenkins.clouds.getAll(KubernetesCloud.class);
                 KubernetesCloud cloud = clouds.get(random.nextInt(clouds.size()));
                 List<PodTemplate> templates = cloud.getTemplates();
                 PodTemplate podTemplate = templates.get(random.nextInt(templates.size()));
-                if (KubernetesProvisioningLimits.get().register(cloud, podTemplate, 1)) {
-                    Thread.sleep(random.nextInt(3) * 1000);
-                    KubernetesProvisioningLimits.get().unregister(cloud, podTemplate, 1);
+                while (!kubernetesProvisioningLimits.register(cloud, podTemplate, 1)) {
+                    try {
+                        Thread.sleep(8);
+                    } catch(InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        break;
+                    }
                 }
-                return null;
-            };
-            tasks.add(c);
+
+                ecs.submit(() -> {
+                    kubernetesProvisioningLimits.unregister(cloud, podTemplate, 1);
+                }, null);
+            }, null);
         }
-        EXEC.invokeAll(tasks);
+
+        while (ecs.poll(20, TimeUnit.SECONDS) != null) {
+            try {
+                Thread.sleep(8);
+            } catch(InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+
+        threadPool.shutdown();
+        assertTrue(threadPool.awaitTermination(60, TimeUnit.SECONDS));
+        assertTrue(threadPool.shutdownNow().size() == 0);
 
         // Check that every count is back to 0
         for (KubernetesCloud cloud : j.jenkins.clouds.getAll(KubernetesCloud.class)) {
-            assertEquals(0, KubernetesProvisioningLimits.get().getGlobalCount(cloud.name).get());
+            assertEquals(0, KubernetesProvisioningLimits.get().getGlobalCount(cloud.name));
             for (PodTemplate template : cloud.getTemplates()) {
-                assertEquals(0, KubernetesProvisioningLimits.get().getPodTemplateCount(template.getId()).get());
+                assertEquals(0, KubernetesProvisioningLimits.get().getPodTemplateCount(template.getId()));
             }
         }
     }


### PR DESCRIPTION
This change provides a more sound concurrent code rather than double locking on `AtomicInteger` + `SynchronizedMap`. The class now relied on internal locking mechanism and ensure that `#init` method is properly synchronized as well. 

I was not able to reproduce the issue described in [JENKINS-66484](https://issues.jenkins.io/browse/JENKINS-66484) but at least this code does not break it either.

Talking about unit tests, I decreased the number of clouds and templates in order to raise the possibility of a race condition. I also ensured that `#register` and `#unregister` are all called from separate threads. Finally, I replaced the `if` checking the return value of `#register` by a `while`, as we want to test all the cases.

JIRA: https://issues.jenkins.io/browse/JENKINS-66484

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
