### PR TITLE
Clarify in warning message why `retry` might have declined to do so

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesAgentErrorCondition.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesAgentErrorCondition.java
@@ -108,7 +108,7 @@ public class KubernetesAgentErrorCondition extends ErrorCondition {
                     Set<LabelAtom> labels = ws.getLabels();
                     if (labels.stream().noneMatch(l -> Jenkins.get().clouds.stream().anyMatch(c -> c instanceof KubernetesCloud && ((KubernetesCloud) c).getTemplate(l) != null))) {
                         if (!handleNonKubernetes) {
-                            listener.getLogger().println(node + " was not a Kubernetes agent judging by " + labels);
+                            listener.getLogger().println(node + " did not look like a Kubernetes agent judging by " + labels + "; make sure retry is inside podTemplate, not outside");
                         }
                         return handleNonKubernetes;
                     }


### PR DESCRIPTION
With #1335 in use, I hit this on a K8s build recently

```
org-repo-main-230-5fwds-qbqzj-sfdzs was not a Kubernetes agent judging by [org_repo_main_230-5fwds]
```

Turns out the script had been using

```groovy
retry(count: 2, conditions: [kubernetesAgent(), nonresumable()]) {
  podTemplate {
    node(POD_LABEL) {
      // …
    }
  }
}
```

which does not work since at the point that `retry` is asked whether to rerun its block, the only information it has about the agent was that `POD_LABEL`, which has already been deleted from the ephemeral pod template registry (the agent definition itself was probably deleted at the end of the `node` block). I suppose it could match on `/.+-[a-z0-9]{5}/` but this pattern might be used by other cloud plugins as well. Best to just swap the order of the steps, as the documentation and tests already indicate.
