### PR TITLE
JENKINS-56687: Restrict pipeline support to authorised folders fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,13 +134,12 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials-binding</artifactId>
     </dependency>
-
-    <!-- for testing -->
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-job</artifactId>
-      <scope>test</scope>
     </dependency>
+
+    <!-- for testing -->
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-basic-steps</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -134,12 +134,13 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials-binding</artifactId>
     </dependency>
+
+    <!-- for testing -->
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-job</artifactId>
+      <scope>test</scope>
     </dependency>
-
-    <!-- for testing -->
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-basic-steps</artifactId>

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFolderProperty.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFolderProperty.java
@@ -10,6 +10,7 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.model.Job;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
@@ -97,6 +98,19 @@ public class KubernetesFolderProperty extends AbstractFolderProperty<AbstractFol
         }
 
         return ps;
+    }
+
+    @SuppressWarnings({"rawtypes"})
+    public static boolean isAllowed(KubernetesSlave agent, Job job) {
+        ItemGroup parent = job.getParent();
+        Set<String> allowedClouds = new HashSet<>();
+
+        KubernetesCloud targetCloud = agent.getKubernetesCloud();
+        if (targetCloud.isUsageRestricted()) {
+            KubernetesFolderProperty.collectAllowedClouds(allowedClouds, parent);
+            return allowedClouds.contains(targetCloud.name);
+        }
+        return true;
     }
 
     private static String PREFIX_USAGE_PERMISSION = "usage-permission-";

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesQueueTaskDispatcher.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesQueueTaskDispatcher.java
@@ -19,16 +19,25 @@ public class KubernetesQueueTaskDispatcher extends QueueTaskDispatcher {
             KubernetesSlave slave = (KubernetesSlave) node;
             Task ownerTask = item.task.getOwnerTask();
             if (!KubernetesFolderProperty.isAllowed(slave, (Job) ownerTask)) {
-                return new KubernetesCloudNotAllowed();
+                return new KubernetesCloudNotAllowed(slave.getKubernetesCloud(), (Job) ownerTask);
             }
         }
         return null;
     }
 
     public static final class KubernetesCloudNotAllowed extends CauseOfBlockage {
+
+        private final KubernetesCloud cloud;
+        private final Job job;
+
+        public KubernetesCloudNotAllowed(KubernetesCloud cloud, Job job) {
+            this.cloud = cloud;
+            this.job = job;
+        }
+
         @Override
         public String getShortDescription() {
-            return Messages.KubernetesCloudNotAllowed_Description();
+            return Messages.KubernetesCloudNotAllowed_Description(cloud.name, job.getFullName());
         }
     }
 }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesQueueTaskDispatcher.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesQueueTaskDispatcher.java
@@ -1,0 +1,48 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import hudson.Extension;
+import hudson.model.ItemGroup;
+import hudson.model.Job;
+import hudson.model.Node;
+import hudson.model.Queue;
+import hudson.model.queue.CauseOfBlockage;
+import hudson.model.queue.QueueTaskDispatcher;
+import jenkins.model.Jenkins;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Extension
+@SuppressWarnings({"unused", "rawtypes"})
+public class KubernetesQueueTaskDispatcher extends QueueTaskDispatcher {
+
+    @Override
+    public CauseOfBlockage canTake(Node node, Queue.Task task) {
+        if (node instanceof KubernetesSlave) {
+            if (task instanceof Job) {
+                KubernetesSlave slave = (KubernetesSlave) node;
+                Job project = (Job) task;
+                ItemGroup parent = project.getParent();
+                Set<String> allowedClouds = new HashSet<>();
+
+                KubernetesCloud targetCloud = Jenkins.get().clouds.getAll(KubernetesCloud.class)
+                        .stream()
+                        .filter(cloud -> cloud.name.equals(slave.getCloudName()))
+                        .findAny()
+                        .orElse(null);
+                if (targetCloud != null && targetCloud.isUsageRestricted()) {
+                    KubernetesFolderProperty.collectAllowedClouds(allowedClouds, parent);
+                    if (!allowedClouds.contains(targetCloud.name)) {
+                        return new CauseOfBlockage.BecauseNodeIsBusy(node);
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public CauseOfBlockage canTake(Node node, Queue.BuildableItem item) {
+        return this.canTake(node, item.task);
+    }
+}

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesQueueTaskDispatcher.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesQueueTaskDispatcher.java
@@ -5,37 +5,32 @@ import hudson.model.ItemGroup;
 import hudson.model.Job;
 import hudson.model.Node;
 import hudson.model.Queue;
+import hudson.model.Queue.Task;
+
 import hudson.model.queue.CauseOfBlockage;
 import hudson.model.queue.QueueTaskDispatcher;
 import jenkins.model.Jenkins;
+
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 
 import java.util.HashSet;
 import java.util.Set;
 
 @Extension
-@SuppressWarnings({"unused", "rawtypes"})
+@SuppressWarnings({"rawtypes"})
 public class KubernetesQueueTaskDispatcher extends QueueTaskDispatcher {
 
     @Override
-    public CauseOfBlockage canTake(Node node, Queue.Task task) {
+    public CauseOfBlockage canTake(Node node, Queue.Task item) {
         if (node instanceof KubernetesSlave) {
-            if (task instanceof Job) {
-                KubernetesSlave slave = (KubernetesSlave) node;
-                Job project = (Job) task;
-                ItemGroup parent = project.getParent();
-                Set<String> allowedClouds = new HashSet<>();
-
-                KubernetesCloud targetCloud = Jenkins.get().clouds.getAll(KubernetesCloud.class)
-                        .stream()
-                        .filter(cloud -> cloud.name.equals(slave.getCloudName()))
-                        .findAny()
-                        .orElse(null);
-                if (targetCloud != null && targetCloud.isUsageRestricted()) {
-                    KubernetesFolderProperty.collectAllowedClouds(allowedClouds, parent);
-                    if (!allowedClouds.contains(targetCloud.name)) {
-                        return new CauseOfBlockage.BecauseNodeIsBusy(node);
-                    }
-                }
+            KubernetesSlave slave = (KubernetesSlave) node;
+            Task ownerTask = item.getOwnerTask();
+            if (ownerTask instanceof WorkflowJob) {
+                WorkflowJob workflowJob = (WorkflowJob) ownerTask;
+                return check(slave, workflowJob);
+            }
+            if (item instanceof Job) {
+                return check(slave, (Job) item);
             }
         }
         return null;
@@ -45,4 +40,23 @@ public class KubernetesQueueTaskDispatcher extends QueueTaskDispatcher {
     public CauseOfBlockage canTake(Node node, Queue.BuildableItem item) {
         return this.canTake(node, item.task);
     }
+
+    private CauseOfBlockage check(KubernetesSlave agent, Job job) {
+        ItemGroup parent = job.getParent();
+        Set<String> allowedClouds = new HashSet<>();
+
+        KubernetesCloud targetCloud = Jenkins.get().clouds.getAll(KubernetesCloud.class)
+                .stream()
+                .filter(cloud -> cloud.name.equals(agent.getCloudName()))
+                .findAny()
+                .orElse(null);
+        if (targetCloud != null && targetCloud.isUsageRestricted()) {
+            KubernetesFolderProperty.collectAllowedClouds(allowedClouds, parent);
+            if (!allowedClouds.contains(targetCloud.name)) {
+                return new CauseOfBlockage.BecauseNodeIsBusy(agent);
+            }
+        }
+        return null;
+    }
+
 }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesQueueTaskDispatcher.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesQueueTaskDispatcher.java
@@ -1,7 +1,6 @@
 package org.csanchez.jenkins.plugins.kubernetes;
 
 import hudson.Extension;
-import hudson.model.ItemGroup;
 import hudson.model.Job;
 import hudson.model.Node;
 import hudson.model.Queue;
@@ -9,54 +8,27 @@ import hudson.model.Queue.Task;
 
 import hudson.model.queue.CauseOfBlockage;
 import hudson.model.queue.QueueTaskDispatcher;
-import jenkins.model.Jenkins;
-
-import org.jenkinsci.plugins.workflow.job.WorkflowJob;
-
-import java.util.HashSet;
-import java.util.Set;
 
 @Extension
 @SuppressWarnings({"rawtypes"})
 public class KubernetesQueueTaskDispatcher extends QueueTaskDispatcher {
 
     @Override
-    public CauseOfBlockage canTake(Node node, Queue.Task item) {
+    public CauseOfBlockage canTake(Node node, Queue.BuildableItem item) {
         if (node instanceof KubernetesSlave) {
             KubernetesSlave slave = (KubernetesSlave) node;
-            Task ownerTask = item.getOwnerTask();
-            if (ownerTask instanceof WorkflowJob) {
-                WorkflowJob workflowJob = (WorkflowJob) ownerTask;
-                return check(slave, workflowJob);
-            }
-            if (item instanceof Job) {
-                return check(slave, (Job) item);
+            Task ownerTask = item.task.getOwnerTask();
+            if (!KubernetesFolderProperty.isAllowed(slave, (Job) ownerTask)) {
+                return new KubernetesCloudNotAllowed();
             }
         }
         return null;
     }
 
-    @Override
-    public CauseOfBlockage canTake(Node node, Queue.BuildableItem item) {
-        return this.canTake(node, item.task);
-    }
-
-    private CauseOfBlockage check(KubernetesSlave agent, Job job) {
-        ItemGroup parent = job.getParent();
-        Set<String> allowedClouds = new HashSet<>();
-
-        KubernetesCloud targetCloud = Jenkins.get().clouds.getAll(KubernetesCloud.class)
-                .stream()
-                .filter(cloud -> cloud.name.equals(agent.getCloudName()))
-                .findAny()
-                .orElse(null);
-        if (targetCloud != null && targetCloud.isUsageRestricted()) {
-            KubernetesFolderProperty.collectAllowedClouds(allowedClouds, parent);
-            if (!allowedClouds.contains(targetCloud.name)) {
-                return new CauseOfBlockage.BecauseNodeIsBusy(agent);
-            }
+    public static final class KubernetesCloudNotAllowed extends CauseOfBlockage {
+        @Override
+        public String getShortDescription() {
+            return Messages.KubernetesCloudNotAllowed_Description();
         }
-        return null;
     }
-
 }

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/Messages.properties
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/Messages.properties
@@ -8,3 +8,4 @@ KubernetesSlave.HomeWarning=[WARNING] HOME is set to / in the jnlp container. Yo
     troubles when using tools or ssh client. This usually happens if the uid doesn't have any \
     entry in /etc/passwd. Please add a user to your Dockerfile or set the HOME environment \
     variable to a valid directory in the pod template definition.
+KubernetesCloudNotAllowed.Description=Kubernetes cloud is not allowed for folder

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/Messages.properties
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/Messages.properties
@@ -8,4 +8,4 @@ KubernetesSlave.HomeWarning=[WARNING] HOME is set to / in the jnlp container. Yo
     troubles when using tools or ssh client. This usually happens if the uid doesn't have any \
     entry in /etc/passwd. Please add a user to your Dockerfile or set the HOME environment \
     variable to a valid directory in the pod template definition.
-KubernetesCloudNotAllowed.Description=Kubernetes cloud is not allowed for folder
+KubernetesCloudNotAllowed.Description=Kubernetes cloud {0} is not allowed for folder containing job {1}

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesQueueTaskDispatcherTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesQueueTaskDispatcherTest.java
@@ -1,0 +1,106 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import com.cloudbees.hudson.plugins.folder.Folder;
+import hudson.model.FreeStyleProject;
+import hudson.model.Queue;
+import hudson.slaves.DumbSlave;
+import hudson.slaves.RetentionStrategy;
+import net.sf.json.JSONObject;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class KubernetesQueueTaskDispatcherTest {
+
+    @Rule
+    public JenkinsRule jenkins = new JenkinsRule();
+
+
+    @Test
+    public void checkRestrictedTwoClouds() throws Exception {
+
+        Folder folder1 = new Folder(jenkins.jenkins, "A");
+        Folder folder2 = new Folder(jenkins.jenkins, "B");
+
+        FreeStyleProject project1 = folder1.createProject(FreeStyleProject.class, "buildJob");
+        FreeStyleProject project2 = folder2.createProject(FreeStyleProject.class, "buildJob");
+
+        jenkins.jenkins.add(folder1, "A");
+        jenkins.jenkins.add(folder2, "B");
+
+        KubernetesCloud cloud1 = new KubernetesCloud("A");
+        cloud1.setUsageRestricted(true);
+
+        KubernetesCloud cloud2 = new KubernetesCloud("B");
+        cloud2.setUsageRestricted(true);
+
+
+        jenkins.jenkins.clouds.add(cloud1);
+        jenkins.jenkins.clouds.add(cloud2);
+
+        KubernetesFolderProperty property1 = new KubernetesFolderProperty();
+        folder1.addProperty(property1);
+        JSONObject json1 = new JSONObject();
+        json1.element("usage-permission-A", true);
+        json1.element("usage-permission-B", false);
+        folder1.addProperty(property1.reconfigure(null, json1));
+
+
+        KubernetesFolderProperty property2 = new KubernetesFolderProperty();
+        folder2.addProperty(property2);
+        JSONObject json2 = new JSONObject();
+        json2.element("usage-permission-A", false);
+        json2.element("usage-permission-B", true);
+        folder2.addProperty(property2.reconfigure(null, json2));
+
+        KubernetesQueueTaskDispatcher dispatcher = new KubernetesQueueTaskDispatcher();
+        KubernetesSlave slave1 = new KubernetesSlave("A", new PodTemplate(), "testA", "A", "dockerA", new KubernetesLauncher(), RetentionStrategy.INSTANCE);
+        KubernetesSlave slave2 = new KubernetesSlave("B", new PodTemplate(), "testB", "B", "dockerB", new KubernetesLauncher(), RetentionStrategy.INSTANCE);
+
+        assertNull(dispatcher.canTake(slave1, project1));
+        assertNotNull(dispatcher.canTake(slave2, project1));
+
+        assertNotNull(dispatcher.canTake(slave1, project2));
+        assertNull(dispatcher.canTake(slave2, project2));
+
+
+    }
+
+    @Test
+    public void checkNotRestrictedClouds() throws Exception {
+
+        Folder folder = new Folder(jenkins.jenkins, "A");
+
+        FreeStyleProject project = folder.createProject(FreeStyleProject.class, "buildJob");
+
+        jenkins.jenkins.add(folder, "A");
+
+        KubernetesCloud cloud = new KubernetesCloud("A");
+        cloud.setUsageRestricted(false);
+
+        jenkins.jenkins.clouds.add(cloud);
+
+
+
+        KubernetesQueueTaskDispatcher dispatcher = new KubernetesQueueTaskDispatcher();
+        KubernetesSlave slave = new KubernetesSlave("A", new PodTemplate(), "testA", "A", "dockerA", new KubernetesLauncher(), RetentionStrategy.INSTANCE);
+
+        assertNull(dispatcher.canTake(slave, project));
+    }
+
+
+    @Test
+    public void checkDumbSlave() throws Exception {
+        DumbSlave slave = jenkins.createOnlineSlave();
+        KubernetesQueueTaskDispatcher dispatcher = new KubernetesQueueTaskDispatcher();
+
+        FreeStyleProject project = jenkins.createProject(FreeStyleProject.class);
+
+        assertNull(dispatcher.canTake(slave, project));
+
+    }
+
+}


### PR DESCRIPTION
Fix for restricting pipeline support to authorised folders. Functionality seems to be partly implemented.
Use case is to be able to on a folder level restrict which folder that can use which Kubernetes cloud.

Jira Issue:
https://issues.jenkins.io/browse/JENKINS-56687
 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
