### PR TITLE
`KubernetesFolderProperty` threw NPE on a `WorkflowMultiBranchProject`

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFolderProperty.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFolderProperty.java
@@ -23,7 +23,6 @@ import org.kohsuke.stapler.StaplerRequest;
 import com.cloudbees.hudson.plugins.folder.AbstractFolder;
 import com.cloudbees.hudson.plugins.folder.AbstractFolderProperty;
 import com.cloudbees.hudson.plugins.folder.AbstractFolderPropertyDescriptor;
-import com.cloudbees.hudson.plugins.folder.Folder;
 
 import hudson.Extension;
 import hudson.model.ItemGroup;
@@ -215,7 +214,7 @@ public class KubernetesFolderProperty extends AbstractFolderProperty<AbstractFol
         @SuppressWarnings("unused") // Used by jelly
         @Restricted(DoNotUse.class)
         public List<UsagePermission> getEffectivePermissions() {
-            Set<String> inheritedClouds = getInheritedClouds(Stapler.getCurrentRequest().findAncestorObject(Folder.class).getParent());
+            Set<String> inheritedClouds = getInheritedClouds(Stapler.getCurrentRequest().findAncestorObject(AbstractFolder.class).getParent());
             List<UsagePermission> ps = getUsageRestrictedKubernetesClouds().stream()
                                                                            .map(cloud -> new UsagePermission(cloud.name, inheritedClouds.contains(cloud.name), inheritedClouds.contains(cloud.name)))
                                                                            .collect(Collectors.toList());


### PR DESCRIPTION
Untested and not sure if the problem was reproducible. Browsed to the configuration screen of a multibranch project and saw in the logs

```
WARNING	h.ExpressionFactory2$JexlExpression#evaluate: Caught exception evaluating: descriptor.effectivePermissions in /job/multibranch/configure. Reason: java.lang.reflect.InvocationTargetException
java.lang.NullPointerException
	at org.csanchez.jenkins.plugins.kubernetes.KubernetesFolderProperty$DescriptorImpl.getEffectivePermissions(KubernetesFolderProperty.java:218)
```

Fix from source inspection: this is an `AbstractFolderProperty` available on `ComputedFolder`s, so it should not presume that it can find a (non-computed) `Folder` in its ancestor list.

Amends #1181 by @PereBueno.