### PR TITLE
Read yamlFile from workspace if there is no SCM context in declarative pipeline

### DIFF
--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgentScript.groovy
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgentScript.groovy
@@ -35,8 +35,12 @@ public class KubernetesDeclarativeAgentScript extends DeclarativeAgentScript<Kub
     @Override
     public Closure run(Closure body) {
         return {
-            if ((describable.getYamlFile() != null) && (describable.hasScmContext(script))) {
-                describable.setYaml(script.readTrusted(describable.getYamlFile()))
+            if (describable.getYamlFile() != null) {
+                if (describable.hasScmContext(script)) {
+                    describable.setYaml(script.readTrusted(describable.getYamlFile()))
+                } else {
+                    describable.setYaml(script.readFile(describable.getYamlFile()))
+                }
             }
             if (describable.getInheritFrom() == null) {
                 // Do not implicitly inherit from parent template context for declarative Kubernetes agent declaration


### PR DESCRIPTION
In declarative pipeline the `yamlFile` only works, if the referenced file is available in SCM. It should also check the workspace, and load the file from there (as a fallback).

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
