### PR TITLE
Add DNS configs for Pod template

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -166,6 +166,10 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
 
     private Long terminationGracePeriodSeconds;
 
+    private String dnsConfigNameservers;
+
+    private String dnsPolicy;
+
     /**
      * Persisted yaml fragment
      */
@@ -833,6 +837,24 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
         this.terminationGracePeriodSeconds = terminationGracePeriodSeconds;
     }
 
+    public String getDNSConfigNameservers() {
+        return dnsConfigNameservers;
+    }
+
+    @DataBoundSetter
+    public void setDNSConfigNameservers(String dnsConfigNameservers) {
+        this.dnsConfigNameservers = Util.fixEmpty(dnsConfigNameservers);
+    }
+
+    public String getDNSPolicy() {
+        return dnsPolicy;
+    }
+
+    @DataBoundSetter
+    public void setDNSPolicy(String dnsPolicy) {
+        this.dnsPolicy = Util.fixEmpty(dnsPolicy);
+    }
+
     protected Object readResolve() {
         if (containers == null) {
             // upgrading from 0.8
@@ -1051,6 +1073,8 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
                 (annotations == null || annotations.isEmpty() ? "" : ", annotations=" + annotations) +
                 (imagePullSecrets == null || imagePullSecrets.isEmpty() ? "" : ", imagePullSecrets=" + imagePullSecrets) +
                 (nodeProperties == null || nodeProperties.isEmpty() ? "" : ", nodeProperties=" + nodeProperties) +
+                (dnsConfigNameservers == null ? "" : ", dnsConfigNameservers=" + dnsConfigNameservers) +
+                (dnsPolicy == null ? "" : ", dnsPolicy=" + dnsPolicy) +
                 (yamls == null || yamls.isEmpty() ? "" : ", yamls=" + yamls) +
                 '}';
     }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -63,6 +63,7 @@ import io.fabric8.kubernetes.api.model.ExecAction;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.PodDNSConfig;
 import io.fabric8.kubernetes.api.model.PodFluent.MetadataNested;
 import io.fabric8.kubernetes.api.model.PodFluent.SpecNested;
 import io.fabric8.kubernetes.api.model.Probe;
@@ -267,6 +268,14 @@ public class PodTemplateBuilder {
 
         if (template.isHostNetworkSet()) {
             builder.withHostNetwork(template.isHostNetwork());
+        }
+
+        if (template.getDNSConfigNameservers() != null) {
+            builder.withDnsConfig(parseDNSConfig(template.getDNSConfigNameservers()));
+        }
+
+        if (template.getDNSPolicy() != null) {
+            builder.withDnsPolicy(template.getDNSPolicy());
         }
 
         // merge with the yaml fragments
@@ -612,5 +621,21 @@ public class PodTemplateBuilder {
             }
         }
         return Collections.unmodifiableList(builder);
+    }
+
+    private PodDNSConfig parseDNSConfig(String dnsConfigNameservers) {
+        if (isNullOrEmpty(dnsConfigNameservers)) {
+            return new PodDNSConfig();
+        }
+
+        List<String> nameserversBuilder = new ArrayList<>();
+        for (String nameserver: dnsConfigNameservers.split(",")) {
+            if (!isNullOrEmpty(nameserver)) {
+                nameserversBuilder.add(nameserver);
+            } else {
+                LOGGER.log(Level.WARNING, "Ignoring nameserver '{0}'. Nameserver's cannot be empty or null.", nameserver);
+            }
+        }
+        return new PodDNSConfig(nameserversBuilder, new ArrayList<>(), new ArrayList<>());
     }
 }

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
@@ -99,6 +99,14 @@
       <f:textbox/>
     </f:entry>
 
+    <f:entry field="dnsConfigNameservers" title="${%DNS Nameservers}">
+      <f:textbox/>
+    </f:entry>
+
+    <f:entry field="dnsPolicy" title="${%DNS Policy}">
+      <f:textbox/>
+    </f:entry>
+
     <f:entry field="hostNetwork" title="${%Host Network}">
       <f:checkbox default="false"/>
     </f:entry>


### PR DESCRIPTION
Editing the default DNS configs of the pod can be useful when testing against specific DNS or using an internal DNS, this PR introduces two new configurations for Pods:
- `dnsConfigNameservers` mapped to [PodSpec.dnsConfig.nameservers](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec) 
- `dnsPolicy`:  mapped to [PodSpec.dnsPolicy](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec)

Help: I need some directions because this is my first contribution to this project and also in general to a Jenkins plugin so I don't know if I should also update the `KubernetesDeclarativeAgent` and `PodTemplateStep` classes, how can I tested it locally and which is the best place to add an automated test for this feature

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
