### PR TITLE
Document necessary k8s Role rules for plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -820,6 +820,35 @@ just runs something and exit then it should be overridden with something like `c
 **WARNING**
 If you want to provide your own Docker image for the inbound agent, you **must** name the container `jnlp` so it overrides the default one. Failing to do so will result in two agents trying to concurrently connect to the controller.
 
+# Running with custom ServiceAccount
+
+If you need to run Jenkins under a custom service account, it must have these Role rules to make the kubernetes-plugin work:
+
+```yaml
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: jenkins
+rules:
+  - verbs:
+      - create
+      - list
+      - get
+      - watch
+      - delete
+    apiGroups:
+      - ''
+    resources:
+      - pods
+  - verbs:
+      - watch
+    apiGroups:
+      - ''
+    resources:
+      - events
+```
+
+
 # Configuration on minikube
 
 Create and start [minikube](https://github.com/kubernetes/minikube)

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ It is not required to run the Jenkins controller inside Kubernetes.
 * A running Kubernetes cluster 1.14 or later. For OpenShift users, this means OpenShift Container Platform 4.x.
 * A Jenkins instance installed
 * The Jenkins Kubernetes plugin installed
+* A ServiceAccount with sufficient privileges ([example](src/main/kubernetes/service-account.yml))
 
 ## Configuration
 
@@ -819,35 +820,6 @@ just runs something and exit then it should be overridden with something like `c
 
 **WARNING**
 If you want to provide your own Docker image for the inbound agent, you **must** name the container `jnlp` so it overrides the default one. Failing to do so will result in two agents trying to concurrently connect to the controller.
-
-# Running with custom ServiceAccount
-
-If you need to run Jenkins under a custom service account, it must have these Role rules to make the kubernetes-plugin work:
-
-```yaml
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: jenkins
-rules:
-  - verbs:
-      - create
-      - list
-      - get
-      - watch
-      - delete
-    apiGroups:
-      - ''
-    resources:
-      - pods
-  - verbs:
-      - watch
-    apiGroups:
-      - ''
-    resources:
-      - events
-```
-
 
 # Configuration on minikube
 


### PR DESCRIPTION
The plugin requires specific kubernetes Role assignments to work correctly if running under a custom ServiceAccount

I am not particular about the title/wording of the documentation, but it could have saved me some time to have this information in the documentation.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
