### PR TITLE
Prevent empty command/arg configurations from being accidentally set to the plugin default sleep 9999999

### DIFF
--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/config.jelly
@@ -23,11 +23,11 @@
   </f:entry>
 
   <f:entry field="command" title="${%Command to run}">
-    <f:textbox default="sleep"/>
+    <f:textbox/>
   </f:entry>
 
   <f:entry field="args" title="${%Arguments to pass to the command}">
-    <f:textbox default="9999999"/>
+    <f:textbox/>
   </f:entry>
 
   <f:entry field="ttyEnabled" title="${%Allocate pseudo-TTY}">


### PR DESCRIPTION
Prevent empty command/arg configurations from being accidentally set to the plugin default sleep 9999999

When trying to leave the command empty so that the containers default entry point is used the existing default setting often unintentionally overrides it 

Having no default and allowing the entrypoint of the image to be the default would prevent accidental override issues

https://issues.jenkins.io/browse/JENKINS-70217?jql=text%20~%20%22sleep%22
https://github.com/jenkins-infra/jenkins.io/issues/5741

What I've experienced is that when attempting to update an agent template on the UI where the command and/or args are empty this seems to change the fields to their default instead of leaving it empty. Since images generally have entrypoints set by default it would be reasonable to leave this field empty without a default. Since this change only impacts the UI there will be no changes to existing configurations which have already been set to sleep by the original configuration. All future fields would just default to the images entry points which could then easily be overridden and set to sleep if desired.

### Testing done
The bug this is trying to resolve is intermediate and doesn't always trigger so it is difficult to test

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
