### PR TITLE
Add thread pool to verify pod deletion.

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesNodeDeletedTask.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesNodeDeletedTask.java
@@ -1,0 +1,56 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import java.util.Calendar;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import java.io.IOException;
+import org.jenkinsci.plugins.kubernetes.auth.KubernetesAuthException;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+
+public class KubernetesNodeDeletedTask implements Runnable {
+    private static final Logger LOGGER = Logger.getLogger(KubernetesNodeDeletedTask.class.getName());
+
+    private KubernetesSlave node;
+
+    public KubernetesNodeDeletedTask(KubernetesSlave node) {
+        this.node = node;
+    }
+
+    public void run() {
+        PodTemplate template = node.getTemplateOrNull();
+        try {
+            KubernetesClient client = node.getKubernetesCloud().connect();
+
+            Pod pod =  client.pods().inNamespace(node.getNamespace()).withName(node.getNodeName()).get();
+            if (pod != null) {
+                long gracePeriod = 30; // TODO: get from pod template or somewhere else.
+                Calendar end = Calendar.getInstance();
+                end.add(Calendar.SECOND, (int)Math.round(gracePeriod * 1.2));
+                while (Calendar.getInstance().before(end)) {
+                    if (client.pods().inNamespace(node.getNamespace()).withName(node.getNodeName()).get() == null) {
+                        LOGGER.log(Level.INFO, "Pod " + node.getNodeName() + " has been confirmed deleted.");
+                        break;
+                    }
+                    try {
+                        LOGGER.log(Level.INFO, "Pod " + node.getNodeName() + " has NOT been confirmed deleted, waiting.");
+                        Thread.sleep(3000);
+                      } catch (InterruptedException ie) {
+                            Thread.currentThread().interrupt();
+                            break;
+                    }
+                }
+            }
+        } catch (KubernetesAuthException | KubernetesClientException | IOException e) {
+            String msg = String.format("Failed to delete pod for agent %s/%s: %s", node.getNamespace(), node.getNodeName(), e.getMessage());
+            LOGGER.log(Level.WARNING, msg, e);
+        }
+
+        if (template != null) {
+            KubernetesProvisioningLimits instance = KubernetesProvisioningLimits.get();
+            instance.unregister(node.getKubernetesCloud(), template, node.getNumExecutors());
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

The node deletion in the plugin does not respect the terminationGracePeriodSeconds value.  This can result in a race condition where a node is deleted in the plugin, but it has not actually been deleted from Kubernetes as the pod is taking some time to shut down after receiving the SIGTERM signal from Kubernetes.

The problem may be hidden in most cases unless quota is involved. In this situation, it is possible to get a quota exceeded error as the plugin thinks nodes have been deleted and it tries to allocate new nodes. In reality, they may still be around in Kubernetes. 

This may lead people to assume that the concurrency limit setting is being ignored. This may be related to https://issues.jenkins.io/browse/JENKINS-59959.

The fix proposed here is to move the node deletion to a thread pool and have the deletion task ensure that the node is actually removed from Kubernetes before decrementing the plugin counter. The node deletion task waits for a maximum of "the grace period * 120% seconds", checking the node status every three seconds. Currently, the grace period is hard coded to the default 30 seconds.

Existing tests all run, and those already seem to test delete.  I am unsure how to write a test for this but am willing to try with some help.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
