### PR TITLE
JENKINS-68757 - adding subPath support for PersistentVolumeClaim volumes

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes/PersistentVolumeClaim.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes/PersistentVolumeClaim.java
@@ -28,6 +28,7 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 import hudson.Extension;
 import hudson.model.Descriptor;
@@ -36,6 +37,7 @@ import io.fabric8.kubernetes.api.model.VolumeBuilder;
 
 public class PersistentVolumeClaim extends PodVolume {
     private String mountPath;
+    private String subPath;    
     private String claimName;
     @CheckForNull
     private Boolean readOnly;
@@ -61,6 +63,14 @@ public class PersistentVolumeClaim extends PodVolume {
         return readOnly != null && readOnly;
     }
 
+    public String getSubPath() {
+        return subPath;
+    }
+    
+    @DataBoundSetter
+    public void setSubPath(String subPath) {
+        this.subPath = subPath;
+    }
     @Override
     public Volume buildVolume(String volumeName) {
         return new VolumeBuilder()

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/volumes/PersistentVolumeClaim/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/volumes/PersistentVolumeClaim/config.jelly
@@ -13,5 +13,9 @@
   <f:entry title="${%Mount path}" field="mountPath">
     <f:textbox />
   </f:entry>
+  
+  <f:entry title="${%Mount subPath}" field="subPath">
+    <f:textbox />
+  </f:entry>
 
 </j:jelly>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/volumes/PersistentVolumeClaim/config_zh_CN.properties
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/volumes/PersistentVolumeClaim/config_zh_CN.properties
@@ -23,3 +23,4 @@
 Claim\ Name=\u7533\u660E\u503C
 Read\ Only=\u53EA\u8BFB
 Mount\ path=\u6302\u8F7D\u8DEF\u5F84
+Mount\ subPath\u5b50\u8def\u5f84

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PersistentVolumeClaimTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PersistentVolumeClaimTest.java
@@ -1,0 +1,23 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import org.csanchez.jenkins.plugins.kubernetes.volumes.PersistentVolumeClaim;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+public class PersistentVolumeClaimTest {
+
+    @Test
+    public void testNullSubPathValue() {
+	PersistentVolumeClaim persistentVolumeClaim= new PersistentVolumeClaim("oneMountPath", "Myvolume",false);
+        assertNull(persistentVolumeClaim.getSubPath());
+    }
+
+    @Test
+    public void testValidSubPathValue() {
+	PersistentVolumeClaim persistentVolumeClaim= new PersistentVolumeClaim("oneMountPath", "Myvolume",false);
+	persistentVolumeClaim.setSubPath("miSubpath");
+        assertEquals(persistentVolumeClaim.getSubPath(),"miSubpath");
+    }
+
+}


### PR DESCRIPTION
add subpath support for PVC volumes and update volumes definition in yaml output to only keep one volume for PVC with same claimName

- [x ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x ] Ensure that the pull request title represents the desired changelog entry
- [x ] Please describe what you did
- [x ] Link to relevant issues in GitHub or Jira
- [x ] Link to relevant pull requests, esp. upstream and downstream changes
- [x ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
