### PR TITLE
[JENKINS-49707] `retries` option for `agent kubernetes`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -258,11 +258,6 @@
         <scope>import</scope>
         <type>pom</type>
       </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>script-security</artifactId>
-        <version>1172.v35f6a_0b_8207e</version> <!-- TODO until in BOM -->
-      </dependency>
       <dependency> <!-- TODO as above -->
         <groupId>org.jenkinsci.plugins</groupId>
         <artifactId>pipeline-model-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <no-test-jar>false</no-test-jar>
     <useBeta>true</useBeta>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <pipeline-model-definition-plugin.version>2.2109.vb_27c2f52c324</pipeline-model-definition-plugin.version> <!-- TODO https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/533 -->
+    <pipeline-model-definition-plugin.version>2.2114.v2654ca_721309</pipeline-model-definition-plugin.version> <!-- TODO until in BOM -->
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
     <no-test-jar>false</no-test-jar>
     <useBeta>true</useBeta>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
+    <pipeline-model-definition-plugin.version>2.2109.vb_27c2f52c324</pipeline-model-definition-plugin.version> <!-- TODO https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/533 -->
   </properties>
 
   <dependencies>
@@ -256,6 +257,37 @@
         <version>1478.v81d3dc4f9a_43</version>
         <scope>import</scope>
         <type>pom</type>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>script-security</artifactId>
+        <version>1172.v35f6a_0b_8207e</version> <!-- TODO until in BOM -->
+      </dependency>
+      <dependency> <!-- TODO as above -->
+        <groupId>org.jenkinsci.plugins</groupId>
+        <artifactId>pipeline-model-api</artifactId>
+        <version>${pipeline-model-definition-plugin.version}</version>
+      </dependency>
+      <dependency> <!-- TODO as above -->
+        <groupId>org.jenkinsci.plugins</groupId>
+        <artifactId>pipeline-model-definition</artifactId>
+        <version>${pipeline-model-definition-plugin.version}</version>
+      </dependency>
+      <dependency> <!-- TODO as above -->
+        <groupId>org.jenkinsci.plugins</groupId>
+        <artifactId>pipeline-model-definition</artifactId>
+        <version>${pipeline-model-definition-plugin.version}</version>
+        <classifier>tests</classifier>
+      </dependency>
+      <dependency> <!-- TODO as above -->
+        <groupId>org.jenkinsci.plugins</groupId>
+        <artifactId>pipeline-model-extensions</artifactId>
+        <version>${pipeline-model-definition-plugin.version}</version>
+      </dependency>
+      <dependency> <!-- TODO as above -->
+        <groupId>org.jenkinsci.plugins</groupId>
+        <artifactId>pipeline-stage-tags-metadata</artifactId>
+        <version>${pipeline-model-definition-plugin.version}</version>
       </dependency>
       <!-- Fix InjectedTest -->
       <dependency>

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgent.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgent.java
@@ -13,7 +13,6 @@ import org.csanchez.jenkins.plugins.kubernetes.pod.retention.PodRetention;
 import org.csanchez.jenkins.plugins.kubernetes.pod.yaml.YamlMergeStrategy;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.workspace.WorkspaceVolume;
 import org.jenkinsci.Symbol;
-import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgent;
 import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentDescriptor;
 import org.jenkinsci.plugins.variant.OptionalExtension;
 import org.kohsuke.accmod.Restricted;
@@ -30,8 +29,9 @@ import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import org.jenkinsci.plugins.pipeline.modeldefinition.agent.RetryableDeclarativeAgent;
 
-public class KubernetesDeclarativeAgent extends DeclarativeAgent<KubernetesDeclarativeAgent> {
+public class KubernetesDeclarativeAgent extends RetryableDeclarativeAgent<KubernetesDeclarativeAgent> {
 
     private static final Logger LOGGER = Logger.getLogger(KubernetesDeclarativeAgent.class.getName());
 

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgent/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgent/config.jelly
@@ -1,5 +1,5 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
   <f:entry field="cloud" title="${%Cloud to use}">
     <f:select/>
   </f:entry>
@@ -49,5 +49,6 @@
     <f:entry title="${%Workspace Volume}" description="${%Volume to use for sharing the workspace}">
       <f:dropdownDescriptorSelector field="workspaceVolume" default="${descriptor.defaultWorkspaceVolume}"/>
     </f:entry>
+    <st:include page="retries" class="${descriptor.clazz}"/>
   </f:advanced>
 </j:jelly>

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/declarativeRetries.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/declarativeRetries.groovy
@@ -1,0 +1,26 @@
+pipeline {
+  agent {
+    kubernetes {
+      yaml '''
+spec:
+  containers:
+  - name: busybox
+    image: busybox
+    command:
+    - sleep
+    - 99d
+  terminationGracePeriodSeconds: 3
+      '''
+      defaultContainer 'busybox'
+      retries 2
+    }
+  }
+  stages {
+    stage('Run') {
+      steps {
+        sh 'echo hello world'
+        sh 'sleep 15'
+      }
+    }
+  }
+}


### PR DESCRIPTION
Follows up #1190. Split from #1083. Downstream of https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/533.
