### PR TITLE
Use modernized jenkins-table design

### DIFF
--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesComputer/events.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesComputer/events.jelly
@@ -27,23 +27,27 @@ THE SOFTWARE.
   <l:layout title="${it.displayName} log" permission="${app.ADMINISTER}">
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
-      <table class="sortable pane bigtable">
-        <tr>
-          <th>${%Type}</th><th>${%Reason}</th><th>${%Count}</th>
-          <th>${%FirstTime}</th><th>${%LastTime}</th><th>${%From}</th><th>${%Message}</th>
-        </tr>
-
-        <j:forEach var="v" items="${it.podEvents}">
+      <table class="sortable jenkins-table">
+        <thead>
           <tr>
-            <td>${v.type}</td>
-            <td>${v.reason}</td>
-            <td>${v.count}</td>
-            <td>${v.firstTimestamp}</td>
-            <td>${v.lastTimestamp}</td>
-            <td>${v.source.component}</td>
-            <td>${v.message}</td>
+            <th>${%Type}</th><th>${%Reason}</th><th>${%Count}</th>
+            <th>${%FirstTime}</th><th>${%LastTime}</th><th>${%From}</th><th>${%Message}</th>
           </tr>
-        </j:forEach>
+        </thead>
+
+        <tbody>
+          <j:forEach var="v" items="${it.podEvents}">
+            <tr>
+              <td>${v.type}</td>
+              <td>${v.reason}</td>
+              <td>${v.count}</td>
+              <td>${v.firstTimestamp}</td>
+              <td>${v.lastTimestamp}</td>
+              <td>${v.source.component}</td>
+              <td>${v.message}</td>
+            </tr>
+          </j:forEach>
+        </tbody>
       </table>
     </l:main-panel>
   </l:layout>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesComputer/podLog.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesComputer/podLog.jelly
@@ -27,19 +27,23 @@ THE SOFTWARE.
   <l:layout title="${it.displayName} log" permission="${app.ADMINISTER}">
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
-      <table class="sortable pane bigtable">
-        <tr>
-          <th>Name</th><th>Image</th><th>ImagePullPolicy</th><th>WorkingDir</th>
-        </tr>
-
-        <j:forEach var="v" items="${it.containers}">
+      <table class="sortable jenkins-table">
+        <thead>
           <tr>
-            <td><f:link href="container?name=${v.name}">${v.name}</f:link></td>
-            <td>${v.image}</td>
-            <td>${v.imagePullPolicy}</td>
-            <td>${v.workingDir}</td>
+            <th>Name</th><th>Image</th><th>ImagePullPolicy</th><th>WorkingDir</th>
           </tr>
-        </j:forEach>
+        </thead>
+
+        <tbody>
+          <j:forEach var="v" items="${it.containers}">
+            <tr>
+              <td><f:link href="container?name=${v.name}">${v.name}</f:link></td>
+              <td>${v.image}</td>
+              <td>${v.imagePullPolicy}</td>
+              <td>${v.workingDir}</td>
+            </tr>
+          </j:forEach>
+        </tbody>
       </table>
     </l:main-panel>
   </l:layout>


### PR DESCRIPTION
The change proposed utilized the modernized `jenkins-table` design, rather than the old table design.

**Before**:
![Screenshot 2022-10-05 at 10 16 36](https://user-images.githubusercontent.com/13383509/194013645-88f9ca01-88df-40d9-a9c6-3f68c7f24ddc.png)
![Screenshot 2022-10-05 at 10 16 24](https://user-images.githubusercontent.com/13383509/194013615-a455c3bd-8241-4b4e-8db7-557703980c0c.png)

**After**:
![Screenshot 2022-10-05 at 10 16 01](https://user-images.githubusercontent.com/13383509/194013548-bf9d36e8-5aac-448e-b581-ed5365fbb9e8.png)
![Screenshot 2022-10-05 at 10 16 11](https://user-images.githubusercontent.com/13383509/194013572-ba39ae5b-98cc-456c-ab0d-e68c28a1747f.png)
