### PR TITLE
Jenkins design library symbols

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,16 @@ FROM jenkins/jenkins:lts-alpine
 ARG VERSION=1.15.5
 #RUN /usr/local/bin/install-plugins.sh kubernetes:${VERSION}
 
-RUN /usr/local/bin/install-plugins.sh kubernetes-client-api kubernetes-credentials docker-commons cloudbees-folder workflow-api variant durable-task
+RUN jenkins-plugin-cli --plugins kubernetes-client-api \
+    kubernetes-credentials \
+    docker-commons \
+    cloudbees-folder \
+    workflow-api \
+    variant \
+    durable-task \
+    workflow-durable-task-step \
+    metrics \
+    caffeine-api
 COPY target/kubernetes.hpi /usr/share/jenkins/ref/plugins/kubernetes.hpi
 
 # RUN curl -o /usr/share/jenkins/ref/plugins/kubernetes.hpi \

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesComputer/sidepanel2.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesComputer/sidepanel2.jelly
@@ -24,10 +24,10 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
-  <l:task icon="icon-clipboard icon-md" href="${rootURL}/${it.url}log" title="${%Log}" permission="${app.ADMINISTER}"/>
-  <l:task icon="icon-computer icon-md" href="${rootURL}/${it.url}podLog" title="${%Pod Log}" permission="${app.ADMINISTER}"/>
-  <l:task icon="icon-computer icon-md" href="${rootURL}/${it.url}events" title="${%Events}" permission="${app.ADMINISTER}"/>
+  <l:task icon="symbol-terminal icon-md" href="${rootURL}/${it.url}log" title="${%Log}" permission="${app.ADMINISTER}"/>
+  <l:task icon="symbol-terminal icon-md" href="${rootURL}/${it.url}podLog" title="${%Pod Log}" permission="${app.ADMINISTER}"/>
+  <l:task icon="symbol-list icon-md" href="${rootURL}/${it.url}events" title="${%Events}" permission="${app.ADMINISTER}"/>
   <j:if test="${it.channel!=null}">
-    <l:task icon="icon-computer icon-md" href="${rootURL}/${it.url}systemInfo" title="${%System Information}" permission="${app.ADMINISTER}"/>
+    <l:task icon="symbol-computer icon-md" href="${rootURL}/${it.url}systemInfo" title="${%System Information}" permission="${app.ADMINISTER}"/>
   </j:if>
 </j:jelly>


### PR DESCRIPTION
Update KubernetesComputer side panel icons to Jenkins design library symbols.

<img width="337" alt="Screenshot 2023-04-03 at 10 48 10 PM" src="https://user-images.githubusercontent.com/1683550/229951424-4d937803-8f61-455d-b9a9-87b0af6a6004.png">

Includes a fix for Dockerfile build to include required plugin dependencies.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
