### PR TITLE
Make ingress compatible with K8s v1.22 (expects minimum v1.19 now)

### DIFF
--- a/src/main/kubernetes/jenkins.yml
+++ b/src/main/kubernetes/jenkins.yml
@@ -99,7 +99,7 @@ spec:
       protocol: TCP
 
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: jenkins

--- a/src/main/kubernetes/jenkins.yml
+++ b/src/main/kubernetes/jenkins.yml
@@ -115,10 +115,12 @@ metadata:
     ingress.kubernetes.io/proxy-body-size: 50m
     ingress.kubernetes.io/proxy-request-buffering: "off"
 spec:
+  ingressClassName: nginx
   rules:
   - http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
           service:
             name: jenkins

--- a/src/main/kubernetes/jenkins.yml
+++ b/src/main/kubernetes/jenkins.yml
@@ -120,8 +120,10 @@ spec:
       paths:
       - path: /
         backend:
-          serviceName: jenkins
-          servicePort: 80
+          service:
+            name: jenkins
+            port:
+              number: 80
     host: jenkins.example.com
   tls:
   - hosts:


### PR DESCRIPTION
Make ingress compatible with K8s v1.22 (expects minimum v1.19 now)
[kubernetes deprecationguide](https://kubernetes.io/docs/reference/using-api/deprecation-guide/)
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
