### PR TITLE
[JENKINS-66986] Allow non kubernetes nodes to be provisioned inside the container clause

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -249,7 +249,7 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
 
         //Allows other nodes to be provisioned inside the container clause
         //If the node is not a KubernetesSlave return the original launcher
-        if(node != null && node instanceof KubernetesSlave == false) {
+        if(node != null && !(node instanceof KubernetesSlave)) {
            return new Launcher.DecoratedLauncher(launcher) {};
         }
         return new Launcher.DecoratedLauncher(launcher) {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -250,7 +250,7 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
         //Allows other nodes to be provisioned inside the container clause
         //If the node is not a KubernetesSlave return the original launcher
         if(node != null && !(node instanceof KubernetesSlave)) {
-           return new Launcher.DecoratedLauncher(launcher) {};
+           return launcher;
         }
         return new Launcher.DecoratedLauncher(launcher) {
             @Override

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -246,6 +246,12 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
 
     @Override
     public Launcher decorate(final Launcher launcher, final Node node) {
+
+        //Allows other nodes to be provisioned inside the container clause
+        //If the node is not a KubernetesSlave return the original launcher
+        if(node != null && node instanceof KubernetesSlave == false) {
+           return new Launcher.DecoratedLauncher(launcher) {};
+        }
         return new Launcher.DecoratedLauncher(launcher) {
             @Override
             public Proc launch(ProcStarter starter) throws IOException {

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorTest.java
@@ -440,7 +440,7 @@ public class ContainerExecDecoratorTest {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         DummyLauncher dummyLauncher = new DummyLauncher(new StreamTaskListener(new TeeOutputStream(out, System.out)));
         Launcher launcher = decorator.decorate(dummyLauncher, dumbAgent);
-        assertTrue(launcher != null && launcher instanceof DecoratedLauncher);
+        assertEquals(dummyLauncher, launcher);
     }
 
     private ProcReturn execCommand(boolean quiet, boolean launcherStdout, String... cmd) throws Exception {

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorTest.java
@@ -74,6 +74,7 @@ import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.LoggerRule;
 
 import hudson.Launcher;
+import hudson.Launcher.DecoratedLauncher;
 import hudson.Launcher.DummyLauncher;
 import hudson.Launcher.ProcStarter;
 import hudson.model.Node;
@@ -439,8 +440,8 @@ public class ContainerExecDecoratorTest {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         DummyLauncher dummyLauncher = new DummyLauncher(new StreamTaskListener(new TeeOutputStream(out, System.out)));
         Launcher launcher = decorator.decorate(dummyLauncher, dumbAgent);
-        //If the node is not a KubernetesSlave the original launcher is returned
-        assertEquals(dummyLauncher, launcher);
+        //Assert a DecoratedLauncher was returned successfully
+        assertTrue(launcher != null && launcher instanceof DecoratedLauncher);
     }
 
     private ProcReturn execCommand(boolean quiet, boolean launcherStdout, String... cmd) throws Exception {

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorTest.java
@@ -74,7 +74,6 @@ import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.LoggerRule;
 
 import hudson.Launcher;
-import hudson.Launcher.DecoratedLauncher;
 import hudson.Launcher.DummyLauncher;
 import hudson.Launcher.ProcStarter;
 import hudson.model.Node;

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorTest.java
@@ -440,7 +440,6 @@ public class ContainerExecDecoratorTest {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         DummyLauncher dummyLauncher = new DummyLauncher(new StreamTaskListener(new TeeOutputStream(out, System.out)));
         Launcher launcher = decorator.decorate(dummyLauncher, dumbAgent);
-        //Assert a DecoratedLauncher was returned successfully
         assertTrue(launcher != null && launcher instanceof DecoratedLauncher);
     }
 

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorTest.java
@@ -86,6 +86,7 @@ import io.fabric8.kubernetes.client.HttpClientAware;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import okhttp3.OkHttpClient;
 import org.junit.Ignore;
+import org.jvnet.hudson.test.JenkinsRule;
 
 /**
  * @author Carlos Sanchez
@@ -93,6 +94,9 @@ import org.junit.Ignore;
 public class ContainerExecDecoratorTest {
     @Rule
     public ExpectedException exception = ExpectedException.none();
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
 
     private KubernetesCloud cloud;
     private static KubernetesClient client;
@@ -438,6 +442,7 @@ public class ContainerExecDecoratorTest {
     public void testRunningANonKubernetesNodeInsideContainerClause() throws Exception {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         DummyLauncher dummyLauncher = new DummyLauncher(new StreamTaskListener(new TeeOutputStream(out, System.out)));
+        dumbAgent = j.createSlave("test", "", null);
         Launcher launcher = decorator.decorate(dummyLauncher, dumbAgent);
         assertEquals(dummyLauncher, launcher);
     }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorTest.java
@@ -114,12 +114,12 @@ public class ContainerExecDecoratorTest {
     @Rule
     public TestName name = new TestName();
 
-    //@BeforeClass
+    @BeforeClass
     public static void isKubernetesConfigured() throws Exception {
         assumeKubernetes();
     }
 
-    //@Before
+    @Before
     public void configureCloud() throws Exception {
         cloud = setupCloud(this, name);
         client = cloud.connect();
@@ -172,7 +172,7 @@ public class ContainerExecDecoratorTest {
         decorator.setContainerName(image);
     }
 
-    //@After
+    @After
     public void after() throws Exception {
         client.pods().delete(pod);
         deletePods(client, getLabels(this, name), true);


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
**Description:**
When a non Kubernetes node is provisioned inside the container clause the steps executions fail because it is trying to cast a DumbSlave to KubernetesSlave - https://github.com/jenkinsci/kubernetes-plugin/blob/master/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java#L255. I added a check and if the node is not an instance of KubernetesSlave it just returns the original launcher.


**JIRA Link:** https://issues.jenkins.io/browse/JENKINS-66986

_No upstream or downstream changes._

**Before change**

![image](https://user-images.githubusercontent.com/2352273/145394165-92f7b3b6-81ad-4cbc-bda5-b6e005d2e0ca.png)

![image](https://user-images.githubusercontent.com/2352273/145398254-03ba81ed-d97f-451f-a146-e3780ee8afdd.png)

![image](https://user-images.githubusercontent.com/2352273/145398423-6c6319c6-2e0c-48e1-996b-2349065a59f3.png)

![image](https://user-images.githubusercontent.com/2352273/145398462-0f65a45c-85f8-419c-847b-55cc60688483.png)

**After change**

![image](https://user-images.githubusercontent.com/2352273/145411542-78bdd922-f7ec-4508-b97d-630445aea0df.png)

![image](https://user-images.githubusercontent.com/2352273/145414337-191ae1dd-6d71-44f4-8749-8ad0eb48b942.png)

![image](https://user-images.githubusercontent.com/2352273/145414155-b43a8879-fd81-4e3e-83ce-954b921f5673.png)

