### PR TITLE
Abort "running" builds when the pod agent is disconnected

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTerminatedCause.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTerminatedCause.java
@@ -1,0 +1,21 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import hudson.slaves.OfflineCause;
+import jenkins.model.CauseOfInterruption;
+
+public class PodTerminatedCause extends CauseOfInterruption {
+
+	final String podName;
+
+	final OfflineCause cause;
+
+	public PodTerminatedCause(String podName, OfflineCause cause) {
+		this.podName = podName;
+		this.cause = cause;
+	}
+
+	@Override
+	public String getShortDescription() {
+		return "Pod " + podName + " was terminated, cause: " + cause;
+	}
+}

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncherTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncherTest.java
@@ -1,0 +1,80 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import hudson.model.Executor;
+import hudson.model.Queue;
+import hudson.model.Result;
+import hudson.model.TaskListener;
+import hudson.slaves.SlaveComputer;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class KubernetesLauncherTest {
+
+	@Mock
+	private SlaveComputer computer;
+
+	@Mock
+	private TaskListener listener;
+
+	@Test
+	public void givenDisconnectedComputerShouldAbortRunningExecutors() {
+		KubernetesLauncher launcher = new KubernetesLauncher();
+		final FakeExecutor fakeExecutor = new FakeExecutor();
+		Executor executor = fakeExecutor.getMockExecutor();
+
+		when(computer.getDisplayName()).thenReturn("pod-0");
+		when(computer.getExecutors()).thenReturn(Collections.singletonList(executor));
+
+		launcher.afterDisconnect(computer, listener);
+
+		fakeExecutor.assertWasAborted();
+	}
+
+	private static class FakeExecutor {
+
+		private final Executor mockExecutor = mock(Executor.class);
+		private Result lastResult;
+
+		final Answer<Void> answer = new Answer<>() {
+			@Override
+			public Void answer(InvocationOnMock invocation) {
+				lastResult = Result.ABORTED;
+				return null;
+			}
+		};
+
+		public FakeExecutor() {
+			Queue.Task task = mock(Queue.Task.class);
+			final Queue.Executable executable = mock(Queue.Executable.class);
+
+			when(mockExecutor.getCurrentExecutable()).thenReturn(executable);
+			when(executable.getParent()).thenReturn(task);
+			when(task.getOwnerTask()).thenReturn(task);
+
+			doAnswer(answer).when(mockExecutor).interrupt(eq(Result.ABORTED), any());
+		}
+
+		public Executor getMockExecutor() {
+			return mockExecutor;
+		}
+
+		public void assertWasAborted() {
+			assertEquals(Result.ABORTED, lastResult);
+		}
+	}
+}


### PR DESCRIPTION
Pod agents sometimes are disconnected unexpectedly. The most common reason is their Node being shutdown. Frequently, when this happens, builds become "stuck" waiting for the agent to reconnect. Since Pods can't really "reconnect", the builds stay there indefinitely:

![image](https://user-images.githubusercontent.com/17818024/234033867-e6844961-fa2e-408a-bffb-6cede97aad1e.png)

This fix follows [the logic used by the EC2 Fleet Plugin to abort any running builds](https://github.com/jenkinsci/ec2-fleet-plugin/blob/master/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetAutoResubmitComputerLauncher.java#L76-L118) at the moment the agent is disconnected.

This particular PR would also benefit from https://github.com/jenkinsci/kubernetes-plugin/pull/1348 being merged, as it can provide better information in the logs.

**While there is a test implemented, I don't particularly like it**. I tried to find examples of how to properly create a fake `Executor` and pod agent and at the same time verify that the builds are indeed killed, but I failed at doing so, so instead I simply mocked it. However, this means that the test fails if any of the other `interrupt` methods are called. I welcome any suggestions on how to better test this.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
