### PR TITLE
`KubernetesComputer/podLog` throws NPE if `Pod` is missing

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesComputer.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesComputer.java
@@ -85,6 +85,10 @@ public class KubernetesComputer extends AbstractCloudComputer<KubernetesSlave> {
         String namespace = StringUtils.defaultIfBlank(slave.getNamespace(), client.getNamespace());
         Pod pod = client.pods().inNamespace(namespace).withName(getName()).get();
 
+        if (pod == null) {
+            return Collections.emptyList();
+        }
+
         return pod.getSpec().getContainers();
     }
 


### PR DESCRIPTION
Similar circumstances to #1045: a node is still registered in Jenkins but the corresponding `Pod` no longer exists. https://github.com/jenkinsci/kubernetes-plugin/blob/57bd39e5b07743fa7ed50800e53ba799d8e48067/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesComputer/podLog.jelly#L35 throws an error:

```
WARNING	h.ExpressionFactory2$JexlExpression#evaluate: Caught exception evaluating: it.containers in /computer/job-name-4-n708l-xg0h9-wrv2p/podLog. Reason: java.lang.reflect.InvocationTargetException
java.lang.NullPointerException
	at org.csanchez.jenkins.plugins.kubernetes.KubernetesComputer.getContainers(KubernetesComputer.java:88)
```
