### PR TITLE
Allow kubernetesFolderProperty/permittedClouds to be setup without saving

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFolderProperty.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFolderProperty.java
@@ -11,6 +11,8 @@ import java.util.stream.Collectors;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.Job;
+
+import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -221,6 +223,7 @@ public class KubernetesFolderProperty extends AbstractFolderProperty<AbstractFol
      * Descriptor class.
      */
     @Extension
+    @Symbol("kubernetes")
     public static class DescriptorImpl extends AbstractFolderPropertyDescriptor {
 
         @NonNull

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFolderProperty.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFolderProperty.java
@@ -107,7 +107,7 @@ public class KubernetesFolderProperty extends AbstractFolderProperty<AbstractFol
         // Backwards compatibility: this method was expecting a set of entries PREFIX_USAGE_PERMISSION+cloudName --> true | false
         // Now we're getting a set of permitted cloud names inside permittedClouds entry
         Set<String> formCloudnames = new HashSet<>();
-        if (form.get("permittedClouds") == null) {
+        if (form.has("permittedClouds")) {
             form.names().stream().filter(x -> form.getBoolean(x.toString())).forEach(x -> formCloudnames.add(x.toString().replace(PREFIX_USAGE_PERMISSION, "")));
         } else {
             formCloudnames.addAll(form.getJSONArray("permittedClouds").stream().map(x -> x.toString()).collect(Collectors.toSet()));

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFolderProperty.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFolderProperty.java
@@ -27,6 +27,8 @@ import hudson.model.ItemGroup;
 import hudson.model.Descriptor.FormException;
 import hudson.slaves.Cloud;
 import jenkins.model.Jenkins;
+
+import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 
 /**
@@ -109,7 +111,12 @@ public class KubernetesFolderProperty extends AbstractFolderProperty<AbstractFol
         if (!form.has("permittedClouds")) {
             form.names().stream().filter(x -> form.getBoolean(x.toString())).forEach(x -> formCloudNames.add(x.toString().replace(PREFIX_USAGE_PERMISSION, "")));
         } else {
-            formCloudNames.addAll(form.getJSONArray("permittedClouds").stream().map(x -> x.toString()).collect(Collectors.toSet()));
+            JSONArray clouds = form.optJSONArray("permittedClouds");
+            if (clouds != null) {
+                formCloudNames.addAll(clouds.stream().map(x -> x.toString()).collect(Collectors.toSet()));
+            } else {
+                formCloudNames.add(form.getString("permittedClouds")); // arrays with 1 element are considered objects
+            }
         }
         setPermittedClouds(formCloudNames);
         return this;

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFolderProperty.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFolderProperty.java
@@ -1,5 +1,6 @@
 package org.csanchez.jenkins.plugins.kubernetes;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -38,7 +39,7 @@ public class KubernetesFolderProperty extends AbstractFolderProperty<AbstractFol
 
     private static final String PREFIX_USAGE_PERMISSION = "usage-permission-";
 
-    private Set<String> permittedClouds = new HashSet<>();
+    private List<String> permittedClouds = new ArrayList<>();
 
     /**
      * Constructor.
@@ -48,11 +49,11 @@ public class KubernetesFolderProperty extends AbstractFolderProperty<AbstractFol
 
     @DataBoundSetter
     public void setPermittedClouds(Collection<String> permittedClouds){
-        this.permittedClouds = permittedClouds == null ? Collections.emptySet() : new HashSet<>(permittedClouds);
+        this.permittedClouds = permittedClouds == null ? Collections.emptyList() : new ArrayList<>(permittedClouds);
     }
 
-    public Set<String> getPermittedClouds() {
-        return permittedClouds == null ? Collections.emptySet() : Collections.unmodifiableSet(permittedClouds);
+    public Collection<String> getPermittedClouds() {
+        return permittedClouds == null ? Collections.emptyList() : Collections.unmodifiableList(permittedClouds);
     }
 
     private static Set<String> getInheritedClouds(ItemGroup parent) {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFolderProperty.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFolderProperty.java
@@ -105,13 +105,13 @@ public class KubernetesFolderProperty extends AbstractFolderProperty<AbstractFol
         }
         // Backwards compatibility: this method was expecting a set of entries PREFIX_USAGE_PERMISSION+cloudName --> true | false
         // Now we're getting a set of permitted cloud names inside permittedClouds entry
-        Set<String> formCloudnames = new HashSet<>();
+        Set<String> formCloudNames = new HashSet<>();
         if (!form.has("permittedClouds")) {
-            form.names().stream().filter(x -> form.getBoolean(x.toString())).forEach(x -> formCloudnames.add(x.toString().replace(PREFIX_USAGE_PERMISSION, "")));
+            form.names().stream().filter(x -> form.getBoolean(x.toString())).forEach(x -> formCloudNames.add(x.toString().replace(PREFIX_USAGE_PERMISSION, "")));
         } else {
-            formCloudnames.addAll(form.getJSONArray("permittedClouds").stream().map(x -> x.toString()).collect(Collectors.toSet()));
+            formCloudNames.addAll(form.getJSONArray("permittedClouds").stream().map(x -> x.toString()).collect(Collectors.toSet()));
         }
-        setPermittedClouds(formCloudnames);
+        setPermittedClouds(formCloudNames);
         return this;
     }
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFolderProperty.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFolderProperty.java
@@ -1,5 +1,6 @@
 package org.csanchez.jenkins.plugins.kubernetes;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -44,8 +45,8 @@ public class KubernetesFolderProperty extends AbstractFolderProperty<AbstractFol
     public KubernetesFolderProperty() {}
 
     @DataBoundSetter
-    public void setPermittedClouds(Set<String> permittedClouds){
-        this.permittedClouds = new HashSet<>(permittedClouds);
+    public void setPermittedClouds(Collection<String> permittedClouds){
+        this.permittedClouds = permittedClouds == null ? Collections.emptySet() : new HashSet<>(permittedClouds);
     }
 
     public Set<String> getPermittedClouds() {
@@ -63,8 +64,6 @@ public class KubernetesFolderProperty extends AbstractFolderProperty<AbstractFol
      * 
      * @return
      */
-    @SuppressWarnings("unused") // Used by jelly
-    @Restricted(DoNotUse.class) // Used by jelly
     public List<UsagePermission> getEffectivePermissions() {
         Set<String> inheritedClouds = getInheritedClouds(Stapler.getCurrentRequest().findAncestorObject(Folder.class));
         List<UsagePermission> ps = getUsageRestrictedKubernetesClouds().stream()
@@ -107,7 +106,7 @@ public class KubernetesFolderProperty extends AbstractFolderProperty<AbstractFol
         // Backwards compatibility: this method was expecting a set of entries PREFIX_USAGE_PERMISSION+cloudName --> true | false
         // Now we're getting a set of permitted cloud names inside permittedClouds entry
         Set<String> formCloudnames = new HashSet<>();
-        if (form.has("permittedClouds")) {
+        if (!form.has("permittedClouds")) {
             form.names().stream().filter(x -> form.getBoolean(x.toString())).forEach(x -> formCloudnames.add(x.toString().replace(PREFIX_USAGE_PERMISSION, "")));
         } else {
             formCloudnames.addAll(form.getJSONArray("permittedClouds").stream().map(x -> x.toString()).collect(Collectors.toSet()));

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFolderProperty.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFolderProperty.java
@@ -222,7 +222,9 @@ public class KubernetesFolderProperty extends AbstractFolderProperty<AbstractFol
             return Messages.KubernetesFolderProperty_displayName();
         }
 
-        public static List<UsagePermission> getEffectivePermissions() {
+        @SuppressWarnings("unused") // Used by jelly
+        @Restricted(DoNotUse.class) // Used by jelly
+        public List<UsagePermission> getEffectivePermissions() {
             Set<String> inheritedClouds = getInheritedClouds(Stapler.getCurrentRequest().findAncestorObject(Folder.class).getParent());
             List<UsagePermission> ps = getUsageRestrictedKubernetesClouds().stream()
                                                                            .map(cloud -> new UsagePermission(cloud.name, inheritedClouds.contains(cloud.name), inheritedClouds.contains(cloud.name)))

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFolderProperty.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFolderProperty.java
@@ -1,33 +1,31 @@
 package org.csanchez.jenkins.plugins.kubernetes;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.Job;
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 
 import com.cloudbees.hudson.plugins.folder.AbstractFolder;
 import com.cloudbees.hudson.plugins.folder.AbstractFolderProperty;
 import com.cloudbees.hudson.plugins.folder.AbstractFolderPropertyDescriptor;
+import com.cloudbees.hudson.plugins.folder.Folder;
 
 import hudson.Extension;
 import hudson.model.ItemGroup;
 import hudson.model.Descriptor.FormException;
 import hudson.slaves.Cloud;
 import jenkins.model.Jenkins;
-import net.sf.json.JSONArray;
-import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
 
 /**
@@ -35,7 +33,7 @@ import net.sf.json.JSONObject;
  */
 public class KubernetesFolderProperty extends AbstractFolderProperty<AbstractFolder<?>> {
 
-    private static final Logger LOGGER = Logger.getLogger(KubernetesFolderProperty.class.getName());
+    private static final String PREFIX_USAGE_PERMISSION = "usage-permission-";
 
     private Set<String> permittedClouds = new HashSet<>();
 
@@ -43,17 +41,20 @@ public class KubernetesFolderProperty extends AbstractFolderProperty<AbstractFol
      * Constructor.
      */
     @DataBoundConstructor
-    public KubernetesFolderProperty() {
+    public KubernetesFolderProperty() {}
+
+    @DataBoundSetter
+    public void setPermittedClouds(Set<String> permittedClouds){
+        this.permittedClouds = new HashSet<>(permittedClouds);
     }
 
-    private Set<String> getPermittedClouds() {
-        return permittedClouds;
+    public Set<String> getPermittedClouds() {
+        return permittedClouds == null ? Collections.EMPTY_SET : new HashSet<>(permittedClouds);
     }
 
-    private Set<String> getInheritedClouds() {
+    private static Set<String> getInheritedClouds(ItemGroup parent) {
         Set<String> inheritedPermissions = new HashSet<>();
-        collectAllowedClouds(inheritedPermissions, getOwner().getParent());
-
+        collectAllowedClouds(inheritedPermissions, parent);
         return inheritedPermissions;
     }
 
@@ -65,36 +66,15 @@ public class KubernetesFolderProperty extends AbstractFolderProperty<AbstractFol
     @SuppressWarnings("unused") // Used by jelly
     @Restricted(DoNotUse.class) // Used by jelly
     public List<UsagePermission> getEffectivePermissions() {
-        List<UsagePermission> ps = buildPermissions();
-
-        Set<String> inheritedClouds = getInheritedClouds();
-
-        for (UsagePermission p : ps) {
-            if (inheritedClouds.contains(p.name)) {
-                p.setGranted(true);
-                p.setInherited(true);
-            }
-
-            if (getPermittedClouds().contains(p.name)) {
-                p.setGranted(true);
-            }
-        }
-
+        Set<String> inheritedClouds = getInheritedClouds(Stapler.getCurrentRequest().findAncestorObject(Folder.class));
+        List<UsagePermission> ps = getUsageRestrictedKubernetesClouds().stream()
+                                                                       .map(cloud -> new UsagePermission(cloud.name,
+                                                                                                         inheritedClouds.contains(cloud.name) || getEffectivePermissions().contains(cloud.name),
+                                                                                                         inheritedClouds.contains(cloud.name)))
+                                                                       .collect(Collectors.toList());
         // a non-admin User is only allowed to see granted clouds
         if (!userHasAdministerPermission()) {
             ps = ps.stream().filter(UsagePermission::isGranted).collect(Collectors.toList());
-        }
-
-        return ps;
-    }
-
-    private static List<UsagePermission> buildPermissions() {
-        List<UsagePermission> ps = new ArrayList<>();
-
-        for (KubernetesCloud kubernetesCloud : getUsageRestrictedKubernetesClouds()) {
-            UsagePermission p = new UsagePermission();
-            p.setName(kubernetesCloud.name);
-            ps.add(p);
         }
 
         return ps;
@@ -113,8 +93,6 @@ public class KubernetesFolderProperty extends AbstractFolderProperty<AbstractFol
         return true;
     }
 
-    private static String PREFIX_USAGE_PERMISSION = "usage-permission-";
-
     @Override
     public AbstractFolderProperty<?> reconfigure(StaplerRequest req, JSONObject form) throws FormException {
         if (form == null) {
@@ -126,32 +104,15 @@ public class KubernetesFolderProperty extends AbstractFolderProperty<AbstractFol
         if (!userHasAdministerPermission()) {
             return this;
         }
-
-        try {
-            Set<String> inheritedGrants = new HashSet<>();
-            collectAllowedClouds(inheritedGrants, getOwner().getParent());
-
-            Set<String> permittedClouds = new HashSet<>();
-            JSONArray names = form.names();
-            if (names != null) {
-                for (Object name : names) {
-                    String strName = (String) name;
-
-                    if (strName.startsWith(PREFIX_USAGE_PERMISSION) && form.getBoolean(strName)) {
-                        String cloud = StringUtils.replaceOnce(strName, PREFIX_USAGE_PERMISSION, "");
-
-                        if (isUsageRestrictedKubernetesCloud(Jenkins.get().getCloud(cloud))
-                                && !inheritedGrants.contains(cloud)) {
-                            permittedClouds.add(cloud);
-                        }
-                    }
-                }
-            }
-            this.permittedClouds.clear();
-            this.permittedClouds.addAll(permittedClouds);
-        } catch (JSONException e) {
-            LOGGER.log(Level.SEVERE, e, () -> "reconfigure failed: " + e.getMessage());
+        // Backwards compatibility: this method was expecting a set of entries PREFIX_USAGE_PERMISSION+cloudName --> true | false
+        // Now we're getting a set of permitted cloud names inside permittedClouds entry
+        Set<String> formCloudnames = new HashSet<>();
+        if (form.get("permittedClouds") == null) {
+            form.names().stream().filter(x -> form.getBoolean(x.toString())).forEach(x -> formCloudnames.add(x.toString().replace(PREFIX_USAGE_PERMISSION, "")));
+        } else {
+            formCloudnames.addAll(form.getJSONArray("permittedClouds").stream().map(x -> x.toString()).collect(Collectors.toSet()));
         }
+        setPermittedClouds(formCloudnames);
         return this;
     }
 
@@ -195,6 +156,12 @@ public class KubernetesFolderProperty extends AbstractFolderProperty<AbstractFol
 
         private String name;
 
+        public UsagePermission(String name, boolean granted, boolean inherited) {
+            this.name = name;
+            this.granted = granted;
+            this.inherited = inherited;
+        }
+
         private void setInherited(boolean inherited) {
             this.inherited = inherited;
         }
@@ -222,12 +189,7 @@ public class KubernetesFolderProperty extends AbstractFolderProperty<AbstractFol
          * @return
          */
         public String getName() {
-            return name + (isInherited() ? " (inherited)" : "");
-        }
-
-        @SuppressWarnings("unused") // by stapler/jelly
-        public String getFormName() {
-            return PREFIX_USAGE_PERMISSION + getName();
+            return name;
         }
 
         @SuppressWarnings("unused") // by stapler/jelly
@@ -260,6 +222,18 @@ public class KubernetesFolderProperty extends AbstractFolderProperty<AbstractFol
             return Messages.KubernetesFolderProperty_displayName();
         }
 
+        public static List<UsagePermission> getEffectivePermissions() {
+            Set<String> inheritedClouds = getInheritedClouds(Stapler.getCurrentRequest().findAncestorObject(Folder.class).getParent());
+            List<UsagePermission> ps = getUsageRestrictedKubernetesClouds().stream()
+                                                                           .map(cloud -> new UsagePermission(cloud.name, inheritedClouds.contains(cloud.name), inheritedClouds.contains(cloud.name)))
+                                                                           .collect(Collectors.toList());
+            // a non-admin User is only allowed to see granted clouds
+            if (!userHasAdministerPermission()) {
+                ps = ps.stream().filter(UsagePermission::isGranted).collect(Collectors.toList());
+            }
+
+            return ps;
+        }
     }
 
 }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFolderProperty.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFolderProperty.java
@@ -64,26 +64,6 @@ public class KubernetesFolderProperty extends AbstractFolderProperty<AbstractFol
         return inheritedPermissions;
     }
 
-    /**
-     * Called from Jelly.
-     * 
-     * @return
-     */
-    public List<UsagePermission> getEffectivePermissions() {
-        Set<String> inheritedClouds = getInheritedClouds(Stapler.getCurrentRequest().findAncestorObject(Folder.class));
-        List<UsagePermission> ps = getUsageRestrictedKubernetesClouds().stream()
-                                                                       .map(cloud -> new UsagePermission(cloud.name,
-                                                                                                         inheritedClouds.contains(cloud.name) || getEffectivePermissions().contains(cloud.name),
-                                                                                                         inheritedClouds.contains(cloud.name)))
-                                                                       .collect(Collectors.toList());
-        // a non-admin User is only allowed to see granted clouds
-        if (!userHasAdministerPermission()) {
-            ps = ps.stream().filter(UsagePermission::isGranted).collect(Collectors.toList());
-        }
-
-        return ps;
-    }
-
     @SuppressWarnings({"rawtypes"})
     public static boolean isAllowed(KubernetesSlave agent, Job job) {
         ItemGroup parent = job.getParent();
@@ -233,7 +213,7 @@ public class KubernetesFolderProperty extends AbstractFolderProperty<AbstractFol
         }
 
         @SuppressWarnings("unused") // Used by jelly
-        @Restricted(DoNotUse.class) // Used by jelly
+        @Restricted(DoNotUse.class)
         public List<UsagePermission> getEffectivePermissions() {
             Set<String> inheritedClouds = getInheritedClouds(Stapler.getCurrentRequest().findAncestorObject(Folder.class).getParent());
             List<UsagePermission> ps = getUsageRestrictedKubernetesClouds().stream()

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFolderProperty.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFolderProperty.java
@@ -49,7 +49,7 @@ public class KubernetesFolderProperty extends AbstractFolderProperty<AbstractFol
     }
 
     public Set<String> getPermittedClouds() {
-        return permittedClouds == null ? Collections.EMPTY_SET : new HashSet<>(permittedClouds);
+        return permittedClouds == null ? Collections.emptySet() : Collections.unmodifiableSet(permittedClouds);
     }
 
     private static Set<String> getInheritedClouds(ItemGroup parent) {

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesFolderProperty/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesFolderProperty/config.jelly
@@ -4,30 +4,20 @@
 		<f:description>
 			${%Allow pipeline support for the following restricted Kubernetes Clouds}
 		</f:description>
-		<j:choose>
-			<j:when test="${instance != null}">
-				<j:set var="effectivePermissions" value="${instance.effectivePermissions}"/>
+		<f:entry field="permittedClouds">
+				<j:set var="effectivePermissions" value="${descriptor.effectivePermissions}"/>
 				<j:choose>
 					<j:when test="${empty effectivePermissions}">
 						<f:entry title="-- none --" />
 					</j:when>
 					<j:otherwise>
 						<j:forEach var="permission" items="${effectivePermissions}">
-							<f:entry field="${permission.formName}">
 								<j:set var="readOnlyMode" value="${permission.readonly}"/>
-								<f:checkbox title="${permission.name}" checked="${permission.granted}" />
-							</f:entry>
+								<f:checkbox title="${permission.name} ${permission.inherited ? '(inherited)' : ''}" json="${permission.name}"
+											checked="${permission.granted or instance.permittedClouds.contains(permission.name)}" /><br/>
 						</j:forEach>
 					</j:otherwise>
 				</j:choose>
-			</j:when>
-			<j:otherwise>
-				<f:entry title="${%You have to save this folder first before you can manage Kubernetes Clouds.}" />
-				<f:invisibleEntry>
-					<!-- Needed to create the property on save -->
-					<input type="checkbox"/>
-				</f:invisibleEntry>
-			</j:otherwise>
-		</j:choose>
+		</f:entry>
 	</f:section>
 </j:jelly>

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFolderPropertyTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFolderPropertyTest.java
@@ -1,0 +1,52 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import java.util.Collections;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import com.cloudbees.hudson.plugins.folder.Folder;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class KubernetesFolderPropertyTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void propertySavedOnFirstSaveTest() throws Exception {
+        KubernetesCloud kube1 = new KubernetesCloud("kube1");
+        kube1.setUsageRestricted(true);
+        KubernetesCloud kube2 = new KubernetesCloud("kube2");
+        kube2.setUsageRestricted(true);
+        j.jenkins.clouds.add(kube1);
+        j.jenkins.clouds.add(kube2);
+
+        Folder folder = j.jenkins.createProject(Folder.class, "folder001");
+        KubernetesFolderProperty prop = new KubernetesFolderProperty();
+        folder.addProperty(prop);
+
+        Folder after = j.configRoundtrip(folder);
+        assertThat("Property exists after saving", after.getProperties().get(KubernetesFolderProperty.class), notNullValue());
+        assertThat("No selected clouds", after.getProperties().get(KubernetesFolderProperty.class).getPermittedClouds(), empty());
+
+        folder.getProperties().get(KubernetesFolderProperty.class).setPermittedClouds(Collections.singletonList("kube1"));
+        after = j.configRoundtrip(folder);
+        assertThat("Kube1 cloud is added", after.getProperties().get(KubernetesFolderProperty.class).getPermittedClouds(), contains("kube1"));
+
+        Folder subFolder = folder.createProject(Folder.class, "subfolder001");
+        KubernetesFolderProperty prop2 = new KubernetesFolderProperty();
+        prop2.setPermittedClouds(Collections.singletonList("kube2"));
+        subFolder.addProperty(prop2);
+
+        after = j.configRoundtrip(subFolder);
+        assertThat("Contains own and inherited cloud", after.getProperties().get(KubernetesFolderProperty.class).getPermittedClouds(), containsInAnyOrder("kube1", "kube2"));
+    }
+
+}

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesQueueTaskDispatcherTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesQueueTaskDispatcherTest.java
@@ -20,7 +20,6 @@ import org.mockito.junit.MockitoRule;
 
 import java.util.ArrayList;
 import java.util.Calendar;
-import java.util.Collections;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.when;
@@ -74,55 +73,9 @@ public class KubernetesQueueTaskDispatcherTest {
         slaveB = new KubernetesSlave("B", new PodTemplate(), "testB", "B", "dockerB", new KubernetesLauncher(), RetentionStrategy.INSTANCE);
     }
 
-    public void setUpTwoCloudsPermittedCloudsForm() throws Exception {
-        folderA = new Folder(jenkins.jenkins, "A");
-        folderB = new Folder(jenkins.jenkins, "B");
-        jenkins.jenkins.add(folderA, "Folder A");
-        jenkins.jenkins.add(folderB, "Folder B");
-
-        KubernetesCloud cloudA = new KubernetesCloud("A");
-        cloudA.setUsageRestricted(true);
-
-        KubernetesCloud cloudB = new KubernetesCloud("B");
-        cloudB.setUsageRestricted(true);
-
-        jenkins.jenkins.clouds.add(cloudA);
-        jenkins.jenkins.clouds.add(cloudB);
-
-        KubernetesFolderProperty property1 = new KubernetesFolderProperty();
-        folderA.addProperty(property1);
-        JSONObject json1 = new JSONObject();
-        json1.element("permittedClouds", Collections.singletonList("A"));
-        folderA.addProperty(property1.reconfigure(null, json1));
-
-        KubernetesFolderProperty property2 = new KubernetesFolderProperty();
-        folderB.addProperty(property2);
-        JSONObject json2 = new JSONObject();
-        json2.element("permittedClouds", Collections.singletonList("B"));
-        folderB.addProperty(property2.reconfigure(null, json2));
-
-        slaveA = new KubernetesSlave("A", new PodTemplate(), "testA", "A", "dockerA", new KubernetesLauncher(), RetentionStrategy.INSTANCE);
-        slaveB = new KubernetesSlave("B", new PodTemplate(), "testB", "B", "dockerB", new KubernetesLauncher(), RetentionStrategy.INSTANCE);
-    }
-
     @Test
     public void checkRestrictedTwoClouds() throws Exception {
         setUpTwoClouds();
-
-        FreeStyleProject projectA = folderA.createProject(FreeStyleProject.class, "buildJob");
-        FreeStyleProject projectB = folderB.createProject(FreeStyleProject.class, "buildJob");
-        KubernetesQueueTaskDispatcher dispatcher = new KubernetesQueueTaskDispatcher();
-
-        assertNull(dispatcher.canTake(slaveA, new Queue.BuildableItem(new Queue.WaitingItem(Calendar.getInstance(), projectA, new ArrayList<>()))));
-        assertTrue(canTake(dispatcher, slaveB, projectA) instanceof KubernetesQueueTaskDispatcher.KubernetesCloudNotAllowed);
-        assertTrue(canTake(dispatcher, slaveA, projectB) instanceof KubernetesQueueTaskDispatcher.KubernetesCloudNotAllowed);
-        assertNull(canTake(dispatcher, slaveB, projectB));
-    }
-
-    @Test
-    public void checkRestrictedTwoCloudsPermittedCloudsForm() throws Exception {
-        // New permittedClouds form for permittedClouds
-        setUpTwoCloudsPermittedCloudsForm();
 
         FreeStyleProject projectA = folderA.createProject(FreeStyleProject.class, "buildJob");
         FreeStyleProject projectB = folderB.createProject(FreeStyleProject.class, "buildJob");

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesQueueTaskDispatcherTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesQueueTaskDispatcherTest.java
@@ -20,6 +20,7 @@ import org.mockito.junit.MockitoRule;
 
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collections;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.when;
@@ -73,6 +74,36 @@ public class KubernetesQueueTaskDispatcherTest {
         slaveB = new KubernetesSlave("B", new PodTemplate(), "testB", "B", "dockerB", new KubernetesLauncher(), RetentionStrategy.INSTANCE);
     }
 
+    public void setUpTwoCloudsPermittedCloudsForm() throws Exception {
+        folderA = new Folder(jenkins.jenkins, "A");
+        folderB = new Folder(jenkins.jenkins, "B");
+        jenkins.jenkins.add(folderA, "Folder A");
+        jenkins.jenkins.add(folderB, "Folder B");
+
+        KubernetesCloud cloudA = new KubernetesCloud("A");
+        cloudA.setUsageRestricted(true);
+
+        KubernetesCloud cloudB = new KubernetesCloud("B");
+        cloudB.setUsageRestricted(true);
+
+        jenkins.jenkins.clouds.add(cloudA);
+        jenkins.jenkins.clouds.add(cloudB);
+
+        KubernetesFolderProperty property1 = new KubernetesFolderProperty();
+        folderA.addProperty(property1);
+        JSONObject json1 = new JSONObject();
+        json1.element("permittedClouds", Collections.singletonList("A"));
+        folderA.addProperty(property1.reconfigure(null, json1));
+
+        KubernetesFolderProperty property2 = new KubernetesFolderProperty();
+        folderB.addProperty(property2);
+        JSONObject json2 = new JSONObject();
+        json2.element("permittedClouds", Collections.singletonList("B"));
+        folderB.addProperty(property2.reconfigure(null, json2));
+
+        slaveA = new KubernetesSlave("A", new PodTemplate(), "testA", "A", "dockerA", new KubernetesLauncher(), RetentionStrategy.INSTANCE);
+        slaveB = new KubernetesSlave("B", new PodTemplate(), "testB", "B", "dockerB", new KubernetesLauncher(), RetentionStrategy.INSTANCE);
+    }
 
     @Test
     public void checkRestrictedTwoClouds() throws Exception {
@@ -82,8 +113,22 @@ public class KubernetesQueueTaskDispatcherTest {
         FreeStyleProject projectB = folderB.createProject(FreeStyleProject.class, "buildJob");
         KubernetesQueueTaskDispatcher dispatcher = new KubernetesQueueTaskDispatcher();
 
-        assertNull(dispatcher.canTake(slaveA, new Queue.BuildableItem(new Queue.WaitingItem(Calendar.getInstance(),
-                projectA, new ArrayList<>()))));
+        assertNull(dispatcher.canTake(slaveA, new Queue.BuildableItem(new Queue.WaitingItem(Calendar.getInstance(), projectA, new ArrayList<>()))));
+        assertTrue(canTake(dispatcher, slaveB, projectA) instanceof KubernetesQueueTaskDispatcher.KubernetesCloudNotAllowed);
+        assertTrue(canTake(dispatcher, slaveA, projectB) instanceof KubernetesQueueTaskDispatcher.KubernetesCloudNotAllowed);
+        assertNull(canTake(dispatcher, slaveB, projectB));
+    }
+
+    @Test
+    public void checkRestrictedTwoCloudsPermittedCloudsForm() throws Exception {
+        // New permittedClouds form for permittedClouds
+        setUpTwoCloudsPermittedCloudsForm();
+
+        FreeStyleProject projectA = folderA.createProject(FreeStyleProject.class, "buildJob");
+        FreeStyleProject projectB = folderB.createProject(FreeStyleProject.class, "buildJob");
+        KubernetesQueueTaskDispatcher dispatcher = new KubernetesQueueTaskDispatcher();
+
+        assertNull(dispatcher.canTake(slaveA, new Queue.BuildableItem(new Queue.WaitingItem(Calendar.getInstance(), projectA, new ArrayList<>()))));
         assertTrue(canTake(dispatcher, slaveB, projectA) instanceof KubernetesQueueTaskDispatcher.KubernetesCloudNotAllowed);
         assertTrue(canTake(dispatcher, slaveA, projectB) instanceof KubernetesQueueTaskDispatcher.KubernetesCloudNotAllowed);
         assertNull(canTake(dispatcher, slaveB, projectB));


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
kubernetesFolderProperty/permittedClouds used a "non-standard" way of setting property up, so it needed to have the folder saved before applying it (Configure -> Save -> Configure).

With this change cloud list is provided by the `Descriptorimpl` having all the clouds available regardless the instance of the property hasn't been created yet.

Also, clouds in the form were being treated as `JSONObject` map entries (`usage-permission-<cloud-name>` --> `true | false`), so this object was treated in `reconfigure` to generate a `Set<String>` with the permitted clouds, this has been changed to follow a simpler approach, with a `permittedClouds` entry containing the list of cloud names now (`permittedClouds` --> `["cloudA", "cloudB", ...]`).

Migration is not needed, as the saved object is the same as before this change. Anyway, a check has been added to `KubernetesFolderProperty#reconfigure` to make sure usage of the old form values is still accepted. 

An analog test to existing ones with the new form layout has also been added.


- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
