### PR TITLE
Improve PodTemplate name and inheritFrom help messages

### DIFF
--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/help-inheritFrom.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/help-inheritFrom.html
@@ -1,4 +1,7 @@
 <p>
+    <b>Name</b> of the podTemplate to inherit from.
+</p>
+<p>
     A podTemplate may or may not inherit from an existing template.<br/>
     This means that the podTemplate will inherit node selector, service account, image pull secrets, containerTemplates and volumes from the template it inherits from.
 </p>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/help-name.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/help-name.html
@@ -13,6 +13,10 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-
-The name prefix of the pod.
-Defaults to the label.
+<p>
+    Name that identifies the pod template. Also used to prefix the name of the node and pod created.
+</p>
+<p>
+    When omitted, the agent and pod name is randomly generated using <i>jenkins-agent-</i> as a prefix.
+    When omitted <b>in a <i>podTemplate(...)</i> step</b>, the <i>label</i> is used as a prefix for the name of the dynamic pod template.
+</p>


### PR DESCRIPTION
The help message of the PodTemplate `name`  attribute is wrongly suggesting that the name defaults to the `label`. This isn't true. 

* In the context of a `podTemplate(...)` step execution, a name would be automatically generated and use the `label` as a prefix.
* In other contexts, by default the pod and node created are prefixed with `jenkins-agent-`. As per https://github.com/jenkinsci/kubernetes-plugin/blob/d5b1bcbc89dec3fbcbcc5a49e32bbc9a63ed74a8/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java#L71.

Also improved the `inheritFrom` help that the name of a template must be provided (and not a label)

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue