### PR TITLE
Make sure namespace is set explicitly in the pod metadata when set either through the cloud or the pod template

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -221,6 +221,12 @@ public class PodTemplateBuilder {
         if (agent != null) {
             metadataBuilder.withName(agent.getPodName());
         }
+        if (template.getNamespace() != null) {
+            metadataBuilder.withNamespace(template.getNamespace());
+        } else if (cloud != null && cloud.getNamespace() != null) {
+            metadataBuilder.withNamespace(cloud.getNamespace());
+        }
+
 
         Map<String, String> labels = new HashMap<>();
         if (agent != null) {

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/AbstractKubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/AbstractKubernetesPipelineTest.java
@@ -28,6 +28,8 @@ import static java.util.Arrays.*;
 import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.*;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
@@ -36,9 +38,12 @@ import hudson.slaves.NodeProvisioner;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.jenkins.plugins.kubernetes.NoDelayProvisionerStrategy;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 import org.csanchez.jenkins.plugins.kubernetes.ContainerEnvVar;
 import org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate;
 import org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud;
+import org.csanchez.jenkins.plugins.kubernetes.KubernetesComputer;
 import org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil;
 import org.csanchez.jenkins.plugins.kubernetes.PodTemplate;
 import org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar;
@@ -196,5 +201,17 @@ public abstract class AbstractKubernetesPipelineTest {
             client.namespaces().createOrReplace(
                     new NamespaceBuilder().withNewMetadata().withName(namespace).endMetadata().build());
         }
+    }
+
+    protected static List<PodTemplate> podTemplatesWithLabel(String label, List<PodTemplate> templates) {
+        return templates.stream().filter(t -> label.equals(t.getLabel())).collect(Collectors.toList());
+    }
+
+    @Nonnull
+    protected List<KubernetesComputer> getKubernetesComputers() {
+        return Arrays.stream(r.jenkins.getComputers())
+                .filter(c -> c instanceof KubernetesComputer)
+                .map(KubernetesComputer.class::cast)
+                .collect(Collectors.toList());
     }
 }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
@@ -150,7 +150,7 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
 
         Map<String, String> labels = getLabels(cloud, this, name);
         SemaphoreStep.waitForStart("pod/1", b);
-        for (Computer c : Arrays.stream(r.jenkins.getComputers()).filter(c -> c instanceof SlaveComputer).collect(Collectors.toList())) { // TODO perhaps this should be built into JenkinsRule via ComputerListener.preLaunch?
+        for (Computer c : getKubernetesComputers()) { // TODO perhaps this should be built into JenkinsRule via ComputerListener.preLaunch?
             new Thread(() -> {
                 long pos = 0;
                 try {
@@ -247,10 +247,6 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
         r.assertLogContains("Started container jnlp", b);
         assertFalse("There are pods leftover after test execution, see previous logs",
                 deletePods(cloud.connect(), getLabels(cloud, this, name), true));
-    }
-
-    private List<PodTemplate> podTemplatesWithLabel(String label, List<PodTemplate> templates) {
-        return templates.stream().filter(t -> label.equals(t.getLabel())).collect(Collectors.toList());
     }
 
     @Issue("JENKINS-57893")

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runWithCloudOverriddenNamespace.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runWithCloudOverriddenNamespace.groovy
@@ -3,6 +3,7 @@ podTemplate(volumes: [emptyDirVolume(mountPath: '/my-mount')], containers: [
 ]) {
 
     node(POD_LABEL) {
+        semaphore 'pod'
         container(name: 'jnlp') {
             sh 'cat /var/run/secrets/kubernetes.io/serviceaccount/namespace'
         }

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runWithStepOverriddenNamespace.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/runWithStepOverriddenNamespace.groovy
@@ -7,6 +7,7 @@ podTemplate(
     ]) {
 
     node(POD_LABEL) {
+        semaphore 'pod'
         container(name: 'jnlp') {
             sh 'cat /var/run/secrets/kubernetes.io/serviceaccount/namespace'
         }


### PR DESCRIPTION
This allows `PodDecorator` instances to have access to the full pod specification when decorating it.
Updated existing tests to ensure that.

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
