### PR TITLE
Fix tests for the upcoming LTS

### DIFF
--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudTest.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.gargoylesoftware.htmlunit.ElementNotFoundException;
 import com.gargoylesoftware.htmlunit.html.DomElement;
 import com.gargoylesoftware.htmlunit.html.DomNodeList;
 import com.gargoylesoftware.htmlunit.html.HtmlButton;
@@ -257,11 +258,11 @@ public class KubernetesCloudTest {
         JenkinsRule.WebClient wc = j.createWebClient();
         HtmlPage p = wc.goTo("configureClouds/");
         HtmlForm f = p.getFormByName("config");
-        HtmlButton buttonExtends = HtmlFormUtil.getButtonByCaption(f, "Pod Templates...");
+        HtmlButton buttonExtends = getButton(f, "Pod Templates");
         buttonExtends.click();
-        HtmlButton buttonAdd = HtmlFormUtil.getButtonByCaption(f, "Add Pod Template");
+        HtmlButton buttonAdd = getButton(f, "Add Pod Template");
         buttonAdd.click();
-        HtmlButton buttonDetails = HtmlFormUtil.getButtonByCaption(f, "Pod Template details...");
+        HtmlButton buttonDetails = getButton(f, "Pod Template details");
         buttonDetails.click();
         DomElement templates = p.getElementByName("templates");
         HtmlInput templateName = getInputByName(templates, "_.name");
@@ -271,6 +272,17 @@ public class KubernetesCloudTest {
         PodTemplate podTemplate = cloud.getTemplates().get(0);
         assertEquals("default-workspace-volume", podTemplate.getName());
         assertEquals(WorkspaceVolume.getDefault(), podTemplate.getWorkspaceVolume());
+    }
+
+    private HtmlButton getButton(HtmlForm f, String buttonText) {
+        HtmlButton button;
+        try {
+            button = HtmlFormUtil.getButtonByCaption(f, buttonText);
+        } catch (ElementNotFoundException e) {
+            // before https://github.com/jenkinsci/jenkins/pull/7173 the 3 dots where added by core
+            button = HtmlFormUtil.getButtonByCaption(f, buttonText + "...");
+        }
+        return button;
     }
 
     @Test

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudTest.java
@@ -274,6 +274,7 @@ public class KubernetesCloudTest {
         assertEquals(WorkspaceVolume.getDefault(), podTemplate.getWorkspaceVolume());
     }
 
+    // TODO 2.385+ delete
     private HtmlButton getButton(HtmlForm f, String buttonText) {
         HtmlButton button;
         try {


### PR DESCRIPTION
The next Jenkins core LTS based on 2.387 has changed how "advanced" buttons are rendered. This is fixing tests so they pass for both 2.387 and also older versions.

cf. https://github.com/jenkinsci/jenkins/commit/f81a7c121d81adca87b7d141634c4bda80351755

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
