### PR TITLE
Send diag to build log when `KubernetesAgentErrorCondition` does not match

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesAgentErrorCondition.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesAgentErrorCondition.java
@@ -19,6 +19,7 @@ package org.csanchez.jenkins.plugins.kubernetes.pipeline;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.model.Node;
+import hudson.model.TaskListener;
 import hudson.model.labels.LabelAtom;
 import java.io.IOException;
 import java.util.HashSet;
@@ -36,10 +37,8 @@ import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.graph.BlockEndNode;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.graphanalysis.LinearBlockHoppingScanner;
-import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.support.steps.AgentErrorCondition;
-import org.jenkinsci.plugins.workflow.support.steps.ExecutorStepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
@@ -80,9 +79,12 @@ public class KubernetesAgentErrorCondition extends ErrorCondition {
             LOGGER.fine(() -> "Not a recognized failure: " + t);
             return false;
         }
+        TaskListener listener = context.get(TaskListener.class);
         FlowNode _origin = ErrorAction.findOrigin(t, context.get(FlowExecution.class));
         if (_origin == null) {
-            LOGGER.fine(() -> "No recognized origin of error: " + t);
+            if (!handleNonKubernetes) {
+                listener.getLogger().println("Unable to identify source of error (" + t + ") to see if this was associated with a Kubernetes agent");
+            }
             return handleNonKubernetes;
         }
         FlowNode origin = _origin instanceof BlockEndNode ? ((BlockEndNode) _origin).getStartNode() : _origin;
@@ -96,27 +98,33 @@ public class KubernetesAgentErrorCondition extends ErrorCondition {
                 Node n = Jenkins.get().getNode(node);
                 if (n != null) {
                     if (!(n instanceof KubernetesSlave)) {
-                        LOGGER.fine(() -> node + " was not a K8s agent");
+                        if (!handleNonKubernetes) {
+                            listener.getLogger().println(n.getNodeName() + " was not a Kubernetes agent");
+                        }
                         return handleNonKubernetes;
                     }
                 } else {
                     // May have been removed already, but we can look up the labels to see what it was.
                     Set<LabelAtom> labels = ws.getLabels();
                     if (labels.stream().noneMatch(l -> Jenkins.get().clouds.stream().anyMatch(c -> c instanceof KubernetesCloud && ((KubernetesCloud) c).getTemplate(l) != null))) {
-                        LOGGER.fine(() -> node + " was not a K8s agent judging by " + labels);
+                        if (!handleNonKubernetes) {
+                            listener.getLogger().println(n.getNodeName() + " was not a Kubernetes agent judging by " + labels);
+                        }
                         return handleNonKubernetes;
                     }
                 }
                 Set<String> terminationReasons = ExtensionList.lookupSingleton(Reaper.class).terminationReasons(node);
                 if (terminationReasons.stream().anyMatch(r -> IGNORED_CONTAINER_TERMINATION_REASONS.contains(r))) {
-                    LOGGER.fine(() -> "ignored termination reason(s) for " + node + ": " + terminationReasons);
+                    listener.getLogger().println("Ignored termination reason(s) for " + node + " for purposes of retry: " + terminationReasons);
                     return false;
                 }
                 LOGGER.fine(() -> "active on " + node + " (termination reasons: " + terminationReasons + ")");
                 return true;
             }
         }
-        LOGGER.fine(() -> "found no WorkspaceAction starting from " + origin);
+        if (!handleNonKubernetes) {
+            listener.getLogger().println("Could not find a node block associated with " + origin.getDisplayFunctionName() + " (source of error)");
+        }
         return handleNonKubernetes;
     }
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesAgentErrorCondition.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesAgentErrorCondition.java
@@ -99,7 +99,7 @@ public class KubernetesAgentErrorCondition extends ErrorCondition {
                 if (n != null) {
                     if (!(n instanceof KubernetesSlave)) {
                         if (!handleNonKubernetes) {
-                            listener.getLogger().println(n.getNodeName() + " was not a Kubernetes agent");
+                            listener.getLogger().println(node + " was not a Kubernetes agent");
                         }
                         return handleNonKubernetes;
                     }
@@ -108,7 +108,7 @@ public class KubernetesAgentErrorCondition extends ErrorCondition {
                     Set<LabelAtom> labels = ws.getLabels();
                     if (labels.stream().noneMatch(l -> Jenkins.get().clouds.stream().anyMatch(c -> c instanceof KubernetesCloud && ((KubernetesCloud) c).getTemplate(l) != null))) {
                         if (!handleNonKubernetes) {
-                            listener.getLogger().println(n.getNodeName() + " was not a Kubernetes agent judging by " + labels);
+                            listener.getLogger().println(node + " was not a Kubernetes agent judging by " + labels);
                         }
                         return handleNonKubernetes;
                     }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesAgentErrorConditionTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesAgentErrorConditionTest.java
@@ -64,6 +64,7 @@ public class KubernetesAgentErrorConditionTest {
         SemaphoreStep.success("wait/1", null);
         s.toComputer().connect(false);
         r.assertBuildStatus(Result.FAILURE, r.waitForCompletion(b));
+        r.assertLogContains(s.getNodeName() + " was not a Kubernetes agent", b);
         b = p.scheduleBuild2(0, new ParametersAction(new BooleanParameterValue("HNK", true))).waitForStart();
         SemaphoreStep.waitForStart("wait/2", b);
         s.toComputer().disconnect(new OfflineCause.UserCause(null, null));
@@ -74,6 +75,7 @@ public class KubernetesAgentErrorConditionTest {
         SemaphoreStep.success("wait/3", null);
         s.toComputer().connect(false);
         r.assertBuildStatusSuccess(r.waitForCompletion(b));
+        r.assertLogNotContains(s.getNodeName() + " was not a Kubernetes agent", b);
     }
 
 }


### PR DESCRIPTION
Amending #1190. Sometimes a `node` block can fail with e.g. `AgentOfflineException` yet this is not `retry`d and it is not obvious why. Was OOMKiller active, for example?