### PR TITLE
Fix `KubernetesPipelineTest#errorPod` flakiness

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodUtils.java
@@ -145,7 +145,7 @@ public final class PodUtils {
                     sb.append(log);
                     sb.append("\n");
                 } catch (KubernetesClientException e) {
-                    LOGGER.log(Level.FINE, "Unable to retrieve container logs as it is already gone", e);
+                    LOGGER.log(Level.FINE, e, () -> namespace + "/" + podName + " Unable to retrieve container logs as the pod is already gone");
                 }
             }
         }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/retention/Reaper.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/retention/Reaper.java
@@ -240,10 +240,10 @@ public class Reaper extends ComputerListener implements Watcher<Pod> {
                     LOGGER.info(() -> ns + "/" + name + " Container " + c.getName() + " was just terminated, so removing the corresponding Jenkins agent");
                     runListener.getLogger().printf("%s/%s Container %s was terminated (Exit Code: %d, Reason: %s)%n", ns, name, c.getName(), t.getExitCode(), t.getReason());
                 });
+                logLastLinesThenTerminateNode(node, pod, runListener);
                 try (ACLContext _ = ACL.as(ACL.SYSTEM)) {
                     PodUtils.cancelQueueItemFor(pod, "ContainerError");
                 }
-                logLastLinesThenTerminateNode(node, pod, runListener);
             }
         }
     }


### PR DESCRIPTION
Looks like removing the queue item can kill the thread (?) so the
logging wasn't performed as expected

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
