### PR TITLE
[JENKINS-67196] Pods are terminated after ~110s and ignore PodTemplate.connectionTimeout when containers start

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/AllContainersRunningPodWatcher.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/AllContainersRunningPodWatcher.java
@@ -89,8 +89,7 @@ public class AllContainersRunningPodWatcher implements Watcher<Pod> {
             return periodicAwait(0, System.currentTimeMillis(), 0, 0);
         }
         try {
-            // Retry with 10% of the remaining time, with a min of 1s and a max of 10s
-            return periodicAwait(10, System.currentTimeMillis(), Math.min(10000L, Math.max(remaining / 10, 1000L)), remaining);
+            return periodicAwait(10, System.currentTimeMillis(), Math.max(remaining / 10, 1000L), remaining);
         } catch (KubernetesClientTimeoutException e) {
             // Wrap using the right timeout
             throw new KubernetesClientTimeoutException(pod, amount, timeUnit);


### PR DESCRIPTION
[JENKINS-67196](https://issues.jenkins.io/browse/JENKINS-67196)

Amends #1050 
Partially revert f95a6044, as it was not honoring long timeouts anymore.

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
