### PR TITLE
Fixes an ArrayOutOfBoundException on node launch failure

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
@@ -253,7 +253,7 @@ public class KubernetesLauncher extends JNLPLauncher {
             Metrics.metricRegistry().counter(MetricNames.PODS_LAUNCHED).inc();
         } catch (Throwable ex) {
             Throwable[] suppressed = ex.getSuppressed();
-            if (suppressed[0] instanceof ContainerLogs) {
+            if (suppressed.length > 0 && suppressed[0] instanceof ContainerLogs) {
                 runListener.getLogger().println("Unable to provision agent " + node.getNodeName() + " :");
                 runListener.getLogger().print(suppressed[0].getMessage());
             }


### PR DESCRIPTION
This fixes an exception raised when a node fails to launch, but without any suppressed exception to log.

While the exception is raised in an already-failing case, it was also preventing proper handling of that failure (notably, the subsequent call to `node.terminate()` would not happen), which would leave the affected node in a bad state.

Example of a stack trace where this issue is encountered:
```
ERROR: Unexpected error in launching an agent. This is probably a bug in Jenkins
Also:   java.lang.Throwable: launched here
	at hudson.slaves.SlaveComputer._connect(SlaveComputer.java:282)
	at hudson.model.Computer.connect(Computer.java:440)
	at hudson.slaves.CloudRetentionStrategy.start(CloudRetentionStrategy.java:73)
	at org.jenkinsci.plugins.durabletask.executors.OnceRetentionStrategy.start(OnceRetentionStrategy.java:83)
	at org.jenkinsci.plugins.durabletask.executors.OnceRetentionStrategy.start(OnceRetentionStrategy.java:46)
	at hudson.model.AbstractCIBase.createNewComputerForNode(AbstractCIBase.java:176)
	at hudson.model.AbstractCIBase.updateNewComputer(AbstractCIBase.java:218)
	at jenkins.model.Jenkins.updateNewComputer(Jenkins.java:1664)
	at jenkins.model.Nodes.addNode(Nodes.java:144)
	at jenkins.model.Jenkins.addNode(Jenkins.java:2204)
	at hudson.slaves.NodeProvisioner.update(NodeProvisioner.java:248)
	at hudson.slaves.NodeProvisioner.lambda$suggestReviewNow$1(NodeProvisioner.java:189)
	at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28)
	at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:68)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
java.lang.ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0
	at org.csanchez.jenkins.plugins.kubernetes.KubernetesLauncher.launch(KubernetesLauncher.java:256)
	at hudson.slaves.SlaveComputer.lambda$_connect$0(SlaveComputer.java:293)
	at jenkins.util.ContextResettingExecutorService$2.call(ContextResettingExecutorService.java:46)
	at jenkins.security.ImpersonatingExecutorService$2.call(ImpersonatingExecutorService.java:80)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```