### PR TITLE
`Cloud.name` should be part of `equals/hashCode`

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -661,7 +661,8 @@ public class KubernetesCloud extends Cloud {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         KubernetesCloud that = (KubernetesCloud) o;
-        return skipTlsVerify == that.skipTlsVerify &&
+        return Objects.equals(name, that.name) &&
+                skipTlsVerify == that.skipTlsVerify &&
                 addMasterProxyEnvVars == that.addMasterProxyEnvVars &&
                 capOnlyOnAlivePods == that.capOnlyOnAlivePods &&
                 Objects.equals(containerCap, that.containerCap) &&
@@ -687,7 +688,7 @@ public class KubernetesCloud extends Cloud {
 
     @Override
     public int hashCode() {
-        return Objects.hash(defaultsProviderTemplate, templates, serverUrl, serverCertificate, skipTlsVerify,
+        return Objects.hash(name, defaultsProviderTemplate, templates, serverUrl, serverCertificate, skipTlsVerify,
                 addMasterProxyEnvVars, capOnlyOnAlivePods, namespace, jnlpregistry, jenkinsUrl, jenkinsTunnel, credentialsId,
                 containerCap, retentionTimeout, connectTimeout, readTimeout, podLabels, usageRestricted,
                 maxRequestsPerHost, podRetention, useJenkinsProxy);

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudTest.java
@@ -2,6 +2,7 @@ package org.csanchez.jenkins.plugins.kubernetes;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
@@ -24,6 +25,7 @@ import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.csanchez.jenkins.plugins.kubernetes.pod.retention.Always;
 import org.csanchez.jenkins.plugins.kubernetes.pod.retention.PodRetention;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.EmptyDirVolume;
@@ -244,7 +246,7 @@ public class KubernetesCloudTest {
 
         KubernetesCloud copy = new KubernetesCloud("copy", cloud);
         assertEquals("copy", copy.name);
-        assertEquals("Expected cloud from copy constructor to be equal to the source except for name", cloud, copy);
+        assertTrue("Expected cloud from copy constructor to be equal to the source except for name", EqualsBuilder.reflectionEquals(cloud, copy, true, KubernetesCloud.class, "name"));
     }
 
     @Test


### PR DESCRIPTION
This can cause two clouds with identical configuration except for name to be mistaken.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
