### PR TITLE
Initialize reaper when launching a kubernetes agent

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
@@ -48,6 +48,7 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import jenkins.metrics.api.Metrics;
 import org.apache.commons.lang.StringUtils;
+import org.csanchez.jenkins.plugins.kubernetes.pod.retention.Reaper;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import static java.util.logging.Level.FINE;
@@ -94,6 +95,8 @@ public class KubernetesLauncher extends JNLPLauncher {
         if (!(computer instanceof KubernetesComputer)) {
             throw new IllegalArgumentException("This Launcher can be used only with KubernetesComputer");
         }
+        // Activate reaper if it never got activated.
+        Reaper.getInstance().maybeActivate();
         KubernetesComputer kubernetesComputer = (KubernetesComputer) computer;
         computer.setAcceptingTasks(false);
         KubernetesSlave node = kubernetesComputer.getNode();

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/retention/Reaper.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/retention/Reaper.java
@@ -113,6 +113,10 @@ public class Reaper extends ComputerListener implements Watcher<Pod> {
                 continue;
             }
             KubernetesSlave ks = (KubernetesSlave) n;
+            if (ks.getLauncher().isLaunchSupported()) {
+                // Being launched, don't touch it.
+                continue;
+            }
             String ns = ks.getNamespace();
             String name = ks.getPodName();
             try {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/retention/Reaper.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/retention/Reaper.java
@@ -103,7 +103,7 @@ public class Reaper extends ComputerListener implements Watcher<Pod> {
         }
     }
 
-    private synchronized void activate() {
+    private void activate() {
         LOGGER.fine("Activating reaper");
         // First check all existing nodes to see if they still have active pods.
         // (We may have missed deletion events while Jenkins was shut off,

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/retention/Reaper.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/retention/Reaper.java
@@ -92,12 +92,18 @@ public class Reaper extends ComputerListener implements Watcher<Pod> {
 
     @Override
     public void onOnline(Computer c, TaskListener listener) throws IOException, InterruptedException {
-        if (c instanceof KubernetesComputer && activated.compareAndSet(false, true)) {
+        if (c instanceof KubernetesComputer) {
+            maybeActivate();
+        }
+    }
+
+    public void maybeActivate() {
+        if (activated.compareAndSet(false, true)) {
             activate();
         }
     }
 
-    private void activate() {
+    private synchronized void activate() {
         LOGGER.fine("Activating reaper");
         // First check all existing nodes to see if they still have active pods.
         // (We may have missed deletion events while Jenkins was shut off,

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
@@ -701,6 +701,12 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
         r.assertLogContains("Queue task was cancelled", b);
     }
 
+    @Test
+    public void invalidImageGetsCancelled() throws Exception {
+        r.assertBuildStatus(Result.ABORTED, r.waitForCompletion(b));
+        r.assertLogContains("Queue task was cancelled", b);
+    }
+
     @Issue("SECURITY-1646")
     @Test
     public void substituteEnv() throws Exception {

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/invalidImageGetsCancelled.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/invalidImageGetsCancelled.groovy
@@ -5,6 +5,6 @@ spec:
     image: some/invalid
 ''') {
   node(POD_LABEL) {
-    sh 'false "This will never run"'
+    sh 'false'
   }
 }

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/invalidImageGetsCancelled.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/invalidImageGetsCancelled.groovy
@@ -1,0 +1,10 @@
+podTemplate(yaml: '''
+spec:
+  containers:
+  - name: jnlp
+    image: some/invalid
+''') {
+  node(POD_LABEL) {
+    sh 'This will never run'
+  }
+}

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/invalidImageGetsCancelled.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/invalidImageGetsCancelled.groovy
@@ -5,6 +5,6 @@ spec:
     image: some/invalid
 ''') {
   node(POD_LABEL) {
-    sh 'This will never run'
+    sh 'false "This will never run"'
   }
 }


### PR DESCRIPTION
When launching an agent before any kubernetes agent has ever come online, reaper should be initialized so that it can handle events like unable to pull image, etc.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
