### PR TITLE
[JENKINS-67160] Don't fail if not able to retrieve container logs when the pod is terminated

### DIFF
--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/terminatedPod.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/terminatedPod.groovy
@@ -3,6 +3,7 @@ podTemplate(label: '$NAME', containers: [
     ]) {
     node ('$NAME') {
         container('busybox') {
+            sh 'hello world'
             sh 'sleep 9999999'
         }
     }

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/terminatedPod.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/terminatedPod.groovy
@@ -3,7 +3,7 @@ podTemplate(label: '$NAME', containers: [
     ]) {
     node ('$NAME') {
         container('busybox') {
-            sh 'hello world'
+            sh 'echo hello world'
             sh 'sleep 9999999'
         }
     }


### PR DESCRIPTION
[JENKINS-67160](https://issues.jenkins.io/browse/JENKINS-67160)

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
