### PR TITLE
Plugin cannot compile with Java 11

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/retention/Reaper.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/retention/Reaper.java
@@ -416,7 +416,7 @@ public class Reaper extends ComputerListener {
                     }
                 });
                 logLastLinesThenTerminateNode(node, pod, runListener);
-                try (ACLContext _ = ACL.as(ACL.SYSTEM)) {
+                try (ACLContext context = ACL.as(ACL.SYSTEM)) {
                     PodUtils.cancelQueueItemFor(pod, "ContainerError");
                 }
             }
@@ -479,7 +479,7 @@ public class Reaper extends ComputerListener {
                 runListener.error("Unable to pull Docker image \""+cs.getImage()+"\". Check if image tag name is spelled correctly.");
             });
             terminationReasons.add("ImagePullBackOff");
-            try (ACLContext _ = ACL.as(ACL.SYSTEM)) {
+            try (ACLContext context = ACL.as(ACL.SYSTEM)) {
                 PodUtils.cancelQueueItemFor(pod, "ImagePullBackOff");
             }
             node.terminate();


### PR DESCRIPTION
When running with `mvn clean verify -Djenkins.version=2.357`, I noticed these errors:

```
[ERROR] src/jenkinsci/kubernetes-plugin/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/retention/Reaper.java:[419,32] error: as of release 9, '_' is a keyword, and may not be used as an identifier
[ERROR] src/jenkinsci/kubernetes-plugin/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/retention/Reaper.java:[482,28] error: as of release 9, '_' is a keyword, and may not be used as an identifier
```

After this PR I can no longer reproduce the problem.