### PR TITLE
[JENKINS-49707] Test `retry(…, conditions: [kubernetesAgent()])` across restarts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
+      <version>2725.v7b_c717eb_12ce</version> <!-- TODO until in BOM -->
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -136,13 +137,14 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-durable-task-step</artifactId>
-      <version>1174.v73a_9a_17edce0</version> <!-- TODO until in BOM -->
+      <version>1217.v0a_5c299d0a_59</version> <!-- TODO https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/180 -->
     </dependency>
 
     <!-- for testing -->
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-job</artifactId>
+      <version>1186.v8def1a_5f3944</version> <!-- TODO until in BOM -->
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -165,6 +167,7 @@
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
       <classifier>tests</classifier>
+      <version>2725.v7b_c717eb_12ce</version> <!-- TODO until in BOM -->
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -220,6 +223,12 @@
       <groupId>io.jenkins.configuration-as-code</groupId>
       <artifactId>test-harness</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion> <!-- TODO bom bug? -->
+          <groupId>org.jenkins-ci.main</groupId>
+          <artifactId>jenkins-test-harness</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <connectorHost />
     <jenkins.host.address />
     <slaveAgentPort />
-    <jenkins.version>2.332.1</jenkins.version>
+    <jenkins.version>2.346.1</jenkins.version>
     <no-test-jar>false</no-test-jar>
     <useBeta>true</useBeta>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
@@ -100,6 +100,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
+      <version>639.v6eca_cd8c04a_a_</version> <!-- TODO until in BOM -->
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -119,6 +120,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
+      <version>2759.v87459c4eea_ca_</version> <!-- TODO until in BOM -->
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -136,7 +138,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-durable-task-step</artifactId>
-      <version>1253.v17476f78c9db_</version> <!-- TODO https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/180 -->
+      <version>1283.v2e95e3a_da_a_c0</version> <!-- TODO https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/180 -->
     </dependency>
 
     <!-- for testing -->
@@ -252,7 +254,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.332.x</artifactId>
+        <artifactId>bom-2.346.x</artifactId>
         <version>1478.v81d3dc4f9a_43</version>
         <scope>import</scope>
         <type>pom</type>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
-      <version>2725.v7b_c717eb_12ce</version> <!-- TODO until in BOM -->
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -137,14 +136,13 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-durable-task-step</artifactId>
-      <version>1217.v0a_5c299d0a_59</version> <!-- TODO https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/180 -->
+      <version>1253.v17476f78c9db_</version> <!-- TODO https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/180 -->
     </dependency>
 
     <!-- for testing -->
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-job</artifactId>
-      <version>1186.v8def1a_5f3944</version> <!-- TODO until in BOM -->
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -167,7 +165,6 @@
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
       <classifier>tests</classifier>
-      <version>2725.v7b_c717eb_12ce</version> <!-- TODO until in BOM -->
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -223,12 +220,6 @@
       <groupId>io.jenkins.configuration-as-code</groupId>
       <artifactId>test-harness</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion> <!-- TODO bom bug? -->
-          <groupId>org.jenkins-ci.main</groupId>
-          <artifactId>jenkins-test-harness</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -100,11 +100,11 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
-      <version>639.v6eca_cd8c04a_a_</version> <!-- TODO until in BOM -->
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-api</artifactId>
+      <version>1200.v8005c684b_a_c6</version> <!-- TODO until in BOM -->
     </dependency>
     <dependency> <!-- DeclarativeAgent -->
       <groupId>org.jenkinsci.plugins</groupId>
@@ -120,7 +120,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
-      <version>2759.v87459c4eea_ca_</version> <!-- TODO until in BOM -->
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -138,7 +137,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-durable-task-step</artifactId>
-      <version>1283.v2e95e3a_da_a_c0</version> <!-- TODO https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/180 -->
+      <version>1206.v8a_d5f86e336b</version> <!-- TODO until in BOM -->
     </dependency>
 
     <!-- for testing -->
@@ -255,7 +254,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.346.x</artifactId>
-        <version>1494.v5d4d71876757</version>
+        <version>1643.v1cffef51df73</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/SecretsMasker.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/SecretsMasker.java
@@ -84,7 +84,13 @@ public final class SecretsMasker extends TaskListenerDecorator {
 
         @Override
         protected TaskListenerDecorator get(DelegatedContext context) throws IOException, InterruptedException {
-            KubernetesComputer c = context.get(KubernetesComputer.class);
+            KubernetesComputer c;
+            try {
+                c = context.get(KubernetesComputer.class);
+            } catch (IOException | InterruptedException x) {
+                LOGGER.log(Level.FINE, "Unable to look up KubernetesComputer", x);
+                return null;
+            }
             if (c == null) {
                 return null;
             }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/SecretsMasker.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/SecretsMasker.java
@@ -84,13 +84,7 @@ public final class SecretsMasker extends TaskListenerDecorator {
 
         @Override
         protected TaskListenerDecorator get(DelegatedContext context) throws IOException, InterruptedException {
-            KubernetesComputer c;
-            try {
-                c = context.get(KubernetesComputer.class);
-            } catch (IOException | InterruptedException x) {
-                LOGGER.log(Level.FINE, "Unable to look up KubernetesComputer", x);
-                return null;
-            }
+            KubernetesComputer c = context.get(KubernetesComputer.class);
             if (c == null) {
                 return null;
             }

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/terminatedPodAfterRestart.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/terminatedPodAfterRestart.groovy
@@ -1,11 +1,20 @@
 package org.csanchez.jenkins.plugins.kubernetes.pipeline
 
-podTemplate(label: '$NAME', containers: [
-        containerTemplate(name: 'busybox', image: 'busybox', ttyEnabled: true, command: '/bin/cat'),
-]) {
-    node ('$NAME') {
+podTemplate(yaml: '''
+spec:
+  containers:
+  - name: busybox
+    image: busybox
+    command:
+    - sleep
+    - 99d
+  terminationGracePeriodSeconds: 3
+''') {
+  retry(count: 2, conditions: [kubernetesAgent()]) {
+    node(POD_LABEL) {
         container('busybox') {
-                sh 'sleep 9999999'
+            sh 'sleep 15'
         }
     }
+  }
 }


### PR DESCRIPTION
Follows up #1190. Split from #1083. Downstream of https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/180.
