### PR TITLE
wait for docker daemon to start in dind example to avoid error

### DIFF
--- a/examples/dind.groovy
+++ b/examples/dind.groovy
@@ -16,6 +16,9 @@ podTemplate(yaml: '''
                 containers:
                 - name: docker
                   image: docker:19.03.1
+                  readinessProbe:
+                    exec:
+                      command: [sh, -c, "ls -S /var/run/docker.sock"]
                   command:
                   - sleep
                   args:
@@ -34,7 +37,6 @@ podTemplate(yaml: '''
   node(POD_LABEL) {
     writeFile file: 'Dockerfile', text: 'FROM scratch'
     container('docker') {
-      sh 'echo "Waiting for docker daemon."; while (! docker stats --no-stream); do sleep 1; done &> /dev/null'
       sh 'docker version && DOCKER_BUILDKIT=1 docker build --progress plain -t testing .'
     }
   }

--- a/examples/dind.groovy
+++ b/examples/dind.groovy
@@ -34,6 +34,7 @@ podTemplate(yaml: '''
   node(POD_LABEL) {
     writeFile file: 'Dockerfile', text: 'FROM scratch'
     container('docker') {
+      sh 'echo "Waiting for docker daemon."; while (! docker stats --no-stream); do sleep 1; done &> /dev/null'
       sh 'docker version && DOCKER_BUILDKIT=1 docker build --progress plain -t testing .'
     }
   }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This is simple fix to "dind" example, which when run returns error as `docker version `executes before docker daemon is up in another container.
The change will now execute simple loop to ensure daemon is up and only then execute `docker version`.

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
