### PR TITLE
Upgrade kubernetes-client-api to 6.4.1-215.v2ed17097a_8e9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>kubernetes-client-api</artifactId>
-      <version>6.4.1-214.vf41b_4f849088</version>
+      <version>6.4.1-215.v2ed17097a_8e9</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -236,7 +236,7 @@
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-server-mock</artifactId>
-      <version>6.3.1</version>
+      <version>6.4.1</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -256,6 +256,11 @@
         <version>1836.vfe602c266c05</version>
         <scope>import</scope>
         <type>pom</type>
+      </dependency>
+      <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>mockwebserver</artifactId>
+        <version>4.9.3</version><!-- should be aligned with the version provided by okhttp-api-plugin -->
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>kubernetes-client-api</artifactId>
-      <version>6.4.1-208.vfe09a_9362c2c</version>
+      <version>6.4.1-214.vf41b_4f849088</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
From https://github.com/jenkinsci/kubernetes-client-api-plugin/pull/179

Upgrade kubernetes-client-api to use okhttp-api plugin instead of embedding the client.

This also indirectly upgrades okhttp to 4.x, but it is binary compatible with okhttp 3.x and it fixes a compatibility issue with ipv6.

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
