### PR TITLE
NPE from `KubernetesSlave.getKubernetesCloud`

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
@@ -233,6 +233,8 @@ public class KubernetesSlave extends AbstractCloudSlave {
         Cloud cloud = Jenkins.get().getCloud(cloudName);
         if (cloud instanceof KubernetesCloud) {
             return (KubernetesCloud) cloud;
+        } else if (cloud == null) {
+            throw new IllegalStateException("No such cloud " + cloudName);
         } else {
             throw new IllegalStateException(KubernetesSlave.class.getName() + " can be launched only by instances of " + KubernetesCloud.class.getName() + ". Cloud is " + cloud.getClass().getName());
         }


### PR DESCRIPTION
Not sure what the problem was exactly, but the error handling itself was broken when `getCloud` returned null:

```
WARNING	jenkins.util.Listeners#lambda$notify$0
java.lang.NullPointerException
	at org.csanchez.jenkins.plugins.kubernetes.KubernetesSlave.getKubernetesCloud(KubernetesSlave.java:237)
	at org.csanchez.jenkins.plugins.kubernetes.KubernetesSlave.getKubernetesCloud(KubernetesSlave.java:229)
	at org.csanchez.jenkins.plugins.kubernetes.KubernetesProvisioningLimits$NodeListenerImpl.onDeleted(KubernetesProvisioningLimits.java:146)
	at jenkins.model.NodeListener.lambda$fireOnDeleted$2(NodeListener.java:85)
	at jenkins.util.Listeners.lambda$notify$0(Listeners.java:59)
	at jenkins.util.Listeners.notify(Listeners.java:70)
	at jenkins.model.NodeListener.fireOnDeleted(NodeListener.java:85)
	at jenkins.model.Nodes.removeNode(Nodes.java:292)
	at jenkins.model.Jenkins.removeNode(Jenkins.java:2237)
	at hudson.slaves.AbstractCloudSlave.terminate(AbstractCloudSlave.java:91)
	at org.jenkinsci.plugins.durabletask.executors.OnceRetentionStrategy$1$1.run(OnceRetentionStrategy.java:128)
	at hudson.model.Queue._withLock(Queue.java:1395)
	at hudson.model.Queue.withLock(Queue.java:1269)
	at org.jenkinsci.plugins.durabletask.executors.OnceRetentionStrategy$1.run(OnceRetentionStrategy.java:123)
	at …
```
