### PR TITLE
JENKINS-46253 BugFix: Handle missing subPath key on config.xml after plugin upgrade

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes/ConfigMapVolume.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes/ConfigMapVolume.java
@@ -29,20 +29,13 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 import hudson.Extension;
 import hudson.Util;
-import java.util.logging.Logger;
 import hudson.model.Descriptor;
-import io.fabric8.kubernetes.api.model.KeyToPath;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeBuilder;
-import java.io.IOException;
-import java.util.logging.Level;
-import jenkins.model.Jenkins;
 import org.kohsuke.stapler.DataBoundSetter;
 
 
 public class ConfigMapVolume extends PodVolume {
-    private static final Logger LOGGER = Logger.getLogger(ConfigMapVolume.class.getName());
-
     private String mountPath;
     private String subPath;
     private String configMapName;
@@ -81,24 +74,17 @@ public class ConfigMapVolume extends PodVolume {
     }
     
     public String getSubPath() {
-        if (subPath == null ) {
-            LOGGER.warning("Kubernetes-plugin: subPath Not set in config.xml Setting empty String instead of null: & Saving Instance configuration.");
-            this.subPath ="";
-            try {
-                //Saving Jenkins Configuration whenever we found a missing subPath.
-                Jenkins j = Jenkins.getInstanceOrNull();
-                if (j != null) j.save();
-            } catch (IOException ex) {
-                LOGGER.log(Level.SEVERE, null, ex);
-            }
-        }
         return subPath;
     }
     
     @DataBoundSetter
     public void setSubPath(String subPath) {
-        this.subPath = Util.fixNull(subPath);
-        //LOGGER.info("Kubernetes-plugin: ConfigMap SET");
+        this.subPath = Util.fixEmpty(subPath);
+    }
+
+    protected Object readResolve() {
+        this.subPath = Util.fixEmpty(subPath);
+        return this;
     }
     
     @Extension

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/ConfigMapVolumeTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/ConfigMapVolumeTest.java
@@ -15,8 +15,6 @@
 
 package org.csanchez.jenkins.plugins.kubernetes;
 
-import hudson.util.FormValidation;
-import java.util.Collections;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.ConfigMapVolume;
 
 import static org.junit.Assert.*;
@@ -27,7 +25,7 @@ public class ConfigMapVolumeTest {
     @Test
     public void testNullSubPathValue() {
         ConfigMapVolume configMapVolume= new ConfigMapVolume("oneMountPath", "Myvolume",false);
-        assertEquals(configMapVolume.getSubPath(),"");
+        assertNull(configMapVolume.getSubPath());
     }
 
     @Test


### PR DESCRIPTION
This fix will handle the missing subPath key from the config.xml after the plugin upgrade to release 1.30.3.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
        JENKINS-46253 BugFix: Handle missing subPath key on config.xml after plugin upgrade handle null value for subPath
- [X] Link to relevant issues in GitHub or Jira  
        [](https://issues.jenkins.io/browse/JENKINS-66841)
- [X] Link to relevant pull requests, esp. upstream and downstream changes
       [Pull request that introduced the bug](https://github.com/jenkinsci/kubernetes-plugin/pull/1024)
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
