### PR TITLE
Make Docker registry for JNLP image configurable

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -160,13 +160,12 @@ public class KubernetesCloud extends Cloud {
     }
 
     @Deprecated
-    public KubernetesCloud(String name, List<? extends PodTemplate> templates, String serverUrl, String namespace, String jnlpregistry,
+    public KubernetesCloud(String name, List<? extends PodTemplate> templates, String serverUrl, String namespace,
             String jenkinsUrl, String containerCapStr, int connectTimeout, int readTimeout, int retentionTimeout) {
         this(name);
 
         setServerUrl(serverUrl);
         setNamespace(namespace);
-        setJnlpregistry(jnlpregistry);
         setJenkinsUrl(jenkinsUrl);
         if (templates != null) {
             this.templates.addAll(templates);

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -280,7 +280,6 @@ public class KubernetesCloud extends Cloud {
     @DataBoundSetter
     public void setJnlpregistry(String jnlpregistry) {
         this.jnlpregistry = Util.fixEmpty(jnlpregistry);
-        PodTemplateBuilder.DEFAULT_JNLP_DOCKER_REGISTRY_PREFIX = jnlpregistry;
     }
 
     @CheckForNull

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -110,6 +110,7 @@ public class KubernetesCloud extends Cloud {
     private boolean capOnlyOnAlivePods;
 
     private String namespace;
+    private String jnlpregistry;
     private boolean webSocket;
     private boolean directConnection = false;
     private String jenkinsUrl;
@@ -159,12 +160,13 @@ public class KubernetesCloud extends Cloud {
     }
 
     @Deprecated
-    public KubernetesCloud(String name, List<? extends PodTemplate> templates, String serverUrl, String namespace,
+    public KubernetesCloud(String name, List<? extends PodTemplate> templates, String serverUrl, String namespace, String jnlpregistry,
             String jenkinsUrl, String containerCapStr, int connectTimeout, int readTimeout, int retentionTimeout) {
         this(name);
 
         setServerUrl(serverUrl);
         setNamespace(namespace);
+        setJnlpregistry(jnlpregistry);
         setJenkinsUrl(jenkinsUrl);
         if (templates != null) {
             this.templates.addAll(templates);
@@ -269,6 +271,16 @@ public class KubernetesCloud extends Cloud {
     @DataBoundSetter
     public void setNamespace(String namespace) {
         this.namespace = Util.fixEmpty(namespace);
+    }
+
+    public String getJnlpregistry() {
+        return jnlpregistry;
+    }
+
+    @DataBoundSetter
+    public void setJnlpregistry(String jnlpregistry) {
+        this.jnlpregistry = Util.fixEmpty(jnlpregistry);
+        PodTemplateBuilder.DEFAULT_JNLP_DOCKER_REGISTRY_PREFIX = jnlpregistry;
     }
 
     @CheckForNull
@@ -663,6 +675,7 @@ public class KubernetesCloud extends Cloud {
                 Objects.equals(serverUrl, that.serverUrl) &&
                 Objects.equals(serverCertificate, that.serverCertificate) &&
                 Objects.equals(namespace, that.namespace) &&
+                Objects.equals(jnlpregistry, that.jnlpregistry)&&
                 Objects.equals(jenkinsUrl, that.jenkinsUrl) &&
                 Objects.equals(jenkinsTunnel, that.jenkinsTunnel) &&
                 Objects.equals(credentialsId, that.credentialsId) &&
@@ -675,7 +688,7 @@ public class KubernetesCloud extends Cloud {
     @Override
     public int hashCode() {
         return Objects.hash(defaultsProviderTemplate, templates, serverUrl, serverCertificate, skipTlsVerify,
-                addMasterProxyEnvVars, capOnlyOnAlivePods, namespace, jenkinsUrl, jenkinsTunnel, credentialsId,
+                addMasterProxyEnvVars, capOnlyOnAlivePods, namespace, jnlpregistry, jenkinsUrl, jenkinsTunnel, credentialsId,
                 containerCap, retentionTimeout, connectTimeout, readTimeout, podLabels, usageRestricted,
                 maxRequestsPerHost, podRetention, useJenkinsProxy);
     }
@@ -884,6 +897,7 @@ public class KubernetesCloud extends Cloud {
                 ", addMasterProxyEnvVars=" + addMasterProxyEnvVars +
                 ", capOnlyOnAlivePods=" + capOnlyOnAlivePods +
                 ", namespace='" + namespace + '\'' +
+                ", jnlpregistry='" + jnlpregistry + '\'' +
                 ", jenkinsUrl='" + jenkinsUrl + '\'' +
                 ", jenkinsTunnel='" + jenkinsTunnel + '\'' +
                 ", credentialsId='" + credentialsId + '\'' +

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -312,7 +312,9 @@ public class PodTemplateBuilder {
         pod.getSpec().getContainers().stream().filter(c -> c.getWorkingDir() == null).forEach(c -> c.setWorkingDir(jnlp.getWorkingDir()));
         if (StringUtils.isBlank(jnlp.getImage())) {
             String jnlpImage = DEFAULT_JNLP_IMAGE;
-            if (StringUtils.isNotEmpty(DEFAULT_JNLP_DOCKER_REGISTRY_PREFIX)) {
+            if (StringUtils.isNotEmpty(cloud.getJnlpregistry())) {
+                jnlpImage = Util.ensureEndsWith(cloud.getJnlpregistry(), "/") + jnlpImage;
+            } else if (StringUtils.isNotEmpty(DEFAULT_JNLP_DOCKER_REGISTRY_PREFIX)) {
                 jnlpImage = Util.ensureEndsWith(DEFAULT_JNLP_DOCKER_REGISTRY_PREFIX, "/") + jnlpImage;
             }
             jnlp.setImage(jnlpImage);

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -312,7 +312,7 @@ public class PodTemplateBuilder {
         pod.getSpec().getContainers().stream().filter(c -> c.getWorkingDir() == null).forEach(c -> c.setWorkingDir(jnlp.getWorkingDir()));
         if (StringUtils.isBlank(jnlp.getImage())) {
             String jnlpImage = DEFAULT_JNLP_IMAGE;
-            if (StringUtils.isNotEmpty(cloud.getJnlpregistry())) {
+            if (cloud != null && StringUtils.isNotEmpty(cloud.getJnlpregistry())) {
                 jnlpImage = Util.ensureEndsWith(cloud.getJnlpregistry(), "/") + jnlpImage;
             } else if (StringUtils.isNotEmpty(DEFAULT_JNLP_DOCKER_REGISTRY_PREFIX)) {
                 jnlpImage = Util.ensureEndsWith(DEFAULT_JNLP_DOCKER_REGISTRY_PREFIX, "/") + jnlpImage;

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/config.jelly
@@ -27,6 +27,10 @@
         <f:textbox/>
       </f:entry>
 
+      <f:entry title="${%JNLP Docker Registry}" field="jnlpregistry">
+        <f:textbox/>
+      </f:entry>
+
       <f:entry title="${%Credentials}" field="credentialsId">
         <c:select/>
       </f:entry>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/help-jnlpregistry.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/help-jnlpregistry.html
@@ -1,0 +1,3 @@
+<div>
+    Provide the docker registry you want to use to pull the JNLP image if none is specified
+</div>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
In case a Jenkins does not have the ability to pull from DockerHub but instead there is a DockerHub mirror available this should be used for the default JNLP image that will be in every pod that has not specified a JNLP image.
The reason why only the registry should be configured instead of the entire image path is that this way the plugin still decides which is the correct image to use and the configuration only defines where this image should come from.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
