### PR TITLE
[JENKINS-71737] refactor to support dedicated cloud rename page

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,9 +45,9 @@
     <connectorHost />
     <jenkins.host.address />
     <slaveAgentPort />
-    <!-- TODO fix KubernetesCloudTest todos once past 2.414 -->
-    <jenkins.version>2.401.1</jenkins.version>
-    <bom>2.401.x</bom>
+    <!-- TODO https://github.com/jenkinsci/jenkins/pull/8310 -->
+    <jenkins.version>2.423-rc34199.8c3d6c65b_758</jenkins.version>
+    <bom>2.414.x</bom>
     <bom.version>2357.v1043f8578392</bom.version>
     <no-test-jar>false</no-test-jar>
     <useBeta>true</useBeta>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/config.jelly
@@ -1,10 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
 
-    <f:entry title="${%Name}" field="name">
-      <f:textbox default="kubernetes" clazz="required"/>
-    </f:entry>
-    
     <f:advanced title="Kubernetes Cloud details">
 
       <f:entry title="${%Kubernetes URL}" field="serverUrl">

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import hudson.util.VersionNumber;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -16,8 +15,6 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import jenkins.model.Jenkins;
-import org.htmlunit.ElementNotFoundException;
 import org.htmlunit.html.DomElement;
 import org.htmlunit.html.DomNodeList;
 import org.htmlunit.html.HtmlButton;
@@ -69,19 +66,14 @@ public class KubernetesCloudTest {
         j.jenkins.clouds.add(cloud);
         j.jenkins.save();
         JenkinsRule.WebClient wc = j.createWebClient();
-        HtmlPage p = getCloudPage(wc);
+        HtmlPage p = getCloudPage(wc, cloud);
         HtmlForm f = p.getFormByName("config");
         j.submit(f);
         assertEquals("PodTemplate{id='"+podTemplate.getId()+"', name='test-template', label='test'}", podTemplate.toString());
     }
 
-    // TODO 2.414+ delete
-    private HtmlPage getCloudPage(JenkinsRule.WebClient wc) throws IOException, SAXException {
-        if (Jenkins.getVersion().isNewerThanOrEqualTo(new VersionNumber("2.414"))) {
-            return wc.goTo("cloud/kubernetes/configure");
-        } else {
-            return wc.goTo("configureClouds/");
-        }
+    private HtmlPage getCloudPage(JenkinsRule.WebClient wc, KubernetesCloud cloud) throws IOException, SAXException {
+        return wc.goTo(cloud.getUrl() + "configure");
     }
 
     @Test
@@ -269,7 +261,7 @@ public class KubernetesCloudTest {
         j.jenkins.clouds.add(cloud);
         j.jenkins.save();
         JenkinsRule.WebClient wc = j.createWebClient();
-        HtmlPage p = getCloudPage(wc);
+        HtmlPage p = getCloudPage(wc, cloud);
         HtmlForm f = p.getFormByName("config");
         HtmlButton buttonExtends = getButton(f, "Pod Templates");
         buttonExtends.click();
@@ -287,16 +279,8 @@ public class KubernetesCloudTest {
         assertEquals(WorkspaceVolume.getDefault(), podTemplate.getWorkspaceVolume());
     }
 
-    // TODO 2.385+ delete
     private HtmlButton getButton(HtmlForm f, String buttonText) {
-        HtmlButton button;
-        try {
-            button = HtmlFormUtil.getButtonByCaption(f, buttonText);
-        } catch (ElementNotFoundException e) {
-            // before https://github.com/jenkinsci/jenkins/pull/7173 the 3 dots where added by core
-            button = HtmlFormUtil.getButtonByCaption(f, buttonText + "...");
-        }
-        return button;
+        return HtmlFormUtil.getButtonByCaption(f, buttonText);
     }
 
     @Test


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
downstream of https://github.com/jenkinsci/jenkins/pull/8310

refactoring to support dedicated cloud rename page

### Testing done
Manually created new cloud, changed its name, validated cloud name is not editable in config

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
