### PR TITLE
Relax terminated exit code - can be 137 (SIGKILL) or 143 (SIGTERM)

### DIFF
--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
@@ -479,8 +479,8 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
         deletePods(cloud.connect(), getLabels(this, name), false);
         r.assertBuildStatus(Result.ABORTED, r.waitForCompletion(b));
         r.waitForMessage(new ExecutorStepExecution.RemovedNodeCause().getShortDescription(), b);
-        r.assertLogContains("busybox -- terminated (137)", b);
-        r.assertLogContains("jnlp -- terminated (143)", b);
+        r.assertLogContains("busybox -- terminated", b);
+        r.assertLogContains("jnlp -- terminated", b);
     }
 
     @Issue("JENKINS-59340")


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

I'm seeing occasional flakes where 137 is returned instead of 143 and vice versa. What matters is that it gets logged here.

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
