### PR TITLE
Prefer `getTemplateOrNull` to `getTemplate`

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
@@ -291,7 +291,7 @@ public class KubernetesLauncher extends JNLPLauncher {
                 if (!StringUtils.isBlank(log)) {
                     String msg = errors != null ? String.format(" exited with error %s", errors.get(containerName)) : "";
                     LOGGER.log(Level.SEVERE, "Error in provisioning; agent={0}, template={1}. Container {2}{3}. Logs: {4}",
-                            new Object[]{slave, slave.getTemplate(), containerName, msg, log});
+                            new Object[]{slave, slave.getTemplateOrNull(), containerName, msg, log});
                 }
             }
         }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
@@ -84,7 +84,7 @@ public class KubernetesSlave extends AbstractCloudSlave {
     private transient Pod pod;
 
     @NonNull
-    public PodTemplate getTemplate() {
+    public PodTemplate getTemplate() throws IllegalStateException {
         // Look up updated pod template after a restart
         PodTemplate template = getTemplateOrNull();
         if (template == null) {
@@ -402,7 +402,7 @@ public class KubernetesSlave extends AbstractCloudSlave {
                 if (currentExecutable != null && executables.add(currentExecutable)) {
                     listener.getLogger().println(Messages.KubernetesSlave_AgentIsProvisionedFromTemplate(
                             ModelHyperlinkNote.encodeTo("/computer/" + getNodeName(), getNodeName()),
-                            getTemplate().getName())
+                            template.getName())
                     );
                     printAgentDescription(listener);
                     checkHomeAndWarnIfNeeded(listener);

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/retention/Reaper.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/retention/Reaper.java
@@ -64,6 +64,7 @@ import org.csanchez.jenkins.plugins.kubernetes.KubernetesClientProvider;
 import org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud;
 import org.csanchez.jenkins.plugins.kubernetes.KubernetesComputer;
 import org.csanchez.jenkins.plugins.kubernetes.KubernetesSlave;
+import org.csanchez.jenkins.plugins.kubernetes.PodTemplate;
 import org.csanchez.jenkins.plugins.kubernetes.PodUtils;
 import org.jenkinsci.plugins.kubernetes.auth.KubernetesAuthException;
 
@@ -386,9 +387,11 @@ public class Reaper extends ComputerListener {
             }
             String ns = pod.getMetadata().getNamespace();
             String name = pod.getMetadata().getName();
-            TaskListener runListener = node.getTemplate().getListener();
             LOGGER.info(() -> ns + "/" + name + " was just deleted, so removing corresponding Jenkins agent");
-            runListener.getLogger().printf("Pod %s/%s was just deleted%n", ns, name);
+            PodTemplate template = node.getTemplateOrNull();
+            if (template != null) {
+                template.getListener().getLogger().printf("Pod %s/%s was just deleted%n", ns, name);
+            }
             Jenkins.get().removeNode(node);
         }
     }
@@ -405,7 +408,8 @@ public class Reaper extends ComputerListener {
             if (!terminatedContainers.isEmpty()) {
                 String ns = pod.getMetadata().getNamespace();
                 String name = pod.getMetadata().getName();
-                TaskListener runListener = node.getTemplate().getListener();
+                PodTemplate template = node.getTemplateOrNull();
+                TaskListener runListener = template != null ? template.getListener() : TaskListener.NULL;
                 terminatedContainers.forEach(c -> {
                     ContainerStateTerminated t = c.getState().getTerminated();
                     LOGGER.info(() -> ns + "/" + name + " Container " + c.getName() + " was just terminated, so removing the corresponding Jenkins agent");
@@ -433,7 +437,8 @@ public class Reaper extends ComputerListener {
             if ("Failed".equals(pod.getStatus().getPhase())) {
                 String ns = pod.getMetadata().getNamespace();
                 String name = pod.getMetadata().getName();
-                TaskListener runListener = node.getTemplate().getListener();
+                PodTemplate template = node.getTemplateOrNull();
+                TaskListener runListener = template != null ? template.getListener() : TaskListener.NULL;
                 String reason = pod.getStatus().getReason();
                 LOGGER.info(() -> ns + "/" + name + " Pod just failed. Removing the corresponding Jenkins agent. Reason: " + reason + ", Message: " + pod.getStatus().getMessage());
                 runListener.getLogger().printf("%s/%s Pod just failed (Reason: %s, Message: %s)%n", ns, name, reason, pod.getStatus().getMessage());
@@ -475,8 +480,10 @@ public class Reaper extends ComputerListener {
                 return;
             }
             backOffContainers.forEach(cs -> {
-                TaskListener runListener = node.getTemplate().getListener();
-                runListener.error("Unable to pull Docker image \""+cs.getImage()+"\". Check if image tag name is spelled correctly.");
+                PodTemplate template = node.getTemplateOrNull();
+                if (template != null) {
+                    template.getListener().error("Unable to pull Docker image \"" + cs.getImage() + "\". Check if image tag name is spelled correctly.");
+                }
             });
             terminationReasons.add("ImagePullBackOff");
             try (ACLContext context = ACL.as(ACL.SYSTEM)) {


### PR DESCRIPTION
Similar to #1096 etc. An observed stack trace indicates some problem but it should be handled more gracefully:

```
WARNING	o.c.j.p.k.p.r.Reaper$CloudPodWatcher#lambda$eventReceived$0: Listener org.csanchez.jenkins.plugins.kubernetes.pod.retention.Reaper$TerminateAgentOnContainerTerminated@… failed for …
java.lang.IllegalStateException: Unable to resolve pod template from id=…
	at org.csanchez.jenkins.plugins.kubernetes.KubernetesSlave.getTemplate(KubernetesSlave.java:91)
	at org.csanchez.jenkins.plugins.kubernetes.pod.retention.Reaper$TerminateAgentOnContainerTerminated.onEvent(Reaper.java:408)
	at org.csanchez.jenkins.plugins.kubernetes.pod.retention.Reaper$CloudPodWatcher.lambda$eventReceived$0(Reaper.java:318)
	at java.base/java.lang.Iterable.forEach(Iterable.java:75)
	at org.csanchez.jenkins.plugins.kubernetes.pod.retention.Reaper$CloudPodWatcher.eventReceived(Reaper.java:316)
	at org.csanchez.jenkins.plugins.kubernetes.pod.retention.Reaper$CloudPodWatcher.eventReceived(Reaper.java:276)
	at …
```
