### PR TITLE
Cancel Queue Items for Pod - `TerminateAgentOnContainerTerminated ` Listener

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/retention/Reaper.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/retention/Reaper.java
@@ -240,6 +240,9 @@ public class Reaper extends ComputerListener implements Watcher<Pod> {
                     LOGGER.info(() -> ns + "/" + name + " Container " + c.getName() + " was just terminated, so removing the corresponding Jenkins agent");
                     runListener.getLogger().printf("%s/%s Container %s was terminated (Exit Code: %d, Reason: %s)%n", ns, name, c.getName(), t.getExitCode(), t.getReason());
                 });
+                try (ACLContext _ = ACL.as(ACL.SYSTEM)) {
+                    PodUtils.cancelQueueItemFor(pod, "ContainerError");
+                }
                 logLastLinesThenTerminateNode(node, pod, runListener);
             }
         }
@@ -294,29 +297,6 @@ public class Reaper extends ComputerListener implements Watcher<Pod> {
             });
             try (ACLContext _ = ACL.as(ACL.SYSTEM)) {
                 PodUtils.cancelQueueItemFor(pod, "ImagePullBackOff");
-            }
-            node.terminate();
-        }
-    }
-
-    @Extension
-    public static class TerminateAgentOnCreateContainerError implements Listener {
-
-        @Override
-        public void onEvent(@NonNull Action action, @NonNull KubernetesSlave node, @NonNull Pod pod) throws IOException, InterruptedException {
-            List<ContainerStatus> backOffContainers = PodUtils.getContainers(pod, cs -> {
-                ContainerStateWaiting waiting = cs.getState().getWaiting();
-                return waiting != null && waiting.getMessage() != null && waiting.getMessage().contains("container create failed");
-            });
-            if (backOffContainers.isEmpty()) {
-                return;
-            }
-            backOffContainers.forEach(cs -> {
-                TaskListener runListener = node.getTemplate().getListener();
-                runListener.error("Container creation error \""+cs.getName()+"\". Please check container's logs.");
-            });
-            try (ACLContext _ = ACL.as(ACL.SYSTEM)) {
-                PodUtils.cancelQueueItemFor(pod, "CreateContainerError");
             }
             node.terminate();
         }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgentTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgentTest.java
@@ -179,6 +179,13 @@ public class KubernetesDeclarativeAgentTest extends AbstractKubernetesPipelineTe
         r.assertLogContains("ERROR: Unable to pull Docker image", b);
     }
 
+    @Test
+    public void declarativeWithCreateContainerError() throws Exception {
+        assertNotNull(createJobThenScheduleRun());
+        r.assertBuildStatus(Result.ABORTED, r.waitForCompletion(b));
+        r.assertLogContains("ERROR: Container creation error", b);
+    }
+
     @Issue("JENKINS-61360")
     @Test
     public void declarativeShowRawYamlFalse() throws Exception {

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgentTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgentTest.java
@@ -183,7 +183,7 @@ public class KubernetesDeclarativeAgentTest extends AbstractKubernetesPipelineTe
     public void declarativeWithCreateContainerError() throws Exception {
         assertNotNull(createJobThenScheduleRun());
         r.assertBuildStatus(Result.ABORTED, r.waitForCompletion(b));
-        r.assertLogContains("ERROR: Container creation error", b);
+        r.assertLogContains("was terminated", b);
     }
 
     @Issue("JENKINS-61360")

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/declarativeWithCreateContainerError.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/declarativeWithCreateContainerError.groovy
@@ -1,0 +1,30 @@
+pipeline {
+  agent {
+    kubernetes {
+      yaml '''
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    some-label: some-label-value
+spec:
+  containers:
+  - name: busybox
+    image: busybox
+    tty: true
+    command: ['sh', '-c', "thiscommandshouldcreateanerror;"]
+'''
+     }
+  }
+  stages {
+    stage('Run') {
+      steps {
+        container('busybox') {
+          sh """
+        will never run
+          """
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Signed-off-by: Mor Cohen <mocohen@redhat.com>

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->

**Description:** 
When creating a pod with a miss configured container, its state becomes `CreateContainerError`, and for some reason (probably because `kubernetes-client`) the pipeline enters to an endless loop that creates pods until the pipeline is stopped (aborted/pipeline timeout/etc.. but not by a timeout set by this plugin.). 
Currently, the plugin knows how to handle errors like `ImagePullBackOff` state or when one of the containers are terminated, but not when the pod's state is `CreateContainerError`.
**Jira ticket:** 
https://issues.jenkins.io/browse/JENKINS-66822


