### PR TITLE
Avoid NPE if container environment is null

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -36,7 +36,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -314,7 +313,9 @@ public class PodTemplateBuilder {
         Map<String, EnvVar> envVars = new HashMap<>();
         envVars.putAll(jnlpEnvVars(jnlp.getWorkingDir()));
         envVars.putAll(defaultEnvVars(template.getEnvVars()));
-        envVars.putAll(jnlp.getEnv().stream().collect(Collectors.toMap(EnvVar::getName, Function.identity())));
+        Optional.ofNullable(jnlp.getEnv()).ifPresent(jnlpEnv -> {
+            jnlpEnv.forEach(var -> envVars.put(var.getName(), var));
+        });
         jnlp.setEnv(new ArrayList<>(envVars.values()));
         if (jnlp.getResources() == null) {
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
@@ -664,15 +664,13 @@ public class PodTemplateUtils {
     }
 
     private static List<EnvVar> combineEnvVars(Container parent, Container template) {
-        Map<String,EnvVar> combinedEnvVars = mergeMaps(envVarstoMap(parent.getEnv()),envVarstoMap(template.getEnv()));
-        return combinedEnvVars.entrySet().stream()
-                .filter(envVar -> !isNullOrEmpty(envVar.getKey()))
-                .map(Map.Entry::getValue)
-                .collect(toList());
-    }
-
-    static Map<String, EnvVar> envVarstoMap(List<EnvVar> envVarList) {
-        return envVarList.stream().collect(toMap(EnvVar::getName, Function.identity()));
+        Map<String, EnvVar> combinedEnvVars = new HashMap<>();
+        Stream.of(parent.getEnv(), template.getEnv())
+                .filter(Objects::nonNull)
+                .flatMap(List::stream)
+                .filter(var -> !isNullOrEmpty(var.getName()))
+                .forEachOrdered(var -> combinedEnvVars.put(var.getName(), var));
+        return new ArrayList<>(combinedEnvVars.values());
     }
 
     private static List<TemplateEnvVar> combineEnvVars(ContainerTemplate parent, ContainerTemplate template) {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/SecretsMasker.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/SecretsMasker.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
@@ -126,12 +127,15 @@ public final class SecretsMasker extends TaskListenerDecorator {
             LOGGER.finer(() -> "inspecting " + Serialization.asYaml(pod));
             for (Container container : pod.getSpec().getContainers()) {
                 Set<String> secretContainerKeys = new TreeSet<>();
-                for (EnvVar envVar : container.getEnv()) {
-                    EnvVarSource envVarSource = envVar.getValueFrom();
-                    if (envVarSource != null) {
-                        SecretKeySelector secretKeySelector = envVarSource.getSecretKeyRef();
-                        if (secretKeySelector != null) {
-                            secretContainerKeys.add(envVar.getName());
+                List<EnvVar> env = container.getEnv();
+                if (env != null) {
+                    for (EnvVar envVar : env) {
+                        EnvVarSource envVarSource = envVar.getValueFrom();
+                        if (envVarSource != null) {
+                            SecretKeySelector secretKeySelector = envVarSource.getSecretKeyRef();
+                            if (secretKeySelector != null) {
+                                secretContainerKeys.add(envVar.getName());
+                            }
                         }
                     }
                 }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
@@ -44,6 +44,9 @@ import org.csanchez.jenkins.plugins.kubernetes.model.SecretEnvVar;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.HostPathVolume;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
 import org.jvnet.hudson.test.Issue;
 
 import hudson.model.Node;
@@ -65,6 +68,7 @@ import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
 import org.jvnet.hudson.test.JenkinsRule;
 
+@RunWith(Theories.class)
 public class PodTemplateUtilsTest {
 
     @Rule
@@ -501,6 +505,23 @@ public class PodTemplateUtilsTest {
         Container result = combine(container, new Container());
 
         assertEquals(0, result.getEnvFrom().size());
+    }
+
+    @Theory
+    public void shouldTreatNullEnvFromSouresAsEmpty(boolean parentEnvNull, boolean templateEnvNull) {
+        Container parent = new Container();
+        if (parentEnvNull) {
+            parent.setEnv(null);
+        }
+
+        Container template = new Container();
+        if (templateEnvNull) {
+            template.setEnv(null);
+        }
+
+        Container result = combine(parent, template);
+
+        assertThat(result.getEnv(), is(empty()));
     }
 
     @Test

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgentTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgentTest.java
@@ -122,6 +122,14 @@ public class KubernetesDeclarativeAgentTest extends AbstractKubernetesPipelineTe
         r.assertLogContains("BUSYBOX_CONTAINER_ENV_VAR = busybox\n", b);
     }
 
+    @Test
+    public void declarativeFromYamlWithNullEnv() throws Exception {
+        assertNotNull(createJobThenScheduleRun());
+        r.assertBuildStatusSuccess(r.waitForCompletion(b));
+        r.assertLogContains("\njnlp container: OK\n", b);
+        r.assertLogContains("\ndefault container: OK\n", b);
+    }
+
     @Issue("JENKINS-52623")
     @Test
     public void declarativeSCMVars() throws Exception {

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/declarativeFromYamlWithNullEnv.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/declarativeFromYamlWithNullEnv.groovy
@@ -1,0 +1,53 @@
+pipeline {
+  agent {
+    kubernetes {
+      defaultContainer 'maven'
+      yaml '''
+metadata:
+  labels:
+    some-label: some-label-value
+    class: KubernetesDeclarativeAgentTest
+spec:
+  containers:
+  - name: jnlp
+    env:
+    - name: CONTAINER_ENV_VAR
+      value: jnlp
+  - name: maven
+    image: maven:3.3.9-jdk-8-alpine
+    command:
+    - cat
+    tty: true
+    env:
+'''
+    }
+  }
+  stages {
+    stage('Run in JNLP container') {
+      steps {
+        container('jnlp') {
+          sh '''
+            if [ "$CONTAINER_ENV_VAR" = jnlp ]; then
+              echo jnlp container: OK
+            else
+              echo "jnlp container: CONTAINER_ENV_VAR='$CONTAINER_ENV_VAR'"
+              exit 1
+            fi
+          '''
+        }
+      }
+    }
+    stage('Run in default container') {
+      steps {
+        sh '''
+          if [ -z "${CONTAINER_ENV_VAR+defined}" ]; then
+            echo default container: OK
+          else
+            echo "default container: CONTAINER_ENV_VAR='$CONTAINER_ENV_VAR'"
+            exit 1
+          fi
+        '''
+      }
+    }
+  }
+}

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pod-jnlp-nullenv.yaml
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pod-jnlp-nullenv.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Pod
+spec:
+  containers:
+  - name: jnlp
+    image: jnlp-agent
+    env:


### PR DESCRIPTION
This may happen if `env` is explicitly set to null in the container spec.

A pipeline snippet triggering this:

```groovy
pipeline {
  agent {
    kubernetes {
      yaml """\
        spec:
          containers:
          - name: builder
            image: alpine:3.15
            imagePullPolicy: Always
            env:
        """.stripIndent()
      defaultContainer 'builder'
    }
  }

  // ...
}
```

A stack trace copied from a failed build that triggered this:

```
 java.lang.NullPointerException
 	at org.csanchez.jenkins.plugins.kubernetes.pipeline.SecretsMasker$Factory.secretsOf(SecretsMasker.java:129)
 	at org.csanchez.jenkins.plugins.kubernetes.pipeline.SecretsMasker$Factory.get(SecretsMasker.java:101)
 	at org.csanchez.jenkins.plugins.kubernetes.pipeline.SecretsMasker$Factory.get(SecretsMasker.java:73)
 	at org.jenkinsci.plugins.workflow.steps.DynamicContext$Typed.get(DynamicContext.java:94)
 	at org.jenkinsci.plugins.workflow.cps.ContextVariableSet.get(ContextVariableSet.java:139)
 	at org.jenkinsci.plugins.workflow.cps.CpsThread.getContextVariable(CpsThread.java:135)
 	at org.jenkinsci.plugins.workflow.cps.CpsStepContext.doGet(CpsStepContext.java:297)
 	at org.jenkinsci.plugins.workflow.support.DefaultStepContext.get(DefaultStepContext.java:75)
 	at org.jenkinsci.plugins.workflow.support.DefaultStepContext.getListener(DefaultStepContext.java:127)
 	at org.jenkinsci.plugins.workflow.support.DefaultStepContext.get(DefaultStepContext.java:79)
 	at org.jenkinsci.plugins.workflow.cps.DSL.invokeStep(DSL.java:258)
 	at org.jenkinsci.plugins.workflow.cps.DSL.invokeMethod(DSL.java:193)
 	at org.jenkinsci.plugins.workflow.cps.CpsScript.invokeMethod(CpsScript.java:122)
 	at org.codehaus.groovy.runtime.callsite.PogoMetaClassSite.call(PogoMetaClassSite.java:48)
 	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48)
 	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:113)
 	at com.cloudbees.groovy.cps.sandbox.DefaultInvoker.methodCall(DefaultInvoker.java:20)
 	at org.jenkinsci.plugins.pipeline.modeldefinition.agent.CheckoutScript.performCheckout(CheckoutScript.groovy:72)
 	at org.jenkinsci.plugins.pipeline.modeldefinition.agent.CheckoutScript.checkoutAndRun(CheckoutScript.groovy:56)
 	at org.jenkinsci.plugins.pipeline.modeldefinition.agent.CheckoutScript.doCheckout(CheckoutScript.groovy:40)
 	at org.csanchez.jenkins.plugins.kubernetes.pipeline.KubernetesDeclarativeAgentScript.run(KubernetesDeclarativeAgentScript.groovy:53)
 	at ___cps.transform___(Native Method)
 	at com.cloudbees.groovy.cps.impl.ContinuationGroup.methodCall(ContinuationGroup.java:86)
 	at com.cloudbees.groovy.cps.impl.FunctionCallBlock$ContinuationImpl.dispatchOrArg(FunctionCallBlock.java:113)
 	at com.cloudbees.groovy.cps.impl.FunctionCallBlock$ContinuationImpl.fixArg(FunctionCallBlock.java:83)
 	at jdk.internal.reflect.GeneratedMethodAccessor223.invoke(Unknown Source)
 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
 	at java.base/java.lang.reflect.Method.invoke(Unknown Source)
 	at com.cloudbees.groovy.cps.impl.ContinuationPtr$ContinuationImpl.receive(ContinuationPtr.java:72)
 	at com.cloudbees.groovy.cps.impl.ClosureBlock.eval(ClosureBlock.java:46)
 	at com.cloudbees.groovy.cps.Next.step(Next.java:83)
 	at com.cloudbees.groovy.cps.Continuable$1.call(Continuable.java:174)
 	at com.cloudbees.groovy.cps.Continuable$1.call(Continuable.java:163)
 	at org.codehaus.groovy.runtime.GroovyCategorySupport$ThreadCategoryInfo.use(GroovyCategorySupport.java:129)
 	at org.codehaus.groovy.runtime.GroovyCategorySupport.use(GroovyCategorySupport.java:268)
 	at com.cloudbees.groovy.cps.Continuable.run0(Continuable.java:163)
 	at org.jenkinsci.plugins.workflow.cps.SandboxContinuable.access$001(SandboxContinuable.java:18)
 	at org.jenkinsci.plugins.workflow.cps.SandboxContinuable.run0(SandboxContinuable.java:51)
 	at org.jenkinsci.plugins.workflow.cps.CpsThread.runNextChunk(CpsThread.java:185)
 	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.run(CpsThreadGroup.java:400)
 	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.access$400(CpsThreadGroup.java:96)
 	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:312)
 	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:276)
 	at org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService$2.call(CpsVmExecutorService.java:67)
 	at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
 	at hudson.remoting.SingleLaneExecutorService$1.run(SingleLaneExecutorService.java:139)
 	at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28)
 	at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:68)
 	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)
 	at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
 	at java.base/java.lang.Thread.run(Unknown Source)
```

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
