### PR TITLE
`KubernetesSlave#readResolve` should call super implementation

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
@@ -482,9 +482,11 @@ public class KubernetesSlave extends AbstractCloudSlave {
         }
     }
 
+    @Override
     protected Object readResolve() {
-        this.executables = new HashSet<>();
-        return this;
+        KubernetesSlave ks = (KubernetesSlave) super.readResolve();
+        ks.executables = new HashSet<>();
+        return ks;
     }
 
     /**


### PR DESCRIPTION
As I understand it, this caused `KubernetesSlave#nodeProperties` to be `null`  after a restart instead of returning an empty list.

Could not reproduce it via `RestartPipelineTest` maybe because `RestartableJenkinsRule` is not realistic.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
