### PR TITLE
Fixing test: Labels have been updated from master to built-in

### DIFF
--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateJenkinsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateJenkinsTest.java
@@ -1,6 +1,8 @@
 package org.csanchez.jenkins.plugins.kubernetes;
 
 import hudson.model.Label;
+
+import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -9,7 +11,10 @@ import org.jvnet.hudson.test.JenkinsRule;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
+
+import net.bytebuddy.matcher.ElementMatchers;
 
 import static org.csanchez.jenkins.plugins.kubernetes.PodTemplate.LABEL_DIGEST_FUNCTION;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -59,10 +64,12 @@ public class PodTemplateJenkinsTest {
         PodTemplate podTemplate = new PodTemplate();
         kubernetesCloud.addTemplate(podTemplate);
         podTemplate.setLabel("foo bar");
-        assertThat(j.jenkins.getLabels().stream()
-                .map(Label::getName)
-                .collect(Collectors.toSet()),
-                containsInAnyOrder("master", "foo", "bar")
+
+        Set<String> labels = j.jenkins.getLabels().stream().map(Label::getName).collect(Collectors.toSet());
+        assertThat(labels, Matchers.anyOf(
+                containsInAnyOrder("master", "foo", "bar"),
+                containsInAnyOrder("built-in","foo", "bar")
+                )
         );
     }
 }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateJenkinsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateJenkinsTest.java
@@ -14,8 +14,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import net.bytebuddy.matcher.ElementMatchers;
-
 import static org.csanchez.jenkins.plugins.kubernetes.PodTemplate.LABEL_DIGEST_FUNCTION;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;


### PR DESCRIPTION
`mvn test -Djenkins.version=2.309 -Dtest=PodTemplateJenkinsTest#jenkinsLabels` is failing with
```
[ERROR] org.csanchez.jenkins.plugins.kubernetes.PodTemplateJenkinsTest.jenkinsLabels  Time elapsed: 7.243 s  <<< FAILURE!
java.lang.AssertionError: 

Expected: iterable with items ["master", "foo", "bar"] in any order
     but: not matched: "built-in"
```
This is because of terminology changes in Jenkins Core. I am keep the previous "master" and new "built-in" to have it work on both previous Jenkins 2.309 and after.

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
