### PR TITLE
Avoid an `IllegalStateException` from `KubernetesProvisioningLimits$NodeListenerImpl.onDeleted`

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesProvisioningLimits.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesProvisioningLimits.java
@@ -130,7 +130,10 @@ public final class KubernetesProvisioningLimits {
         protected void onDeleted(@Nonnull Node node) {
             if (node instanceof KubernetesSlave) {
                 KubernetesSlave kubernetesNode = (KubernetesSlave) node;
-                KubernetesProvisioningLimits.get().unregister(kubernetesNode.getKubernetesCloud(), kubernetesNode.getTemplate(), node.getNumExecutors());
+                PodTemplate template = kubernetesNode.getTemplateOrNull();
+                if (template != null) {
+                    KubernetesProvisioningLimits.get().unregister(kubernetesNode.getKubernetesCloud(), template, node.getNumExecutors());
+                }
             }
         }
     }


### PR DESCRIPTION
After restarting Jenkins with a recreated and thus bogus agent pod, the pod eventually terminated itself (fine) and the build eventually failed because the pod was dead (also fine) but there was a stray stack trace in the system log:

```
INFO	o.c.j.p.k.KubernetesSlave#_terminate: Terminating Kubernetes instance for agent job-name-3-t0407-lvrzd-wtfj1
INFO	o.c.j.p.k.KubernetesSlave#deleteSlavePod: Terminated Kubernetes instance for agent cbci/job-name-3-t0407-lvrzd-wtfj1
Terminated Kubernetes instance for agent cbci/job-name-3-t0407-lvrzd-wtfj1
Disconnected computer job-name-3-t0407-lvrzd-wtfj1
INFO	o.c.j.p.k.KubernetesSlave#_terminate: Disconnected computer job-name-3-t0407-lvrzd-wtfj1
WARNING	jenkins.model.NodeListener#fireOnDeleted: Listener invocation failed
java.lang.IllegalStateException: Not expecting pod template to be null at this point
	at org.csanchez.jenkins.plugins.kubernetes.KubernetesSlave.getTemplate(KubernetesSlave.java:92)
	at org.csanchez.jenkins.plugins.kubernetes.KubernetesProvisioningLimits$NodeListenerImpl.onDeleted(KubernetesProvisioningLimits.java:142)
	at jenkins.model.NodeListener.fireOnDeleted(NodeListener.java:99)
	at jenkins.model.Nodes.removeNode(Nodes.java:289)
	at jenkins.model.Jenkins.removeNode(Jenkins.java:2213)
	at hudson.slaves.AbstractCloudSlave.terminate(AbstractCloudSlave.java:93)
	at org.jenkinsci.plugins.durabletask.executors.OnceRetentionStrategy$1$1.run(OnceRetentionStrategy.java:128)
	at hudson.model.Queue._withLock(Queue.java:1398)
	at hudson.model.Queue.withLock(Queue.java:1274)
	at org.jenkinsci.plugins.durabletask.executors.OnceRetentionStrategy$1.run(OnceRetentionStrategy.java:123)
	at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28)
	at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:68)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
WARNING	o.j.p.w.cps.CpsThreadGroup#unexport: double unexport of 3
INFO	o.j.p.workflow.job.WorkflowRun#finish: job-name #3 completed: FAILURE
```

Seems we could skip this cleanup at this point; the agent node is gone from the controller anyway. Amends #966.
