### PR TITLE
Drop dependency on Commons Codec

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -10,6 +10,7 @@ import java.net.SocketTimeoutException;
 import java.net.URL;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -28,7 +29,6 @@ import hudson.model.ItemGroup;
 import hudson.model.Node;
 import hudson.util.XStream2;
 import jenkins.metrics.api.Metrics;
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
 import org.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateMap;
 import org.csanchez.jenkins.plugins.kubernetes.pod.retention.Default;
@@ -905,7 +905,7 @@ public class KubernetesCloud extends Cloud {
 
     private Object readResolve() {
         if ((serverCertificate != null) && !serverCertificate.trim().startsWith("-----BEGIN CERTIFICATE-----")) {
-            serverCertificate = new String(Base64.decodeBase64(serverCertificate.getBytes(UTF_8)), UTF_8);
+            serverCertificate = new String(Base64.getDecoder().decode(serverCertificate.getBytes(UTF_8)), UTF_8);
             LOGGER.log(Level.INFO, "Upgraded Kubernetes server certificate key: {0}",
                     serverCertificate.substring(0, 80));
         }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFactoryAdapter.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFactoryAdapter.java
@@ -1,6 +1,7 @@
 package org.csanchez.jenkins.plugins.kubernetes;
 
 
+import java.util.Base64;
 import java.util.Collections;
 import java.util.logging.Logger;
 
@@ -14,7 +15,6 @@ import hudson.security.ACL;
 import hudson.util.Secret;
 import jenkins.authentication.tokens.api.AuthenticationTokens;
 import jenkins.model.Jenkins;
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
 
 import io.fabric8.kubernetes.client.Config;
@@ -111,7 +111,7 @@ public class KubernetesFactoryAdapter {
 
         if (caCertData != null) {
             // JENKINS-38829 CaCertData expects a Base64 encoded certificate
-            builder.withCaCertData(Base64.encodeBase64String(caCertData.getBytes(UTF_8)));
+            builder.withCaCertData(Base64.getEncoder().encodeToString(caCertData.getBytes(UTF_8)));
         }
 
         builder = builder.withRequestTimeout(readTimeout * 1000).withConnectionTimeout(connectTimeout * 1000);


### PR DESCRIPTION
Java 8 includes a built-in Base64 encoder and decoder, so there is no reason to depend on a third-party library. Using the built-in Java Platform functionality simplifies maintenance.