### PR TITLE
Add support for `serverCertificate` base64-encoded, such as what is provided by Amazon EKS

### DIFF
--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/help-serverCertificate.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/help-serverCertificate.html
@@ -1,3 +1,3 @@
 <div>
-    X509 PEM encoded certificate
+    X509 PEM encoded certificate. Can be additionally base64 encoded (as provided by Amazon EKS).
 </div>


### PR DESCRIPTION
This improves overall usability when trying to connect to a remote EKS cluster.

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
