### PR TITLE
Replace old spinner.gif with modern animation

### DIFF
--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesComputer/container.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesComputer/container.jelly
@@ -29,7 +29,7 @@ THE SOFTWARE.
     <l:main-panel>
       <pre id="out" />
       <div id="spinner">
-        <img src="${imagesURL}/spinner.gif" alt=""/>
+        <l:progressAnimation />
       </div>
       <t:progressiveText href="containerLog?containerId=${request.getParameter('name')}" idref="out" spinner="spinner" />
     </l:main-panel>


### PR DESCRIPTION
The change proposed replaces the spinner.gif animation with the drop-in replacement provided by `<l:progressAnimation>`:

**Before**:

https://user-images.githubusercontent.com/13383509/194014960-9f32b808-7142-4d4e-be17-b7bb932b468d.mp4

**After**:

https://user-images.githubusercontent.com/13383509/194015157-be85bc4b-1dc8-4eb6-b83b-c97c5cd4d5e9.mp4