### PR TITLE
Removing comment about `Reaper` rendered incorrect by #714

### DIFF
--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/RestartPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/RestartPipelineTest.java
@@ -248,12 +248,6 @@ public class RestartPipelineTest {
         story.then(r -> {
             WorkflowRun b = r.jenkins.getItemByFullName(projectName.get(), WorkflowJob.class).getBuildByNumber(1);
             r.waitForMessage("Ready to run", b);
-            // Note that the test is cheating here slightly.
-            // The watch in Reaper is still running across the in-JVM restarts,
-            // whereas in production it would have been cancelled during the shutdown.
-            // But it does not matter since we are waiting for the agent to come back online after the restart,
-            // which is sufficient trigger to reactivate the reaper.
-            // Indeed we get two Reaper instances running, which independently remove the node.
             deletePods(cloud.connect(), getLabels(this, name), false);
             r.assertBuildStatus(Result.ABORTED, r.waitForCompletion(b));
             r.waitForMessage(new ExecutorStepExecution.RemovedNodeCause().getShortDescription(), b);


### PR DESCRIPTION
Extracted from #1083.
