### PR TITLE
Add a test for non-configurable cloud added via casc

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/NonConfigurableKubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/NonConfigurableKubernetesCloud.java
@@ -7,6 +7,7 @@ import hudson.model.DescriptorVisibilityFilter;
 import hudson.slaves.Cloud;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.StaplerRequest;
 
 public class NonConfigurableKubernetesCloud extends KubernetesCloud {
@@ -23,6 +24,7 @@ public class NonConfigurableKubernetesCloud extends KubernetesCloud {
     }
 
     @Extension
+    @Symbol("nonConfigurableKubernetes")
     public static class DescriptorImpl extends KubernetesCloud.DescriptorImpl {
         @Override
         public String getDisplayName() {

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/casc/CasCTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/casc/CasCTest.java
@@ -4,11 +4,16 @@ import io.jenkins.plugins.casc.misc.RoundTripAbstractTest;
 import org.csanchez.jenkins.plugins.kubernetes.ContainerLivenessProbe;
 import org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate;
 import org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud;
+import org.csanchez.jenkins.plugins.kubernetes.NonConfigurableKubernetesCloud;
 import org.csanchez.jenkins.plugins.kubernetes.PodTemplate;
+import org.csanchez.jenkins.plugins.kubernetes.model.TemplateEnvVar;
 import org.csanchez.jenkins.plugins.kubernetes.pod.yaml.Merge;
 import org.csanchez.jenkins.plugins.kubernetes.pod.yaml.Overrides;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.workspace.DynamicPVCWorkspaceVolume;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.workspace.WorkspaceVolume;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.RestartableJenkinsRule;
 
 import java.util.List;
@@ -21,68 +26,130 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+
+@RunWith(Parameterized.class)
 public class CasCTest extends RoundTripAbstractTest {
+    final Strategy strategy;
+
+    public CasCTest(Strategy strategy) {
+        this.strategy = strategy;
+    }
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Object[] permutations() {
+        return new Object[][] {
+                {new DefaultStrategy()},
+                {new NonConfigurableStrategy()},
+        };
+    }
+
+    @Override
+    protected String configResource() {
+        return strategy.getResource() + ".yaml";
+    }
 
     @Override
     protected void assertConfiguredAsExpected(RestartableJenkinsRule r, String configContent) {
-        List<KubernetesCloud> all = r.j.jenkins.clouds.getAll(KubernetesCloud.class);
-        assertThat(all, hasSize(1));
-        KubernetesCloud cloud = all.get(0);
-        assertNotNull(cloud);
-        assertEquals(10,cloud.getContainerCap());
-        assertEquals("http://jenkinshost:8080/jenkins/", cloud.getJenkinsUrl());
-        assertEquals(32, cloud.getMaxRequestsPerHost());
-        assertEquals("kubernetes", cloud.name);
-        List<PodTemplate> templates = cloud.getTemplates();
-        assertNotNull(templates);
-        assertEquals(3, templates.size());
-        PodTemplate podTemplate = templates.get(0);
-        assertFalse(podTemplate.isHostNetwork());
-        assertEquals("java", podTemplate.getLabel());
-        assertEquals("default-java", podTemplate.getName());
-        assertEquals(10, podTemplate.getInstanceCap());
-        assertEquals(123, podTemplate.getSlaveConnectTimeout());
-        assertEquals(5, podTemplate.getIdleMinutes());
-        assertEquals(66, podTemplate.getActiveDeadlineSeconds());
-        assertThat(podTemplate.getYamlMergeStrategy(), isA(Overrides.class));
-        podTemplate = templates.get(1);
-        assertFalse(podTemplate.isHostNetwork());
-        assertEquals("dynamic-pvc", podTemplate.getLabel());
-        assertEquals("dynamic-pvc", podTemplate.getName());
-        assertThat(podTemplate.getYamlMergeStrategy(), isA(Overrides.class));
-        WorkspaceVolume workspaceVolume = podTemplate.getWorkspaceVolume();
-        assertNotNull(workspaceVolume);
-        assertThat(workspaceVolume, isA(DynamicPVCWorkspaceVolume.class));
-        DynamicPVCWorkspaceVolume dynamicPVCVolume = (DynamicPVCWorkspaceVolume) workspaceVolume;
-        assertEquals("ReadWriteOnce", dynamicPVCVolume.getAccessModes());
-        assertEquals("1",dynamicPVCVolume.getRequestsSize());
-        assertEquals("hostpath",dynamicPVCVolume.getStorageClassName());
-        podTemplate = templates.get(2);
-        assertFalse(podTemplate.isHostNetwork());
-        assertEquals("test", podTemplate.getLabel());
-        assertEquals("test", podTemplate.getName());
-        assertThat(podTemplate.getYamlMergeStrategy(), isA(Merge.class));
-        List<ContainerTemplate> containers = podTemplate.getContainers();
-        assertNotNull(containers);
-        assertEquals(1, containers.size());
-        ContainerTemplate container = containers.get(0);
-        assertEquals("cat", container.getArgs());
-        assertEquals("/bin/sh -c", container.getCommand());
-        assertEquals("maven:3.6.3-jdk-8", container.getImage());
-        ContainerLivenessProbe livenessProbe = container.getLivenessProbe();
-        assertEquals(1, livenessProbe.getFailureThreshold());
-        assertEquals(2, livenessProbe.getInitialDelaySeconds());
-        assertEquals(3, livenessProbe.getPeriodSeconds());
-        assertEquals(4, livenessProbe.getSuccessThreshold());
-        assertEquals(5, livenessProbe.getTimeoutSeconds());
-        assertEquals("maven",container.getName());
-        assertTrue(container.isTtyEnabled());
-        assertEquals("/src", container.getWorkingDir());
-
+        strategy.verify(r.j);
     }
 
     @Override
     protected String stringInLogExpected() {
-        return "KubernetesCloud";
+        return strategy.stringInLogExpected();
+    }
+
+    abstract static class Strategy {
+        abstract void verify(JenkinsRule j);
+
+        abstract String getResource();
+
+        String stringInLogExpected() {
+            return "KubernetesCloud";
+        }
+
+        @Override
+        public String toString() {
+            return getResource();
+        }
+    }
+
+    private static class DefaultStrategy extends Strategy {
+
+        @Override
+        void verify(JenkinsRule j) {
+            List<KubernetesCloud> all = j.jenkins.clouds.getAll(KubernetesCloud.class);
+            assertThat(all, hasSize(1));
+            KubernetesCloud cloud = all.get(0);
+            assertNotNull(cloud);
+            assertEquals(10,cloud.getContainerCap());
+            assertEquals("http://jenkinshost:8080/jenkins/", cloud.getJenkinsUrl());
+            assertEquals(32, cloud.getMaxRequestsPerHost());
+            assertEquals("kubernetes", cloud.name);
+            List<PodTemplate> templates = cloud.getTemplates();
+            assertNotNull(templates);
+            assertEquals(3, templates.size());
+            PodTemplate podTemplate = templates.get(0);
+            assertFalse(podTemplate.isHostNetwork());
+            assertEquals("java", podTemplate.getLabel());
+            assertEquals("default-java", podTemplate.getName());
+            assertEquals(10, podTemplate.getInstanceCap());
+            assertEquals(123, podTemplate.getSlaveConnectTimeout());
+            assertEquals(5, podTemplate.getIdleMinutes());
+            assertEquals(66, podTemplate.getActiveDeadlineSeconds());
+            assertThat(podTemplate.getYamlMergeStrategy(), isA(Overrides.class));
+            podTemplate = templates.get(1);
+            assertFalse(podTemplate.isHostNetwork());
+            assertEquals("dynamic-pvc", podTemplate.getLabel());
+            assertEquals("dynamic-pvc", podTemplate.getName());
+            assertThat(podTemplate.getYamlMergeStrategy(), isA(Overrides.class));
+            WorkspaceVolume workspaceVolume = podTemplate.getWorkspaceVolume();
+            assertNotNull(workspaceVolume);
+            assertThat(workspaceVolume, isA(DynamicPVCWorkspaceVolume.class));
+            DynamicPVCWorkspaceVolume dynamicPVCVolume = (DynamicPVCWorkspaceVolume) workspaceVolume;
+            assertEquals("ReadWriteOnce", dynamicPVCVolume.getAccessModes());
+            assertEquals("1",dynamicPVCVolume.getRequestsSize());
+            assertEquals("hostpath",dynamicPVCVolume.getStorageClassName());
+            podTemplate = templates.get(2);
+            assertFalse(podTemplate.isHostNetwork());
+            assertEquals("test", podTemplate.getLabel());
+            assertEquals("test", podTemplate.getName());
+            assertThat(podTemplate.getYamlMergeStrategy(), isA(Merge.class));
+            List<ContainerTemplate> containers = podTemplate.getContainers();
+            assertNotNull(containers);
+            assertEquals(1, containers.size());
+            ContainerTemplate container = containers.get(0);
+            assertEquals("cat", container.getArgs());
+            assertEquals("/bin/sh -c", container.getCommand());
+            assertEquals("maven:3.6.3-jdk-8", container.getImage());
+            ContainerLivenessProbe livenessProbe = container.getLivenessProbe();
+            assertEquals(1, livenessProbe.getFailureThreshold());
+            assertEquals(2, livenessProbe.getInitialDelaySeconds());
+            assertEquals(3, livenessProbe.getPeriodSeconds());
+            assertEquals(4, livenessProbe.getSuccessThreshold());
+            assertEquals(5, livenessProbe.getTimeoutSeconds());
+            assertEquals("maven",container.getName());
+            assertTrue(container.isTtyEnabled());
+            assertEquals("/src", container.getWorkingDir());
+        }
+
+        @Override
+        String getResource() {
+            return "configuration-as-code";
+        }
+    }
+
+    private static class NonConfigurableStrategy extends Strategy {
+        @Override
+        void verify(JenkinsRule j) {
+            var all = j.jenkins.clouds.getAll(NonConfigurableKubernetesCloud.class);
+            assertThat(all, hasSize(1));
+            var cloud = all.get(0);
+            assertNotNull(cloud);
+        }
+
+        @Override
+        String getResource() {
+            return "casc_nonConfigurable";
+        }
     }
 }

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/casc/casc_nonConfigurable.yaml
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/casc/casc_nonConfigurable.yaml
@@ -1,0 +1,4 @@
+jenkins:
+  clouds:
+    - nonConfigurableKubernetes:
+        name: "kubernetes"


### PR DESCRIPTION
Currently fails with

```
java.lang.IllegalStateException: No configurator implementation to manage class org.csanchez.jenkins.plugins.kubernetes.NonConfigurableKubernetesCloud
        at io.jenkins.plugins.casc.impl.configurators.HeteroDescribableConfigurator.lambda$forceLookupConfigurator$8(HeteroDescribableConfigurator.java:137)
        at io.vavr.control.Option.getOrElseThrow(Option.java:351)
        at io.jenkins.plugins.casc.impl.configurators.HeteroDescribableConfigurator.forceLookupConfigurator(HeteroDescribableConfigurator.java:137)
        at io.jenkins.plugins.casc.impl.configurators.HeteroDescribableConfigurator.lambda$configure$1(HeteroDescribableConfigurator.java:85)
        at io.vavr.control.Option.map(Option.java:392)
        at io.jenkins.plugins.casc.impl.configurators.HeteroDescribableConfigurator.lambda$configure$3(HeteroDescribableConfigurator.java:85)
        at io.vavr.Tuple2.apply(Tuple2.java:238)
        at io.jenkins.plugins.casc.impl.configurators.HeteroDescribableConfigurator.configure(HeteroDescribableConfigurator.java:84)
        at io.jenkins.plugins.casc.impl.configurators.HeteroDescribableConfigurator.check(HeteroDescribableConfigurator.java:92)
        at io.jenkins.plugins.casc.impl.configurators.HeteroDescribableConfigurator.check(HeteroDescribableConfigurator.java:55)
        at io.jenkins.plugins.casc.BaseConfigurator.configure(BaseConfigurator.java:355)
        at io.jenkins.plugins.casc.BaseConfigurator.check(BaseConfigurator.java:293)
        at io.jenkins.plugins.casc.ConfigurationAsCode.lambda$checkWith$9(ConfigurationAsCode.java:797)
        at io.jenkins.plugins.casc.ConfigurationAsCode.invokeWith(ConfigurationAsCode.java:731)
        at io.jenkins.plugins.casc.ConfigurationAsCode.checkWith(ConfigurationAsCode.java:797)
        at io.jenkins.plugins.casc.ConfigurationAsCode.configureWith(ConfigurationAsCode.java:783)
        at io.jenkins.plugins.casc.ConfigurationAsCode.configureWith(ConfigurationAsCode.java:652)
        at io.jenkins.plugins.casc.ConfigurationAsCode.configure(ConfigurationAsCode.java:621)
        at io.jenkins.plugins.casc.ConfigurationAsCode.configure(ConfigurationAsCode.java:610)
        at io.jenkins.plugins.casc.misc.RoundTripAbstractTest.configureWithResource(RoundTripAbstractTest.java:133)
        at io.jenkins.plugins.casc.misc.RoundTripAbstractTest.lambda$roundTripTest$0(RoundTripAbstractTest.java:103)
        at org.jvnet.hudson.test.RestartableJenkinsRule$3.evaluate(RestartableJenkinsRule.java:243)
        at org.jvnet.hudson.test.RestartableJenkinsRule$6.evaluate(RestartableJenkinsRule.java:291)
        at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:607)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.lang.Thread.run(Thread.java:833)
```

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
