### PR TITLE
Removing unused `ContainerExecDecorator.ws`

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -104,9 +104,6 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
     private String containerName;
     private EnvironmentExpander environmentExpander;
     private EnvVars globalVars;
-    /** @deprecated no longer used */
-    @Deprecated
-    private FilePath ws;
     private EnvVars rcEnvVars;
     private String shell;
     private KubernetesNodeContext nodeContext;
@@ -118,7 +115,6 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
     public ContainerExecDecorator(KubernetesClient client, String podName, String containerName, String namespace, EnvironmentExpander environmentExpander, FilePath ws) {
         this.containerName = containerName;
         this.environmentExpander = environmentExpander;
-        this.ws = ws;
     }
 
     @Deprecated
@@ -220,16 +216,6 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
 
     public EnvVars getRunContextEnvVars() {
         return this.rcEnvVars;
-    }
-
-    /** @deprecated unused */
-    @Deprecated
-    public FilePath getWs() {
-        return ws;
-    }
-
-    public void setWs(FilePath ws) {
-        this.ws = ws;
     }
 
     public void setShell(String shell) {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerStepExecution.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerStepExecution.java
@@ -17,7 +17,6 @@ import org.jenkinsci.plugins.workflow.steps.StepExecution;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.EnvVars;
-import hudson.FilePath;
 import hudson.LauncherDecorator;
 import hudson.model.Run;
 import hudson.model.TaskListener;
@@ -77,7 +76,6 @@ public class ContainerStepExecution extends StepExecution {
         decorator.setNodeContext(nodeContext);
         decorator.setContainerName(containerName);
         decorator.setEnvironmentExpander(env);
-        decorator.setWs(getContext().get(FilePath.class));
         decorator.setGlobalVars(globalVars);
         decorator.setRunContextEnvVars(rcEnvVars);
         decorator.setShell(shell);


### PR DESCRIPTION
Extracted from #1083. Deprecated and unused since #512.
