### PR TITLE
[JENKINS-70493] Disable Kubernetes client autoconfiguration when an URL is provided

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFactoryAdapter.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFactoryAdapter.java
@@ -107,8 +107,9 @@ public class KubernetesFactoryAdapter {
             LOGGER.log(FINE, "Autoconfiguring Kubernetes client");
             builder = new ConfigBuilder(Config.autoConfigure(null));
         } else {
-            // Using Config.empty() disables autoconfiguration
-            builder = new ConfigBuilder(Config.empty()).withMasterUrl(serviceAddress);
+            // Using Config.empty() disables autoconfiguration when both serviceAddress and auth are set
+            builder = auth == null ? new ConfigBuilder() : new ConfigBuilder(Config.empty());
+            builder = builder.withMasterUrl(serviceAddress);
         }
 
         if (auth != null) {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFactoryAdapter.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFactoryAdapter.java
@@ -107,11 +107,8 @@ public class KubernetesFactoryAdapter {
             LOGGER.log(FINE, "Autoconfiguring Kubernetes client");
             builder = new ConfigBuilder(Config.autoConfigure(null));
         } else {
-            // although this will still autoconfigure based on Config constructor notes
-            // In future releases (2.4.x) the public constructor will be empty.
-            // The current functionality will be provided by autoConfigure().
-            // This is a necessary change to allow us distinguish between auto configured values and builder values.
-            builder = new ConfigBuilder().withMasterUrl(serviceAddress);
+            // Using Config.empty() disables autoconfiguration
+            builder = new ConfigBuilder(Config.empty()).withMasterUrl(serviceAddress);
         }
 
         if (auth != null) {


### PR DESCRIPTION
Related: https://github.com/fabric8io/kubernetes-client/pull/4528

`TokenRefreshInterceptor` in kubernetes-client refreshes the kubernetes client configuration every minute.

When using a "secret text" credentials in Jenkins, the client is initialized with the given token. However upon refresh, it applies autoconfiguration from injected paths such as `/var/run/secrets/kubernetes.io/serviceaccount/token` and so discards the initial token.

https://github.com/fabric8io/kubernetes-client/pull/4528 fixed the problem when providing the full kubeconfig file through a "secret file" credentials.

The remaining problem in kubernetes-client has been filed upstream https://github.com/fabric8io/kubernetes-client/issues/4802

This PR disables autoconfiguration when both a kubernetes URL and credentials are given when configuring the cloud.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
