### PR TITLE
[JENKINS-70392] Compatibility fix with kubernetes-client 6.x (again)

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFactoryAdapter.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFactoryAdapter.java
@@ -188,18 +188,4 @@ public class KubernetesFactoryAdapter {
         return c;
     }
 
-    private static class WithContextClassLoader implements AutoCloseable {
-
-        private final ClassLoader previousClassLoader;
-
-        public WithContextClassLoader(ClassLoader classLoader) {
-            this.previousClassLoader = Thread.currentThread().getContextClassLoader();
-            Thread.currentThread().setContextClassLoader(classLoader);
-        }
-
-        @Override
-        public void close() {
-            Thread.currentThread().setContextClassLoader(previousClassLoader);
-        }
-    }
 }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
@@ -54,8 +54,8 @@ import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.api.model.Toleration;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
-import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 
 import static hudson.Util.replaceMacro;
@@ -599,7 +599,8 @@ public class PodTemplateUtils {
 
     public static Pod parseFromYaml(String yaml) {
         String s = yaml;
-        try (KubernetesClient client = new DefaultKubernetesClient()) {
+        try (WithContextClassLoader ignored = new WithContextClassLoader(PodTemplateUtils.class.getClassLoader());
+             KubernetesClient client = new KubernetesClientBuilder().build()) {
             // JENKINS-57116
             if (StringUtils.isBlank(s)) {
                 LOGGER.log(Level.WARNING, "[JENKINS-57116] Trying to parse invalid yaml: \"{0}\"", yaml);

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/WithContextClassLoader.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/WithContextClassLoader.java
@@ -1,0 +1,17 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+// TODO post 2.362 use jenkins.util.SetContextClassLoader
+class WithContextClassLoader implements AutoCloseable {
+
+    private final ClassLoader previousClassLoader;
+
+    public WithContextClassLoader(ClassLoader classLoader) {
+        this.previousClassLoader = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(classLoader);
+    }
+
+    @Override
+    public void close() {
+        Thread.currentThread().setContextClassLoader(previousClassLoader);
+    }
+}

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesTestUtil.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesTestUtil.java
@@ -160,7 +160,7 @@ public class KubernetesTestUtil {
     }
 
     public static boolean isWindows(@CheckForNull String buildNumber) {
-        try (KubernetesClient client = new DefaultKubernetesClient(new ConfigBuilder(Config.autoConfigure(null)).build())) {
+        try (KubernetesClient client = new KubernetesClientBuilder().build()) {
             for (Node n : client.nodes().list().getItems()) {
                 Map<String, String> labels = n.getMetadata().getLabels();
                 String os = labels.get("kubernetes.io/os");


### PR DESCRIPTION
Updated the last occurrence to `DefaultKubernetesClient` that should be done with a context classloader swap.
The last occurrence under `KubernetesTestUtil` is in test scope so not affected (flat classloader)

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
