### PR TITLE
[JENKINS-64628] Avoid ISE from `KubernetesSlave.getTemplate` in `SecretsMasker`

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/SecretsMasker.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/SecretsMasker.java
@@ -44,6 +44,7 @@ import java.util.logging.Logger;
 import okhttp3.Response;
 import org.csanchez.jenkins.plugins.kubernetes.KubernetesComputer;
 import org.csanchez.jenkins.plugins.kubernetes.KubernetesSlave;
+import org.csanchez.jenkins.plugins.kubernetes.PodTemplate;
 import org.jenkinsci.plugins.credentialsbinding.masking.SecretPatterns;
 import org.jenkinsci.plugins.kubernetes.auth.KubernetesAuthException;
 import org.jenkinsci.plugins.workflow.log.TaskListenerDecorator;
@@ -120,7 +121,11 @@ public final class SecretsMasker extends TaskListenerDecorator {
             if (slave == null) {
                 return null;
             }
-            Pod pod = slave.getTemplate().build(slave);
+            PodTemplate template = slave.getTemplateOrNull();
+            if (template == null) {
+                return null;
+            }
+            Pod pod = template.build(slave);
             Set<String> values = new HashSet<>();
             values.add(c.getJnlpMac());
             LOGGER.finer(() -> "inspecting " + Serialization.asYaml(pod));


### PR DESCRIPTION
https://issues.jenkins.io/browse/JENKINS-64628

Similar to #1045. #1095 may fix root cause, but there are liable to be race conditions here anyway, so best to behave defensively.
