### PR TITLE
Display the cloud name for non-configurable kubernetes clouds to help distinguish between multiple instances.

### DIFF
--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/NonConfigurableKubernetesCloud/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/NonConfigurableKubernetesCloud/config.jelly
@@ -1,5 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
+  <f:description>Cloud name : ${instance.displayName}</f:description>
   <f:invisibleEntry title="${%Cloud name}">
     <f:readOnlyTextbox name="cloudName" value="${instance.displayName}"/>
   </f:invisibleEntry>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/NonConfigurableKubernetesCloud/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/NonConfigurableKubernetesCloud/config.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
-  <f:description>Cloud name : ${instance.displayName}</f:description>
+  <f:description>Cloud name: ${instance.displayName}</f:description>
   <f:invisibleEntry title="${%Cloud name}">
     <f:readOnlyTextbox name="cloudName" value="${instance.displayName}"/>
   </f:invisibleEntry>


### PR DESCRIPTION
Noticed while investigating a customer issue with a LOT of these.
<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
