### PR TITLE
Terminate running nodes after exiting `podTemplate` block

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesProvisioningLimits.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesProvisioningLimits.java
@@ -68,6 +68,7 @@ public final class KubernetesProvisioningLimits {
      * @param numExecutors the number of executors (pretty much always 1)
      */
     public synchronized boolean register(@NonNull KubernetesCloud cloud, @NonNull PodTemplate podTemplate, int numExecutors) {
+        LOGGER.log(Level.FINEST, "Registering {0} executors on cloud {1}, pod template {2}", new Object[]{numExecutors, cloud.name, podTemplate.getName()});
         int newGlobalCount = getGlobalCount(cloud.name) + numExecutors;
         if (newGlobalCount <= cloud.getContainerCap()) {
             int newPodTemplateCount = getPodTemplateCount(podTemplate.getId()) + numExecutors;


### PR DESCRIPTION
This prevents orphan agents left behind after removing a dynamic pod template. In some cases where Jenkins is restarted just after exiting a `podTemplate` block, agents would lose their reference to pod template and cause various exceptions.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
