### PR TITLE
Fix PodTemplateStepExecutionTest in jenkins pipeline build

### DIFF
--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecutionTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecutionTest.java
@@ -25,6 +25,7 @@
 package org.csanchez.jenkins.plugins.kubernetes.pipeline;
 
 import static org.junit.Assert.*;
+import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.*;
 
 import org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud;
 import org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil;
@@ -33,16 +34,17 @@ import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.JenkinsRuleNonLocalhost;
 
 import hudson.model.Result;
 
 public class PodTemplateStepExecutionTest {
 
     @Rule
-    public JenkinsRule r = new JenkinsRule();
+    public JenkinsRuleNonLocalhost r = new JenkinsRuleNonLocalhost();
 
     protected KubernetesCloud cloud;
 
@@ -51,6 +53,11 @@ public class PodTemplateStepExecutionTest {
         cloud = new KubernetesCloud("kubernetes");
         r.jenkins.clouds.add(cloud);
     }
+    
+    @BeforeClass 
+    public static void isKubernetesConfigured() throws Exception { 
+        assumeKubernetes();
+    } 
 
     private String loadPipelineScript(String name) {
         return KubernetesTestUtil.loadPipelineScript(getClass(), name);

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecutionTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecutionTest.java
@@ -35,14 +35,14 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.jvnet.hudson.test.JenkinsRuleNonLocalhost;
+import org.jvnet.hudson.test.JenkinsRule;
 
 import hudson.model.Result;
 
 public class PodTemplateStepExecutionTest {
 
     @Rule
-    public JenkinsRuleNonLocalhost r = new JenkinsRuleNonLocalhost();
+    public JenkinsRule r = new JenkinsRule();
 
     protected KubernetesCloud cloud;
 


### PR DESCRIPTION
If I'm executing `mvn clean install` on my local machine, everything works fine but the build fails in our jenkins pipeline. The `PodTemplateStepExecutionTest` runs into a timeout because the jenkins could not started. After visiting other test classes, I realized that each kubernetes cluster specific test class extends from `AbstractKubernetesPipelineTest` which provides a `JenkinsRuleNonLocalhost` instance. The `PodTemplateStepExecutionTest` class does **not** extends from `AbstractKubernetesPipelineTest` but also provides a `JenkinsRuleNonLocalhost` instance. That seemed really strange to me, so I changed `JenkinsRuleNonLocalhost` to `JenkinsRule` in `PodTemplateStepExecutionTest` (see my committed file). After pushing to our repository, I started the jenkins pipeline build again and voila, it works! The test is successfully executed now.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->