### PR TITLE
[JENKINS-70416] Ensure auto-configure is disabled when auth is provided

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFactoryAdapter.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFactoryAdapter.java
@@ -115,6 +115,8 @@ public class KubernetesFactoryAdapter {
 
         if (auth != null) {
             builder = auth.decorate(builder, new KubernetesAuthConfig(builder.getMasterUrl(), caCertData, skipTlsVerify));
+            // If authentication is provided, disable autoconfigure flag to deactivate auto refresh
+            builder = builder.withAutoConfigure(false);
         }
 
         if (skipTlsVerify) {

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFactoryAdapterTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFactoryAdapterTest.java
@@ -24,10 +24,14 @@
 
 package org.csanchez.jenkins.plugins.kubernetes;
 
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import hudson.ProxyConfiguration;
+import hudson.util.Secret;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.utils.HttpClientUtils;
 import org.jenkinsci.plugins.kubernetes.auth.KubernetesAuthException;
+import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -46,10 +50,14 @@ import static io.fabric8.kubernetes.client.Config.KUBERNETES_NAMESPACE_FILE;
 import static io.fabric8.kubernetes.client.Config.KUBERNETES_NO_PROXY;
 import static io.fabric8.kubernetes.client.Config.KUBERNETES_PROXY_PASSWORD;
 import static io.fabric8.kubernetes.client.Config.KUBERNETES_PROXY_USERNAME;
+import static io.fabric8.kubernetes.client.Config.KUBERNETES_SERVICE_HOST_PROPERTY;
+import static io.fabric8.kubernetes.client.Config.KUBERNETES_SERVICE_PORT_PROPERTY;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test the creation of clients
@@ -71,6 +79,9 @@ public class KubernetesFactoryAdapterTest {
     private static final String NO_PROXY = "noproxy";
     private static final String PROXY_USERNAME = "proxy_username";
     private static final String PROXY_PASSWORD = "proxy_password";
+    private static final String KUBERNETES_HOST = "kubernetes.example";
+    private static final String KUBERNETES_PORT = "443";
+    private static final String KUBERNETES_MASTER_URL = "https://" + KUBERNETES_HOST + ":" + KUBERNETES_PORT + "/";
 
     private Map<String, String> systemProperties = new HashMap<>();
 
@@ -91,6 +102,8 @@ public class KubernetesFactoryAdapterTest {
         System.setProperty(KUBERNETES_NO_PROXY, NO_PROXY);
         System.setProperty(KUBERNETES_PROXY_USERNAME, PROXY_USERNAME);
         System.setProperty(KUBERNETES_PROXY_PASSWORD, PROXY_PASSWORD);
+        System.setProperty(KUBERNETES_SERVICE_HOST_PROPERTY, KUBERNETES_HOST);
+        System.setProperty(KUBERNETES_SERVICE_PORT_PROPERTY, KUBERNETES_PORT);
     }
 
     @After
@@ -110,6 +123,8 @@ public class KubernetesFactoryAdapterTest {
         KubernetesFactoryAdapter factory = new KubernetesFactoryAdapter(null, null, null, false);
         KubernetesClient client = factory.createClient();
         assertEquals("default", client.getNamespace());
+        assertEquals(KUBERNETES_MASTER_URL, client.getConfiguration().getMasterUrl());
+        assertTrue(client.getConfiguration().getAutoConfigure());
     }
 
     @Test
@@ -123,6 +138,8 @@ public class KubernetesFactoryAdapterTest {
         assertArrayEquals(new String[] { NO_PROXY }, client.getConfiguration().getNoProxy());
         assertEquals(PROXY_USERNAME, client.getConfiguration().getProxyUsername());
         assertEquals(PROXY_PASSWORD, client.getConfiguration().getProxyPassword());
+        assertEquals(KUBERNETES_MASTER_URL, client.getConfiguration().getMasterUrl());
+        assertTrue(client.getConfiguration().getAutoConfigure());
     }
 
     @Test
@@ -134,6 +151,27 @@ public class KubernetesFactoryAdapterTest {
         assertArrayEquals(new String[] { NO_PROXY }, client.getConfiguration().getNoProxy());
         assertEquals(PROXY_USERNAME, client.getConfiguration().getProxyUsername());
         assertEquals(PROXY_PASSWORD, client.getConfiguration().getProxyPassword());
+        assertFalse(client.getConfiguration().getAutoConfigure());
+        assertEquals("http://example.com", client.getConfiguration().getMasterUrl());
+    }
+
+    @Test
+    @Issue("JENKINS-70416")
+    public void autoConfigWithAuth() throws Exception {
+        System.setProperty(KUBERNETES_NAMESPACE_FILE, "src/test/resources/kubenamespace");
+        StringCredentialsImpl tokenCredential = new StringCredentialsImpl(CredentialsScope.GLOBAL, "sa-token", "some credentials", Secret.fromString("sa-token"));
+        SystemCredentialsProvider.getInstance().getCredentials().add(tokenCredential);
+        KubernetesFactoryAdapter factory = new KubernetesFactoryAdapter(null, null, "sa-token", false);
+        KubernetesClient client = factory.createClient();
+        assertEquals("test-namespace", client.getNamespace());
+        assertEquals(HTTP_PROXY, client.getConfiguration().getHttpProxy());
+        assertEquals(HTTPS_PROXY, client.getConfiguration().getHttpsProxy());
+        assertArrayEquals(new String[] { NO_PROXY }, client.getConfiguration().getNoProxy());
+        assertEquals(PROXY_USERNAME, client.getConfiguration().getProxyUsername());
+        assertEquals(PROXY_PASSWORD, client.getConfiguration().getProxyPassword());
+        assertFalse(client.getConfiguration().getAutoConfigure());
+        assertEquals(KUBERNETES_MASTER_URL, client.getConfiguration().getMasterUrl());
+        assertEquals("sa-token", client.getConfiguration().getOauthToken());
     }
 
     @Test

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFactoryAdapterTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFactoryAdapterTest.java
@@ -151,8 +151,8 @@ public class KubernetesFactoryAdapterTest {
         assertArrayEquals(new String[] { NO_PROXY }, client.getConfiguration().getNoProxy());
         assertEquals(PROXY_USERNAME, client.getConfiguration().getProxyUsername());
         assertEquals(PROXY_PASSWORD, client.getConfiguration().getProxyPassword());
-        assertFalse(client.getConfiguration().getAutoConfigure());
-        assertEquals("http://example.com", client.getConfiguration().getMasterUrl());
+        assertTrue(client.getConfiguration().getAutoConfigure());
+        assertEquals("http://example.com/", client.getConfiguration().getMasterUrl());
     }
 
     @Test


### PR DESCRIPTION
[JENKINS-70416](https://issues.jenkins.io/browse/JENKINS-70416)

Whenever authentication is provided in the Kubernetes plugin, we do not want to be impacted by the automatic Config refresh mechanism (like the token refresh for example) of the fabric8/kubernetes-client: https://github.com/fabric8io/kubernetes-client/blob/v6.4.1/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java#L637-L651. We might however still want to use the autoconfigure when initializing the `ConfigBuilder` object if configuring a Kubernetes Cloud in the same cluster but in a different namespace or with a different auth.

Fix the token refresh problem in a multi-namespaced / same cluster scenario. Where different serviceaccount (with token) are used in other namespaces and a Secret Text credentials is used to connect to those other namespaces. In such a scenario, you do not need to provide the Kubernetes URL and the CA Certificate that can be inferred from the environment.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue