### PR TITLE
Use latest version of inbound-agent by default

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -140,6 +140,7 @@ public class PodTemplateBuilder {
     private static String getDefaultImageName() {
       // TODO: Reverse logic after inbound-agent:4.9-1
       String name = "jenkins/inbound-agent:latest";
+        
       if (JavaSpecificationVersion.forCurrentJVM().isNewerThanOrEqualTo(JavaSpecificationVersion.JAVA_11)) {
         name = name + "-jdk11";
       }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -139,7 +139,7 @@ public class PodTemplateBuilder {
 
     private static String getDefaultImageName() {
       // TODO: Reverse logic after inbound-agent:4.9-1
-      String name = "jenkins/inbound-agent:4.3-4";
+      String name = "jenkins/inbound-agent:latest";
       if (JavaSpecificationVersion.forCurrentJVM().isNewerThanOrEqualTo(JavaSpecificationVersion.JAVA_11)) {
         name = name + "-jdk11";
       }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

The 4.3-4 version of inbound agent has critical vulnerabilities (specifically CVE-2021-3520 and CVE-2021-3711).  My org is not allowed to run images with critical vulnerabilities.  As a work-around we can override the version of inbound-agent in the podTemplate, but it would be better if the default version was the latest version of the image.

This would not fix the following issue, but it would at least mitigate the risk from it: https://issues.jenkins.io/browse/JENKINS-66046

I'm not sure how to provide tests to prove that the latest version of the image does not contain critical vulnerabilities..

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
