### PR TITLE
Removing unused `AllContainersRunningPodWatcher.runListener`

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/AllContainersRunningPodWatcher.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/AllContainersRunningPodWatcher.java
@@ -9,9 +9,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import edu.umd.cs.findbugs.annotations.CheckForNull;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import hudson.model.TaskListener;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodStatus;
@@ -34,13 +31,9 @@ public class AllContainersRunningPodWatcher implements Watcher<Pod> {
 
     private KubernetesClient client;
 
-    @NonNull
-    private final TaskListener runListener;
-
-    public AllContainersRunningPodWatcher(KubernetesClient client, Pod pod, @CheckForNull TaskListener runListener) {
+    public AllContainersRunningPodWatcher(KubernetesClient client, Pod pod) {
         this.client = client;
         this.pod = pod;
-        this.runListener = runListener == null ? TaskListener.NULL : runListener;
         updateState(pod);
     }
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
@@ -162,7 +162,7 @@ public class KubernetesLauncher extends JNLPLauncher {
             kubernetesComputer.setLaunching(true);
 
             template.getWorkspaceVolume().createVolume(client, pod.getMetadata());
-            watcher = new AllContainersRunningPodWatcher(client, pod, runListener);
+            watcher = new AllContainersRunningPodWatcher(client, pod);
             try (Watch w1 = client.pods().inNamespace(namespace).withName(podName).watch(watcher);
                  Watch w2 = eventWatch(client, podName, namespace, runListener)) {
                 assert watcher != null; // assigned 3 lines above

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorTest.java
@@ -150,7 +150,7 @@ public class ContainerExecDecoratorTest {
                 .endSpec().build());
 
         System.out.println("Created pod: " + pod.getMetadata().getName());
-        AllContainersRunningPodWatcher watcher = new AllContainersRunningPodWatcher(client, pod, TaskListener.NULL);
+        AllContainersRunningPodWatcher watcher = new AllContainersRunningPodWatcher(client, pod);
         try (Watch w1 = client.pods().withName(podName).watch(watcher);) {
             assert watcher != null; // assigned 3 lines above
             watcher.await(30, TimeUnit.SECONDS);


### PR DESCRIPTION
Just some dead code cleanup. Introduced in #497 then rendered unused in #772.
