### PR TITLE
`KubernetesTestUtil.setupHost` should call `KubernetesCloud.setJenkinsUrl` not `JenkinsLocationConfiguration.setUrl`

### DIFF
--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesTestUtil.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesTestUtil.java
@@ -117,7 +117,7 @@ public class KubernetesTestUtil {
         return cloud;
     }
 
-    public static void setupHost() throws Exception {
+    public static void setupHost(KubernetesCloud cloud) throws Exception {
         // Agents running in Kubernetes (minikube) need to connect to this server, so localhost does not work
         URL url = new URL(JenkinsLocationConfiguration.get().getUrl());
         String hostAddress = System.getProperty("jenkins.host.address");
@@ -127,8 +127,7 @@ public class KubernetesTestUtil {
         System.err.println("Calling home to address: " + hostAddress);
         URL nonLocalhostUrl = new URL(url.getProtocol(), hostAddress, url.getPort(),
                 url.getFile());
-        // TODO better to set KUBERNETES_JENKINS_URL
-        JenkinsLocationConfiguration.get().setUrl(nonLocalhostUrl.toString());
+        cloud.setJenkinsUrl(nonLocalhostUrl.toString());
 
         Integer slaveAgentPort = Integer.getInteger("slaveAgentPort");
         if (slaveAgentPort != null) {

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/AbstractKubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/AbstractKubernetesPipelineTest.java
@@ -148,7 +148,7 @@ public abstract class AbstractKubernetesPipelineTest {
         cloud.getTemplates().clear();
         cloud.addTemplate(buildBusyboxTemplate("busybox"));
 
-        setupHost();
+        setupHost(cloud);
 
         r.jenkins.clouds.add(cloud);
 

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/RestartPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/RestartPipelineTest.java
@@ -128,7 +128,7 @@ public class RestartPipelineTest {
         cloud.getTemplates().clear();
         cloud.addTemplate(buildBusyboxTemplate("busybox"));
 
-        setupHost();
+        setupHost(cloud);
 
         story.j.jenkins.clouds.add(cloud);
     }


### PR DESCRIPTION
Noticed in #1083 and worked around there by calling `setupHost` again after restart. Amends #616 in a sense.