### PR TITLE
`container` step: Fix issues with build wrappers on Windows

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -453,6 +453,10 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
                     toggleStdout.disable();
                     OutputStream stdin = watch.getInput();
                     PrintStream in = new PrintStream(stdin, true, StandardCharsets.UTF_8.name());
+                    if (!launcher.isUnix()) {
+                        in.print("@echo off");
+                        in.print(newLine(true));
+                    }
                     if (pwd != null) {
                         // We need to get into the project workspace.
                         // The workspace is not known in advance, so we have to execute a cd command.
@@ -629,10 +633,6 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
         try {
             String encoding = StandardCharsets.UTF_8.name();
             tee = new PrintStream(new TeeOutputStream(in, maskedOutput), false, encoding);
-            if (windows) {
-                tee.print("@echo off");
-                tee.print(newLine(true));
-            }
             // To output things that shouldn't be considered for masking
             PrintStream unmasked = new PrintStream(teeOutput, false, encoding);
             unmasked.print("Executing command: ");
@@ -648,7 +648,7 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
             tee.print(newLine(windows));
             tee.flush();
         } catch (UnsupportedEncodingException e) {
-            e.printStackTrace();
+            LOGGER.log(Level.SEVERE, "Failed to execute command because of unsupported encoding", e);
         }
     }
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -625,10 +625,14 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
         // Mask sensitive output
         MaskOutputStream maskedOutput = new MaskOutputStream(teeOutput, masks);
         // Tee everything together
-        PrintStream tee = null;
+        PrintStream tee;
         try {
             String encoding = StandardCharsets.UTF_8.name();
             tee = new PrintStream(new TeeOutputStream(in, maskedOutput), false, encoding);
+            if (windows) {
+                tee.print("@echo off");
+                tee.print(newLine(true));
+            }
             // To output things that shouldn't be considered for masking
             PrintStream unmasked = new PrintStream(teeOutput, false, encoding);
             unmasked.print("Executing command: ");

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -359,7 +359,7 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
 
                 ByteArrayOutputStream dryRunCaller = new ByteArrayOutputStream();
                 ToggleOutputStream toggleDryRunCaller = new ToggleOutputStream(dryRunCaller);
-                ToggleOutputStream toggleOutputForCaller = new ToggleOutputStream(NullOutputStream.NULL_OUTPUT_STREAM);
+                ToggleOutputStream toggleOutputForCaller = null;
                 // Send to proc caller as well if they sent one
                 if (outputForCaller != null && !outputForCaller.equals(printStream)) {
                     // Initially disable the output for the caller, to prevent it from getting unwanted output such as prompt
@@ -513,7 +513,9 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
                         toggleDryRunCaller.disable();
                         dryRunCaller.reset();
                     }
-                    toggleOutputForCaller.enable();
+                    if (toggleOutputForCaller != null) {
+                        toggleOutputForCaller.enable();
+                    }
                     doExec(in, !launcher.isUnix(), printStream, masks, commands);
 
                     LOGGER.log(Level.INFO, "Created process inside pod: [" + getPodName() + "], container: ["

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -497,7 +497,7 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
                     LOGGER.log(Level.FINEST, "Launching with env vars: {0}", envVars.toString());
 
                     setupEnvironmentVariable(envVars, in, !launcher.isUnix());
-                    if (!launcher.isUnix()) {
+                    if (!launcher.isUnix() && toggleOutputForCaller!= null) {
                         // Windows welcome message should not be sent to the caller as it is a side-effect of calling the wrapping cmd.exe
                         // Microsoft Windows [Version 10.0.17763.2686]
                         // (c) 2018 Microsoft Corporation. All rights reserved.

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorWindowsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorWindowsTest.java
@@ -1,0 +1,227 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, Carlos Sanchez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.csanchez.jenkins.plugins.kubernetes.pipeline;
+
+import hudson.Launcher;
+import hudson.Launcher.DummyLauncher;
+import hudson.Launcher.ProcStarter;
+import hudson.model.Node;
+import hudson.util.StreamTaskListener;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.Watch;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
+import org.apache.commons.io.output.TeeOutputStream;
+import org.apache.commons.lang.RandomStringUtils;
+import org.csanchez.jenkins.plugins.kubernetes.AllContainersRunningPodWatcher;
+import org.csanchez.jenkins.plugins.kubernetes.KubernetesClientProvider;
+import org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud;
+import org.csanchez.jenkins.plugins.kubernetes.KubernetesSlave;
+import org.csanchez.jenkins.plugins.kubernetes.PodTemplate;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TestName;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.LoggerRule;
+import org.jvnet.hudson.test.recipes.WithTimeout;
+
+import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.assumeKubernetes;
+import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.assumeWindows;
+import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.deletePods;
+import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.getLabels;
+import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.setupCloud;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Carlos Sanchez
+ */
+public class ContainerExecDecoratorWindowsTest {
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    private KubernetesCloud cloud;
+    private static KubernetesClient client;
+    private static final Pattern PID_PATTERN = Pattern.compile("^((?:\\[\\d+\\] )?pid is \\d+)$", Pattern.MULTILINE);
+
+    private ContainerExecDecorator decorator;
+    private Pod pod;
+    private KubernetesSlave agent;
+
+    @Rule
+    public LoggerRule containerExecLogs = new LoggerRule()
+            .record(Logger.getLogger(ContainerExecDecorator.class.getName()), Level.ALL) //
+            .record(Logger.getLogger(KubernetesClientProvider.class.getName()), Level.ALL);
+
+    @Rule
+    public TestName name = new TestName();
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        assumeKubernetes();
+        assumeWindows();
+    }
+
+    @Before
+    public void configureCloud() throws Exception {
+        cloud = setupCloud(this, name);
+        client = cloud.connect();
+        deletePods(client, getLabels(this, name), false);
+
+        String image = "mcr.microsoft.com/windows:10.0.17763.2686";
+        String containerName = "container";
+        String podName = "test-command-execution-" + RandomStringUtils.random(5, "bcdfghjklmnpqrstvwxz0123456789");
+        pod = client.pods().create(new PodBuilder()
+                .withNewMetadata()
+                    .withName(podName)
+                    .withLabels(getLabels(this, name))
+                .endMetadata()
+                .withNewSpec()
+                    .withContainers(new ContainerBuilder()
+                                .withName(containerName)
+                                .withImagePullPolicy("IfNotPresent")
+                                .withImage(image)
+                                .withCommand("powershell")
+                                .withArgs("Start-Sleep", "2147483")
+                            .build())
+                    .withNodeSelector(Collections.singletonMap("kubernetes.io/os", "windows"))
+                    .withTerminationGracePeriodSeconds(0L)
+                .endSpec().build());
+
+        System.out.println("Created pod: " + pod.getMetadata().getName());
+        AllContainersRunningPodWatcher watcher = new AllContainersRunningPodWatcher(client, pod);
+        try (Watch w1 = client.pods().withName(podName).watch(watcher);) {
+            assert watcher != null; // assigned 3 lines above
+            watcher.await(10, TimeUnit.MINUTES);
+        }
+        PodTemplate template = new PodTemplate();
+        template.setName(pod.getMetadata().getName());
+        agent = mock(KubernetesSlave.class);
+        when(agent.getNamespace()).thenReturn(client.getNamespace());
+        when(agent.getPodName()).thenReturn(pod.getMetadata().getName());
+        doReturn(cloud).when(agent).getKubernetesCloud();
+        when(agent.getPod()).thenReturn(Optional.of(pod));
+        StepContext context = mock(StepContext.class);
+        when(context.get(Node.class)).thenReturn(agent);
+
+        decorator = new ContainerExecDecorator();
+        decorator.setNodeContext(new KubernetesNodeContext(context));
+        decorator.setContainerName(image);
+    }
+
+    @After
+    public void after() throws Exception {
+        client.pods().delete(pod);
+        deletePods(client, getLabels(this, name), true);
+    }
+
+    @Test
+    @WithTimeout(value = 0)
+    public void testCommandExecution() throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        ProcReturn r = execCommandInContainer("container", null, false, output, "where", "cmd.exe");
+        assertEquals(   "C:\\Windows\\System32\\cmd.exe\r\n", output.toString(StandardCharsets.UTF_8.name()));
+        assertEquals(0, r.exitCode);
+        assertFalse(r.proc.isAlive());
+    }
+
+    @Test
+    @WithTimeout(value = 0)
+    public void testQuietCommandExecution() throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        ProcReturn r = execCommandInContainer("container", null, true, output, "echo", "pid is 9999");
+        String out = output.toString(StandardCharsets.UTF_8.name());
+        System.out.println(out);
+        assertFalse("Output should not contain command: " + out, PID_PATTERN.matcher(out).find());
+        assertEquals(0, r.exitCode);
+        assertFalse(r.proc.isAlive());
+    }
+
+    private ProcReturn execCommandInContainer(String containerName, Node node, boolean quiet, OutputStream outputForCaller, String... cmd) throws Exception {
+        decorator.setContainerName(containerName);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        DummyLauncher dummyLauncher = new DummyLauncher(new StreamTaskListener(new TeeOutputStream(out, System.out))){
+            @Override
+            public boolean isUnix() {
+                return false;
+            }
+        };
+        Launcher launcher = decorator.decorate(dummyLauncher, node);
+        Map<String, String> envs = new HashMap<>(100);
+        for (int i = 0; i < 50; i++) {
+            envs.put("aaaaaaaa" + i, "bbbbbbbb");
+        }
+        envs.put("workingDir1", "C:\\agent");
+
+        ProcStarter procStarter = launcher.new ProcStarter().pwd("C:\\").cmds(cmd).envs(envs).quiet(quiet);
+        if (outputForCaller != null) {
+            procStarter.stdout(outputForCaller);
+        }
+        ContainerExecProc proc = (ContainerExecProc) launcher.launch(procStarter);
+        // wait for proc to finish (shouldn't take long)
+        for (int i = 0; proc.isAlive() && i < 200; i++) {
+            Thread.sleep(100);
+        }
+        assertFalse("proc is alive", proc.isAlive());
+        int exitCode = proc.join();
+        return new ProcReturn(proc, exitCode, out.toString());
+    }
+
+    class ProcReturn {
+        public int exitCode;
+        public String output;
+        public ContainerExecProc proc;
+
+        ProcReturn(ContainerExecProc proc, int exitCode, String output) {
+            this.proc = proc;
+            this.exitCode = exitCode;
+            this.output = output;
+        }
+    }
+}

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorWindowsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorWindowsTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2016, Carlos Sanchez
+ * Copyright (c) 2022, CloudBees Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -74,9 +74,6 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-/**
- * @author Carlos Sanchez
- */
 public class ContainerExecDecoratorWindowsTest {
     public static final String WINDOWS_BUILD = "10.0.17763";
     @Rule
@@ -184,7 +181,6 @@ public class ContainerExecDecoratorWindowsTest {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         ProcReturn r = execCommandInContainer("container", null, true, output, "echo", "pid is 9999");
         String out = output.toString(StandardCharsets.UTF_8.name());
-        System.out.println(out);
         assertFalse("Output should not contain command: " + out, PID_PATTERN.matcher(out).find());
         assertEquals(0, r.exitCode);
         assertFalse(r.proc.isAlive());

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorWindowsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorWindowsTest.java
@@ -128,7 +128,8 @@ public class ContainerExecDecoratorWindowsTest {
                                 .withCommand("powershell")
                                 .withArgs("Start-Sleep", "2147483")
                             .build())
-                    .withNodeSelector(Collections.singletonMap("kubernetes.io/os", "windows"))
+                    .addToNodeSelector("kubernetes.io/os", "windows")
+                    .addToNodeSelector("node.kubernetes.io/windows-build", "10.0.17763")
                     .withTerminationGracePeriodSeconds(0L)
                 .endSpec().build());
 

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorWindowsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorWindowsTest.java
@@ -63,6 +63,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.LoggerRule;
 import org.jvnet.hudson.test.recipes.WithTimeout;
 
+import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.WINDOWS_1809_BUILD;
 import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.assumeKubernetes;
 import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.assumeWindows;
 import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.deletePods;
@@ -75,7 +76,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class ContainerExecDecoratorWindowsTest {
-    public static final String WINDOWS_BUILD = "10.0.17763";
     @Rule
     public ExpectedException exception = ExpectedException.none();
 
@@ -101,7 +101,7 @@ public class ContainerExecDecoratorWindowsTest {
     @BeforeClass
     public static void setUpClass() throws Exception {
         assumeKubernetes();
-        assumeWindows(WINDOWS_BUILD);
+        assumeWindows(WINDOWS_1809_BUILD);
     }
 
     @Before
@@ -110,7 +110,7 @@ public class ContainerExecDecoratorWindowsTest {
         client = cloud.connect();
         deletePods(client, getLabels(this, name), false);
 
-        String image = "mcr.microsoft.com/windows:" + WINDOWS_BUILD + ".2686";
+        String image = "mcr.microsoft.com/windows:" + WINDOWS_1809_BUILD + ".2686";
         String containerName = "container";
         String podName = "test-command-execution-" + RandomStringUtils.random(5, "bcdfghjklmnpqrstvwxz0123456789");
         pod = client.pods().create(new PodBuilder()
@@ -126,7 +126,7 @@ public class ContainerExecDecoratorWindowsTest {
                                 .withArgs("Start-Sleep", "2147483")
                             .build())
                     .addToNodeSelector("kubernetes.io/os", "windows")
-                    .addToNodeSelector("node.kubernetes.io/windows-build", WINDOWS_BUILD)
+                    .addToNodeSelector("node.kubernetes.io/windows-build", WINDOWS_1809_BUILD)
                     .withTerminationGracePeriodSeconds(0L)
                 .endSpec().build());
 

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorWindowsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorWindowsTest.java
@@ -56,7 +56,6 @@ import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -72,7 +71,6 @@ import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.getLabe
 import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.setupCloud;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -131,7 +129,7 @@ public class ContainerExecDecoratorWindowsTest {
                                 .withCommand("powershell")
                                 .withArgs("Start-Sleep", "2147483")
                             .build())
-                    .withNodeSelector(Collections.singletonMap("kubernetes.io/os", "windows"))
+                    .withNodeSelector(Collections.singletonMap("node.kubernetes.io/windows-build", "10.0.17763"))
                     .withTerminationGracePeriodSeconds(0L)
                 .endSpec().build());
 

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorWindowsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorWindowsTest.java
@@ -161,7 +161,7 @@ public class ContainerExecDecoratorWindowsTest {
     }
 
     @Test
-    @WithTimeout(value = 0)
+    @WithTimeout(value = 900) // in case we need to pull windows docker image
     public void testCommandExecution() throws Exception {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         ProcReturn r = execCommandInContainer("container", null, false, output, "where", "cmd.exe");
@@ -171,7 +171,7 @@ public class ContainerExecDecoratorWindowsTest {
     }
 
     @Test
-    @WithTimeout(value = 0)
+    @WithTimeout(value = 900) // in case we need to pull windows docker image
     public void testCommandExecutionNoOutput() throws Exception {
         ProcReturn r = execCommandInContainer("container", null, false, null, "where", "cmd.exe");
         assertEquals(0, r.exitCode);
@@ -179,7 +179,7 @@ public class ContainerExecDecoratorWindowsTest {
     }
 
     @Test
-    @WithTimeout(value = 0)
+    @WithTimeout(value = 900) // in case we need to pull windows docker image
     public void testQuietCommandExecution() throws Exception {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         ProcReturn r = execCommandInContainer("container", null, true, output, "echo", "pid is 9999");

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorWindowsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorWindowsTest.java
@@ -96,7 +96,7 @@ public class ContainerExecDecoratorWindowsTest {
 
     @Rule
     public LoggerRule containerExecLogs = new LoggerRule()
-            .record(Logger.getLogger(ContainerExecDecorator.class.getName()), Level.ALL) //
+            .record(Logger.getLogger(ContainerExecDecorator.class.getName()), Level.ALL)
             .record(Logger.getLogger(KubernetesClientProvider.class.getName()), Level.ALL);
 
     @Rule
@@ -166,7 +166,7 @@ public class ContainerExecDecoratorWindowsTest {
     public void testCommandExecution() throws Exception {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         ProcReturn r = execCommandInContainer("container", null, false, output, "where", "cmd.exe");
-        assertEquals(   "C:\\Windows\\System32\\cmd.exe\r\n", output.toString(StandardCharsets.UTF_8.name()));
+        assertEquals("C:\\Windows\\System32\\cmd.exe\r\n", output.toString(StandardCharsets.UTF_8.name()));
         assertEquals(0, r.exitCode);
         assertFalse(r.proc.isAlive());
     }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorWindowsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorWindowsTest.java
@@ -37,7 +37,6 @@ import io.fabric8.kubernetes.client.Watch;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -79,6 +78,7 @@ import static org.mockito.Mockito.when;
  * @author Carlos Sanchez
  */
 public class ContainerExecDecoratorWindowsTest {
+    public static final String WINDOWS_BUILD = "10.0.17763";
     @Rule
     public ExpectedException exception = ExpectedException.none();
 
@@ -104,7 +104,7 @@ public class ContainerExecDecoratorWindowsTest {
     @BeforeClass
     public static void setUpClass() throws Exception {
         assumeKubernetes();
-        assumeWindows();
+        assumeWindows(WINDOWS_BUILD);
     }
 
     @Before
@@ -113,7 +113,7 @@ public class ContainerExecDecoratorWindowsTest {
         client = cloud.connect();
         deletePods(client, getLabels(this, name), false);
 
-        String image = "mcr.microsoft.com/windows:10.0.17763.2686";
+        String image = "mcr.microsoft.com/windows:" + WINDOWS_BUILD + ".2686";
         String containerName = "container";
         String podName = "test-command-execution-" + RandomStringUtils.random(5, "bcdfghjklmnpqrstvwxz0123456789");
         pod = client.pods().create(new PodBuilder()
@@ -129,7 +129,7 @@ public class ContainerExecDecoratorWindowsTest {
                                 .withArgs("Start-Sleep", "2147483")
                             .build())
                     .addToNodeSelector("kubernetes.io/os", "windows")
-                    .addToNodeSelector("node.kubernetes.io/windows-build", "10.0.17763")
+                    .addToNodeSelector("node.kubernetes.io/windows-build", WINDOWS_BUILD)
                     .withTerminationGracePeriodSeconds(0L)
                 .endSpec().build());
 

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorWindowsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorWindowsTest.java
@@ -128,7 +128,7 @@ public class ContainerExecDecoratorWindowsTest {
                                 .withCommand("powershell")
                                 .withArgs("Start-Sleep", "2147483")
                             .build())
-                    .withNodeSelector(Collections.singletonMap("node.kubernetes.io/windows-build", "10.0.17763"))
+                    .withNodeSelector(Collections.singletonMap("node.kubernetes.io/os", "windows"))
                     .withTerminationGracePeriodSeconds(0L)
                 .endSpec().build());
 

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorWindowsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorWindowsTest.java
@@ -128,7 +128,7 @@ public class ContainerExecDecoratorWindowsTest {
                                 .withCommand("powershell")
                                 .withArgs("Start-Sleep", "2147483")
                             .build())
-                    .withNodeSelector(Collections.singletonMap("node.kubernetes.io/os", "windows"))
+                    .withNodeSelector(Collections.singletonMap("kubernetes.io/os", "windows"))
                     .withTerminationGracePeriodSeconds(0L)
                 .endSpec().build());
 

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorWindowsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorWindowsTest.java
@@ -72,6 +72,7 @@ import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.getLabe
 import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.setupCloud;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -167,6 +168,14 @@ public class ContainerExecDecoratorWindowsTest {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         ProcReturn r = execCommandInContainer("container", null, false, output, "where", "cmd.exe");
         assertEquals("C:\\Windows\\System32\\cmd.exe\r\n", output.toString(StandardCharsets.UTF_8.name()));
+        assertEquals(0, r.exitCode);
+        assertFalse(r.proc.isAlive());
+    }
+
+    @Test
+    @WithTimeout(value = 0)
+    public void testCommandExecutionNoOutput() throws Exception {
+        ProcReturn r = execCommandInContainer("container", null, false, null, "where", "cmd.exe");
         assertEquals(0, r.exitCode);
         assertFalse(r.proc.isAlive());
     }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorWindowsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorWindowsTest.java
@@ -124,7 +124,6 @@ public class ContainerExecDecoratorWindowsTest {
                 .withNewSpec()
                     .withContainers(new ContainerBuilder()
                                 .withName(containerName)
-                                .withImagePullPolicy("IfNotPresent")
                                 .withImage(image)
                                 .withCommand("powershell")
                                 .withArgs("Start-Sleep", "2147483")

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
@@ -26,6 +26,7 @@ package org.csanchez.jenkins.plugins.kubernetes.pipeline;
 
 import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.CONTAINER_ENV_VAR_FROM_SECRET_VALUE;
 import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.POD_ENV_VAR_FROM_SECRET_VALUE;
+import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.WINDOWS_1809_BUILD;
 import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.assumeWindows;
 import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.deletePods;
 import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.getLabels;
@@ -632,7 +633,7 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
     @Issue("JENKINS-57256")
     @Test
     public void basicWindows() throws Exception {
-        assumeWindows();
+        assumeWindows(WINDOWS_1809_BUILD);
         cloud.setDirectConnection(false); // not yet supported by https://github.com/jenkinsci/docker-inbound-agent/blob/517ccd68fd1ce420e7526ca6a40320c9a47a2c18/jenkins-agent.ps1
         r.assertBuildStatusSuccess(r.waitForCompletion(b));
         r.assertLogContains("Directory of C:\\home\\jenkins\\agent\\workspace\\basic Windows", b); // bat
@@ -642,7 +643,7 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
     @Issue("JENKINS-53500")
     @Test
     public void windowsContainer() throws Exception {
-        assumeWindows();
+        assumeWindows(WINDOWS_1809_BUILD);
         cloud.setDirectConnection(false);
         r.assertBuildStatusSuccess(r.waitForCompletion(b));
         r.assertLogContains("Directory of C:\\home\\jenkins\\agent\\workspace\\windows Container\\subdir", b);
@@ -653,7 +654,7 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
     @Ignore("TODO aborts, but with “kill finished with exit code 9009” and “After 20s process did not stop” and no graceful shutdown")
     @Test
     public void interruptedPodWindows() throws Exception {
-        assumeWindows();
+        assumeWindows(WINDOWS_1809_BUILD);
         cloud.setDirectConnection(false);
         r.waitForMessage("starting to sleep", b);
         b.getExecutor().interrupt();
@@ -663,7 +664,7 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
 
     @Test
     public void secretMaskingWindows() throws Exception {
-        assumeWindows();
+        assumeWindows(WINDOWS_1809_BUILD);
         cloud.setDirectConnection(false);
         r.assertBuildStatusSuccess(r.waitForCompletion(b));
         r.assertLogContains("INSIDE_POD_ENV_VAR_FROM_SECRET = **** or " + POD_ENV_VAR_FROM_SECRET_VALUE.toUpperCase(Locale.ROOT), b);

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesSamplesTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesSamplesTest.java
@@ -41,7 +41,7 @@ public class KubernetesSamplesTest extends AbstractKubernetesPipelineTest {
 
     @Test public void smokes() throws Exception {
         for (GroovySample gs : ExtensionList.lookup(GroovySample.class)) {
-            if (gs.name().equals("kubernetes-windows") && !isWindows()) {
+            if (gs.name().equals("kubernetes-windows") && !isWindows(null)) {
                 System.err.println("==== Skipping " + gs.title() + " ====");
                 continue;
             }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/RestartPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/RestartPipelineTest.java
@@ -217,7 +217,7 @@ public class RestartPipelineTest {
 
     @Test
     public void windowsRestart() throws Exception {
-        assumeWindows();
+        assumeWindows(WINDOWS_1809_BUILD);
         AtomicReference<String> projectName = new AtomicReference<>();
         story.then(r -> {
             configureAgentListener();

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/basicWindows.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/basicWindows.groovy
@@ -7,6 +7,7 @@ spec:
     image: jenkins/inbound-agent:windowsservercore-1809
   nodeSelector:
     kubernetes.io/os: windows
+    node.kubernetes.io/windows-build: 10.0.17763
 '''
 ) {
     node(POD_LABEL) {

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/interruptedPodWindows.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/interruptedPodWindows.groovy
@@ -14,6 +14,7 @@ spec:
     - 999999
   nodeSelector:
     kubernetes.io/os: windows
+    node.kubernetes.io/windows-build: 10.0.17763
 ''') {
     node(POD_LABEL) {
         container('shell') {

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/secretMaskingWindows.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/secretMaskingWindows.groovy
@@ -26,6 +26,7 @@ spec:
           name: container-secret
   nodeSelector:
     kubernetes.io/os: windows
+    node.kubernetes.io/windows-build: 10.0.17763
 ''') {
     node(POD_LABEL) {
         powershell 'echo "INSIDE_POD_ENV_VAR_FROM_SECRET = $Env:POD_ENV_VAR_FROM_SECRET or $($Env:POD_ENV_VAR_FROM_SECRET.ToUpper())"'

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/windowsContainer.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/windowsContainer.groovy
@@ -14,6 +14,7 @@ spec:
     - 999999
   nodeSelector:
     kubernetes.io/os: windows
+    node.kubernetes.io/windows-build: 10.0.17763
 '''
 ) {
     node(POD_LABEL) {

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/windowsRestart.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/windowsRestart.groovy
@@ -14,6 +14,7 @@ spec:
     - 999999
   nodeSelector:
     kubernetes.io/os: windows
+    node.kubernetes.io/windows-build: 10.0.17763
 ''') {
     node(POD_LABEL) {
         container('shell') {


### PR DESCRIPTION
When using the `container` step on windows containers, build wrappers are not receiving the expected output compared to the equivalent on linux systems.

There are multiple issues:
* The windows welcome message displayed when running the initial `cmd.exe` in the container
```
Microsoft Windows [Version 10.0.17763.2686]
(c) 2018 Microsoft Corporation. All rights reserved.

C:\>
```
* The input stream itself, now disabled using `cmd.exe /Q`
* The input echo from sending commands. This gets disabled by calling `@echo off` before anything else.

* I also found out that the quoting applied for linux commands can mess with windows commands, especially when it is a builtin command such as `echo`. Not sure whether this is the proper way to deal with it though.

I didn't find any way to disable the initial windows welcome message, and unfortunately output can be delayed from some time so I had to add a wait condition to ensure it doesn't pollute the returned output stream.

This adds a test designed to run against a kubernetes cluster with windows nodes and verifies that the received output is exactly what we expect from the input command, and nothing else. However I have a no idea how to procure a windows node in a lightweight context such as kind so I don't know how this could be tested in a systematic way.

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
