### PR TITLE
Increase kind stage timeout to 90 minutes.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ properties([
 ])
 parallel kind: {
     node('docker') {
-        timeout(60) {
+        timeout(90) {
             checkout scm
             withEnv(["WSTMP=${pwd tmp: true}"]) {
                 try {


### PR DESCRIPTION
Some builds are reaching the 60 minutes timeout (https://github.com/jenkinsci/kubernetes-plugin/pull/1233 / https://ci.jenkins.io/job/Plugins/job/kubernetes-plugin/job/PR-1233/1/display/redirect)

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
