### PR TITLE
Activate `KubernetesAgentErrorCondition` when `podTemplate {node {…}}` fails to connect

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesAgentErrorCondition.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesAgentErrorCondition.java
@@ -36,6 +36,7 @@ import org.jenkinsci.plugins.workflow.flow.ErrorCondition;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.graph.BlockEndNode;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.jenkinsci.plugins.workflow.graph.StepNode;
 import org.jenkinsci.plugins.workflow.graphanalysis.LinearBlockHoppingScanner;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.support.steps.AgentErrorCondition;
@@ -91,6 +92,7 @@ public class KubernetesAgentErrorCondition extends ErrorCondition {
         LOGGER.fine(() -> "Found origin " + origin + " " + origin.getDisplayFunctionName());
         LinearBlockHoppingScanner scanner = new LinearBlockHoppingScanner();
         scanner.setup(origin);
+        boolean foundPodTemplate = false;
         for (FlowNode callStack : scanner) {
             WorkspaceAction ws = callStack.getPersistentAction(WorkspaceAction.class);
             if (ws != null) {
@@ -121,9 +123,15 @@ public class KubernetesAgentErrorCondition extends ErrorCondition {
                 LOGGER.fine(() -> "active on " + node + " (termination reasons: " + terminationReasons + ")");
                 return true;
             }
+            foundPodTemplate |= callStack instanceof StepNode && ((StepNode) callStack).getDescriptor() instanceof PodTemplateStep.DescriptorImpl;
         }
         if (!handleNonKubernetes) {
-            listener.getLogger().println("Could not find a node block associated with " + origin.getDisplayFunctionName() + " (source of error)");
+            if (foundPodTemplate) {
+                listener.getLogger().println("Could not find a node block associated with " + origin.getDisplayFunctionName() + " (source of error) but inside podTemplate");
+                return true;
+            } else {
+                listener.getLogger().println("Could not find a node block associated with " + origin.getDisplayFunctionName() + " (source of error)");
+            }
         }
         return handleNonKubernetes;
     }


### PR DESCRIPTION
https://github.com/jenkinsci/kubernetes-plugin/pull/1344#issuecomment-1500616868

Could cause some inappropriate retries of pipelines that were broken for a good reason (misconfiguration), but that is probably tolerable here in exchange for better robustness when an agent pod fails to connect for a transient reason.

Did not figure out how to write an automated test for this. Manually verified that

```diff
diff --git src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
index 8e794195..1096add3 100644
--- src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -419,7 +419,7 @@ public class PodTemplateBuilder {
             }
 
             if (!cloud.isDirectConnection()) {
-                env.put("JENKINS_URL", cloud.getJenkinsUrlOrDie());
+                env.put("JENKINS_URL", cloud.getJenkinsUrlOrDie().replace("kubernetes-plugin-test", "XXX"));
                 if (cloud.isWebSocket()) {
                     env.put("JENKINS_WEB_SOCKET", "true");
                 }
```

caused the originally reported error (and no retry) after creating a Kind cluster and running

```bash
WORKSPACE_TMP=$(pwd)/target ./test-in-k8s.sh -Dtest=KubernetesPipelineTest\#terminatedPod
```

whereas with this patch the new message is printed and the block retries (only to fail the second time as well, of course, and fail the test case).
