### PR TITLE
Each pod template instance should operate on its own message digest

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -72,12 +72,11 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
      * Digest function that is used to compute the kubernetes label "jenkins/label-digest"
      * Not used for security.
      */
-    protected static final MessageDigest LABEL_DIGEST_FUNCTION;
-    static {
+    protected static MessageDigest getLabelDigestFunction() {
         try {
-            LABEL_DIGEST_FUNCTION = MessageDigest.getInstance("SHA-1");
+            return MessageDigest.getInstance("SHA-1");
         } catch (NoSuchAlgorithmException e) {
-            // will never happen, SHA-256 support required on every Java implementation
+            // will never happen, SHA-1 support required on every Java implementation
             e.printStackTrace();
             // throw error to allow variable to be set as final
             throw new AssertionError(e);
@@ -473,9 +472,10 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
             tempMap.put("jenkins/label", DEFAULT_LABEL);
             tempMap.put("jenkins/label-digest", "0");
         } else {
-            LABEL_DIGEST_FUNCTION.update(label.getBytes(StandardCharsets.UTF_8));
+            MessageDigest labelDigestFunction = getLabelDigestFunction();
+            labelDigestFunction.update(label.getBytes(StandardCharsets.UTF_8));
             tempMap.put("jenkins/label", sanitizeLabel(label));
-            tempMap.put("jenkins/label-digest", String.format("%040x", new BigInteger(1, LABEL_DIGEST_FUNCTION.digest())));
+            tempMap.put("jenkins/label-digest", String.format("%040x", new BigInteger(1, labelDigestFunction.digest())));
         }
         labelsMap = Collections.unmodifiableMap(tempMap);
     }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateJenkinsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateJenkinsTest.java
@@ -2,6 +2,7 @@ package org.csanchez.jenkins.plugins.kubernetes;
 
 import hudson.model.Label;
 
+import java.security.MessageDigest;
 import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
@@ -14,7 +15,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.csanchez.jenkins.plugins.kubernetes.PodTemplate.LABEL_DIGEST_FUNCTION;
+import static org.csanchez.jenkins.plugins.kubernetes.PodTemplate.getLabelDigestFunction;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
@@ -30,8 +31,9 @@ public class PodTemplateJenkinsTest {
         podTemplate.setLabel("foo");
         Map<String, String> labelsMap = podTemplate.getLabelsMap();
         assertEquals("foo" , labelsMap.get("jenkins/label"));
-        LABEL_DIGEST_FUNCTION.update("foo".getBytes(StandardCharsets.UTF_8));
-        assertEquals(String.format("%040x", new BigInteger(1, LABEL_DIGEST_FUNCTION.digest())), labelsMap.get("jenkins/label-digest"));
+        MessageDigest labelDigestFunction = getLabelDigestFunction();
+        labelDigestFunction.update("foo".getBytes(StandardCharsets.UTF_8));
+        assertEquals(String.format("%040x", new BigInteger(1, labelDigestFunction.digest())), labelsMap.get("jenkins/label-digest"));
     }
 
     @Test
@@ -41,8 +43,9 @@ public class PodTemplateJenkinsTest {
         podTemplate.setLabel("foo bar");
         Map<String, String> labelsMap = podTemplate.getLabelsMap();
         assertEquals("foo_bar", labelsMap.get("jenkins/label"));
-        LABEL_DIGEST_FUNCTION.update("foo bar".getBytes(StandardCharsets.UTF_8));
-        assertEquals(String.format("%040x", new BigInteger(1, LABEL_DIGEST_FUNCTION.digest())), labelsMap.get("jenkins/label-digest"));
+        MessageDigest labelDigestFunction = getLabelDigestFunction();
+        labelDigestFunction.update("foo bar".getBytes(StandardCharsets.UTF_8));
+        assertEquals(String.format("%040x", new BigInteger(1, labelDigestFunction.digest())), labelsMap.get("jenkins/label-digest"));
     }
     
     @Test


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Amends #991

I've seen in https://ci.jenkins.io/blue/organizations/jenkins/Plugins%2Fkubernetes-plugin/detail/PR-1068/2/tests/

```
java.lang.AssertionError: expected:<10> but was:<3>
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.failNotEquals(Assert.java:835)
	at org.junit.Assert.assertEquals(Assert.java:647)
	at org.junit.Assert.assertEquals(Assert.java:633)
	at org.csanchez.jenkins.plugins.kubernetes.PodTemplateMapTest.concurrentAdds(PodTemplateMapTest.java:42)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:601)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

and checking out the code shows that the singleton  function doesn't work as it's not thread safe.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X]  Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
