### PR TITLE
[JENKINS-64628] Add some diagnostics logging when registering/re-registering pod templates through DSL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -301,6 +301,7 @@
             <hudson.slaves.NodeProvisioner.MARGIN>50</hudson.slaves.NodeProvisioner.MARGIN>
             <hudson.slaves.NodeProvisioner.MARGIN0>0.85</hudson.slaves.NodeProvisioner.MARGIN0>
             <jenkins.host.address>${jenkins.host.address}</jenkins.host.address>
+            <org.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution.verbose>true</org.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution.verbose>
           </systemProperties>
         </configuration>
       </plugin>

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
@@ -87,7 +87,7 @@ public class KubernetesSlave extends AbstractCloudSlave {
         // Look up updated pod template after a restart
         PodTemplate template = getTemplateOrNull();
         if (template == null) {
-            throw new IllegalStateException("Not expecting pod template to be null at this point");
+            throw new IllegalStateException("Unable to resolve pod template from id=" + podTemplateId);
         }
         return template;
     }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateMap.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateMap.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -53,6 +54,7 @@ public class PodTemplateMap {
      */
     public void addTemplate(@NonNull KubernetesCloud cloud, @NonNull PodTemplate podTemplate) {
         synchronized (this.map) {
+            LOGGER.log(Level.FINE, "Registering template with id=" + podTemplate.getId() + " to kubernetes cloud " + cloud.name);
             List<PodTemplate> list = getOrCreateTemplateList(cloud);
             list.add(podTemplate);
             map.put(cloud.name, list);
@@ -61,6 +63,7 @@ public class PodTemplateMap {
 
     public void removeTemplate(@NonNull KubernetesCloud cloud, @NonNull PodTemplate podTemplate) {
         synchronized (this.map) {
+            LOGGER.log(Level.FINE, "Unregistering template with id=" + podTemplate.getId() + " from kubernetes cloud " + cloud.name);
             getOrCreateTemplateList(cloud).remove(podTemplate);
         }
     }


### PR DESCRIPTION
Can be enabled in the build console starting Jenkins with
`-Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution.verbose=true`

or

```
org.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution.VERBOSE=true
```

in the groovy console.

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
