### PR TITLE
Handle the case when `watch.exitCode` may return null

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -564,7 +564,7 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
 
                     LOGGER.log(Level.INFO, "Created process inside pod: [" + getPodName() + "], container: ["
                             + containerName + "]" + "[" + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startMethod) + " ms]");
-                    ContainerExecProc proc = new ContainerExecProc(watch, alive, finished, stdin);
+                    ContainerExecProc proc = new ContainerExecProc(watch, alive, finished, stdin, printStream);
                     closables.add(proc);
                     return proc;
                 } catch (InterruptedException ie) {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecProc.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecProc.java
@@ -94,6 +94,13 @@ public class ContainerExecProc extends Proc implements Closeable, Runnable {
             LOGGER.log(Level.FINEST, "Command is finished ({0})", finished);
 
             CompletableFuture<Integer> exitCodeFuture = watch.exitCode();
+
+            if (exitCodeFuture == null) {
+                LOGGER.log(Level.FINEST, "exitCodeFuture is null.");
+                printStream.print("exitCodeFuture is null.");
+                return -1;
+            }
+
             Integer exitCode = exitCodeFuture.get();
 
             if (exitCode == null) {
@@ -103,12 +110,14 @@ public class ContainerExecProc extends Proc implements Closeable, Runnable {
             }
             return exitCode;
         } catch (ExecutionException e) {
-            LOGGER.log(Level.FINEST, "ExecutionException occurred while waiting for exit code", e.getCause());
-            printStream.printf("ExecutionException occurred while waiting for exit code: %s%n", e.getCause());
-            return -1;
-        } catch (Exception e) {
-            LOGGER.log(Level.FINEST, "Exception occurred while waiting for exit code", e);
-            printStream.printf("Exception occurred while waiting for exit code: %s%n", e);
+            Throwable cause = e.getCause();
+            if (cause != null) {
+                LOGGER.log(Level.FINEST, "ExecutionException occurred while waiting for exit code", cause);
+                printStream.printf("ExecutionException occurred while waiting for exit code: %s%n", cause);
+            } else {
+                LOGGER.log(Level.FINEST, "ExecutionException occurred while waiting for exit code", e);
+                printStream.printf("ExecutionException occurred while waiting for exit code: %s%n", e);
+            }
             return -1;
         } finally {
             close();

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecProc.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecProc.java
@@ -97,7 +97,7 @@ public class ContainerExecProc extends Proc implements Closeable, Runnable {
             Integer exitCode = exitCodeFuture.get();
 
             if (exitCode == null) {
-                LOGGER.log(Level.FINEST, "Watcher return 'null' instead of exitCode");
+                LOGGER.log(Level.FINEST, "The container exec watch was closed before it could obtain an exit code from the process.");
                 printStream.print("Watcher return 'null' instead of exitCode");
                 return -1;
             }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecProc.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecProc.java
@@ -3,7 +3,7 @@ package org.csanchez.jenkins.plugins.kubernetes.pipeline;
 
 import hudson.Proc;
 import io.fabric8.kubernetes.client.dsl.ExecWatch;
-import io.jenkins.cli.shaded.org.apache.commons.io.output.NullPrintStream;
+import org.apache.commons.io.output.NullPrintStream;
 import jenkins.util.Timer;
 
 import java.io.ByteArrayOutputStream;

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecProc.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecProc.java
@@ -19,7 +19,9 @@ import java.util.logging.Logger;
 
 import hudson.Proc;
 import io.fabric8.kubernetes.client.dsl.ExecWatch;
+import io.jenkins.cli.shaded.org.apache.commons.io.output.NullPrintStream;
 import jenkins.util.Timer;
+
 import static org.csanchez.jenkins.plugins.kubernetes.pipeline.Constants.CTRL_C;
 import static org.csanchez.jenkins.plugins.kubernetes.pipeline.Constants.EXIT;
 import static org.csanchez.jenkins.plugins.kubernetes.pipeline.Constants.NEWLINE;

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecProc.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecProc.java
@@ -62,7 +62,7 @@ public class ContainerExecProc extends Proc implements Closeable, Runnable {
         this.stdin = stdin == null ? watch.getInput() : stdin;
         this.alive = alive;
         this.finished = finished;
-        this.printStream = printStream;
+        this.printStream = printStream == null ? NullPrintStream.NULL_PRINT_STREAM : printStream;
         Timer.get().schedule(this, 1, TimeUnit.MINUTES);
     }
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecProc.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecProc.java
@@ -107,8 +107,8 @@ public class ContainerExecProc extends Proc implements Closeable, Runnable {
             printStream.printf("ExecutionException occurred while waiting for exit code: %s%n", e.getCause());
             return -1;
         } catch (Exception e) {
-            LOGGER.log(Level.FINEST, "Exception occurred while waiting for exit code", e.getCause());
-            printStream.printf("Exception occurred while waiting for exit code: %s: %s%n", e.getClass(), e.getCause());
+            LOGGER.log(Level.FINEST, "Exception occurred while waiting for exit code", e);
+            printStream.printf("Exception occurred while waiting for exit code: %s%n", e);
             return -1;
         } finally {
             close();

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecProc.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecProc.java
@@ -98,17 +98,17 @@ public class ContainerExecProc extends Proc implements Closeable, Runnable {
 
             if (exitCode == null) {
                 LOGGER.log(Level.FINEST, "The container exec watch was closed before it could obtain an exit code from the process.");
-                printStream.print("Watcher return 'null' instead of exitCode");
+                printStream.print("The container exec watch was closed before it could obtain an exit code from the process.");
                 return -1;
             }
             return exitCode;
         } catch (ExecutionException e) {
             LOGGER.log(Level.FINEST, "ExecutionException occurred while waiting for exit code", e.getCause());
-            printStream.printf("ExecutionException occurred while waiting for exit code %s%n", e.getCause());
+            printStream.printf("ExecutionException occurred while waiting for exit code: %s%n", e.getCause());
             return -1;
         } catch (Exception e) {
             LOGGER.log(Level.FINEST, "Exception occurred while waiting for exit code", e.getCause());
-            printStream.printf("Exception occurred while waiting for exit code %s: %s %n", e.getClass(), e.getCause());
+            printStream.printf("Exception occurred while waiting for exit code: %s: %s%n", e.getClass(), e.getCause());
             return -1;
         } finally {
             close();

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecProc.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecProc.java
@@ -90,22 +90,19 @@ public class ContainerExecProc extends Proc implements Closeable, Runnable {
             LOGGER.log(Level.FINEST, "Command is finished ({0})", finished);
 
             CompletableFuture<Integer> exitCodeFuture = watch.exitCode();
-            if (exitCodeFuture == null) {
+            Integer exitCode = exitCodeFuture.get();
+
+            if (exitCode == null) {
                 LOGGER.log(Level.FINEST, "Watcher return 'null' instead of exitCode");
                 return -1;
             }
-
-            try {
-                return exitCodeFuture.get();
-            } catch (ExecutionException e) {
-                Throwable cause = e.getCause();
-                if (cause instanceof NullPointerException) {
-                    LOGGER.log(Level.FINEST, "NullPointerException occurred while waiting for exit code", cause);
-                } else {
-                    LOGGER.log(Level.FINEST, "Exception occurred while waiting for exit code", cause);
-                }
-                return -1;
-            }
+            return exitCode;
+        } catch (ExecutionException e) {
+            LOGGER.log(Level.FINEST, "ExecutionException occurred while waiting for exit code", e.getCause());
+            return -1;
+        } catch (Exception e) {
+            LOGGER.log(Level.FINEST, "Exception occurred while waiting for exit code", e.getCause());
+            return -1;
         } finally {
             close();
         }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecProc.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecProc.java
@@ -9,6 +9,7 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
@@ -86,7 +87,14 @@ public class ContainerExecProc extends Proc implements Closeable, Runnable {
             LOGGER.log(Level.FINEST, "Waiting for websocket to close on command finish ({0})", finished);
             finished.await();
             LOGGER.log(Level.FINEST, "Command is finished ({0})", finished);
-            return watch.exitCode().join();
+
+            CompletableFuture<Integer> exitCodeFuture = watch.exitCode();
+            if (exitCodeFuture == null) {
+                LOGGER.log(Level.FINEST, "Watcher return 'null' instead of exitCode");
+                return -1;
+            }
+
+            return exitCodeFuture.join();
         } finally {
             close();
         }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecProc.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecProc.java
@@ -1,6 +1,11 @@
 package org.csanchez.jenkins.plugins.kubernetes.pipeline;
 
 
+import hudson.Proc;
+import io.fabric8.kubernetes.client.dsl.ExecWatch;
+import io.jenkins.cli.shaded.org.apache.commons.io.output.NullPrintStream;
+import jenkins.util.Timer;
+
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
@@ -17,14 +22,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import hudson.Proc;
-import io.fabric8.kubernetes.client.dsl.ExecWatch;
-import io.jenkins.cli.shaded.org.apache.commons.io.output.NullPrintStream;
-import jenkins.util.Timer;
-
-import static org.csanchez.jenkins.plugins.kubernetes.pipeline.Constants.CTRL_C;
-import static org.csanchez.jenkins.plugins.kubernetes.pipeline.Constants.EXIT;
-import static org.csanchez.jenkins.plugins.kubernetes.pipeline.Constants.NEWLINE;
+import static org.csanchez.jenkins.plugins.kubernetes.pipeline.Constants.*;
 
 /**
  * Handle the liveness of the processes executed in containers, wait for them to finish and process exit codes.


### PR DESCRIPTION
After changes introduced in https://github.com/jenkinsci/kubernetes-plugin/pull/1260 we have frequent error with `NullPointerException`. Based on a [documentation][2] for `watch.exitCode` method it's clear that watch.exitCode() can return null if close is received before the exit code. In such a case, you can handle the null value and provide an appropriate default or error value.

```
java.lang.NullPointerException at
org.csanchez.jenkins.plugins.kubernetes.pipeline.ContainerExecProc.join(ContainerExecProc.java:89)
at hudson.Proc.joinWithTimeout(Proc.java:174)
at com.cloudbees.jenkins.plugins.sshagent.exec.ExecRemoteAgent.stop(ExecRemoteAgent.java:129)
```

Fix for JENKINS-71135

[2]: https://github.com/fabric8io/kubernetes-client/blob/8a879128d893627a40d64cf2a9c7d5da2e7f47d2/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/ExecWatch.java#L68-L82

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
