### PR TITLE
Remove `instance-identity` dep

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,12 +216,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.jenkins-ci.modules</groupId>
-      <artifactId>instance-identity</artifactId>
-      <version>2.2</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>pl.pragmatists</groupId>
       <artifactId>JUnitParams</artifactId>
       <version>1.1.1</version>


### PR DESCRIPTION
Does not appear to be necessary; the only time that the instance identity is used directly by this plugin is in direct connect mode for TCP agents, but even then we get the public key from core anyway: https://github.com/jenkinsci/kubernetes-plugin/blob/44fee1844a33a5946bf9f721edb9da64b7b7b3da/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java#L436

See https://github.com/jenkinsci/jenkins/pull/6585. Supersedes #1183.
