### PR TITLE
Remove duplicated help button around Workspace Volume in Pod Template details

### DIFF
--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
@@ -107,9 +107,7 @@
       <f:textbox/>
     </f:entry>
 
-    <f:entry title="${%Workspace Volume}" field="workspaceVolume">
-      <f:dropdownDescriptorSelector field="workspaceVolume" default="${descriptor.defaultWorkspaceVolume}"/>
-    </f:entry>
+    <f:dropdownDescriptorSelector title="${%Workspace Volume}" field="workspaceVolume" default="${descriptor.defaultWorkspaceVolume}"/>
 
     <f:descriptorList title="${%Node Properties}" descriptors="${h.getNodePropertyDescriptors(descriptor.clazz)}" field="nodeProperties" />
 


### PR DESCRIPTION
This PR remove the duplicated help button around "Workspace Volume" present in "Manage Jenkins" > "Configure Cloud" > "Kubernetes" > "Pod Templates" > "Pod Template details"

Before:

<img width="236" alt="image" src="https://user-images.githubusercontent.com/91831478/230319514-1d8e16c8-a718-4c0c-b93a-f5d293fedaba.png">

After:

<img width="230" alt="image" src="https://user-images.githubusercontent.com/91831478/230319600-2da93dde-76c6-4531-b90a-276bd33137b9.png">


<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
