### PR TITLE
Robustness of `SecretsMasker` looking up `KubernetesComputer`

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/SecretsMasker.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/SecretsMasker.java
@@ -84,7 +84,13 @@ public final class SecretsMasker extends TaskListenerDecorator {
 
         @Override
         protected TaskListenerDecorator get(DelegatedContext context) throws IOException, InterruptedException {
-            KubernetesComputer c = context.get(KubernetesComputer.class);
+            KubernetesComputer c;
+            try {
+                c = context.get(KubernetesComputer.class);
+            } catch (IOException | InterruptedException x) {
+                LOGGER.log(Level.FINE, "Unable to look up KubernetesComputer", x);
+                return null;
+            }
             if (c == null) {
                 return null;
             }


### PR DESCRIPTION
Extracted from a test PR: https://github.com/jenkinsci/kubernetes-plugin/pull/1211#discussion_r922242669
