### PR TITLE
feat:Add configuration for the number of executors for the agent pod.

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ Either way it provides access to the following fields:
 * **podRetention** Controls the behavior of keeping agent pods. Can be 'never()', 'onFailure()', 'always()', or 'default()' - if empty will default to deleting the pod after `activeDeadlineSeconds` has passed.
 * **activeDeadlineSeconds** If `podRetention` is set to `never()` or `onFailure()`, the pod is deleted after this deadline is passed.
 * **idleMinutes** Allows the pod to remain active for reuse until the configured number of minutes has passed since the last step was executed on it.
+* **numExecutors** The maximum number of concurrent builds that Jenkins may perform on this agent pod.
 * **showRawYaml** Enable or disable the output of the raw pod manifest. Defaults to `true`
 * **runAsUser** The user ID to run all containers in the pod as.
 * **runAsGroup** The group ID to run all containers in the pod as. 

--- a/README_zh.md
+++ b/README_zh.md
@@ -156,6 +156,7 @@ podTemplate(label: label, containers: [
 * **podRetention** 用于决定是否保留节点 pod。可以是 'never()'、 'onFailure()'、 'always()' 或 'default()'，如果为空的话，超过 `activeDeadlineSeconds` 设定的时间时间后会删除 pod
 * **activeDeadlineSeconds** 如果 `podRetention` 设置为 'never()' 或 'onFailure()' 的话，在时间超过后 pod 会被删除
 * **idleMinutes** 允许 pod 保持活跃以便再次使用，直到最后一次执行后的时间超过配置的分钟数
+* **numExecutors** 允许 pod 上并行执行的最大构建数量
 
 `containerTemplate` 是容器的模板，会被加到 pod 中。同样地，它的配置可以通过用户界面或流水线来配置，字段包括：
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
@@ -149,7 +149,7 @@ public class KubernetesSlave extends AbstractCloudSlave {
      * @deprecated Use {@link Builder} instead.
      */
     @Deprecated
-    public KubernetesSlave(PodTemplate template, String nodeDescription, KubernetesCloud cloud, String labelStr, Integer numExecutors)
+    public KubernetesSlave(PodTemplate template, String nodeDescription, KubernetesCloud cloud, String labelStr, int numExecutors)
             throws Descriptor.FormException, IOException {
 
         this(template, nodeDescription, cloud.name, labelStr, numExecutors, new OnceRetentionStrategy(cloud.getRetentionTimeout()));
@@ -159,7 +159,7 @@ public class KubernetesSlave extends AbstractCloudSlave {
      * @deprecated Use {@link Builder} instead.
      */
     @Deprecated
-    public KubernetesSlave(PodTemplate template, String nodeDescription, KubernetesCloud cloud, Label label, Integer numExecutors)
+    public KubernetesSlave(PodTemplate template, String nodeDescription, KubernetesCloud cloud, Label label, int numExecutors)
             throws Descriptor.FormException, IOException {
         this(template, nodeDescription, cloud.name, label.toString(), numExecutors, new OnceRetentionStrategy(cloud.getRetentionTimeout())) ;
     }
@@ -168,7 +168,7 @@ public class KubernetesSlave extends AbstractCloudSlave {
      * @deprecated Use {@link Builder} instead.
      */
     @Deprecated
-    public KubernetesSlave(PodTemplate template, String nodeDescription, KubernetesCloud cloud, String labelStr, Integer numExecutors,
+    public KubernetesSlave(PodTemplate template, String nodeDescription, KubernetesCloud cloud, String labelStr, int numExecutors,
                            RetentionStrategy rs)
             throws Descriptor.FormException, IOException {
         this(template, nodeDescription, cloud.name, labelStr, numExecutors, rs);
@@ -179,13 +179,13 @@ public class KubernetesSlave extends AbstractCloudSlave {
      */
     @Deprecated
     @DataBoundConstructor // make stapler happy. Not actually used.
-    public KubernetesSlave(PodTemplate template, String nodeDescription, String cloudName, String labelStr, Integer numExecutors,
+    public KubernetesSlave(PodTemplate template, String nodeDescription, String cloudName, String labelStr, int numExecutors,
                            RetentionStrategy rs)
             throws Descriptor.FormException, IOException {
         this(getSlaveName(template), template, nodeDescription, cloudName, labelStr, numExecutors, new KubernetesLauncher(), rs);
     }
 
-    protected KubernetesSlave(String name, @NonNull PodTemplate template, String nodeDescription, String cloudName, String labelStr, Integer numExecutors,
+    protected KubernetesSlave(String name, @NonNull PodTemplate template, String nodeDescription, String cloudName, String labelStr, int numExecutors,
                            ComputerLauncher computerLauncher, RetentionStrategy rs)
             throws Descriptor.FormException, IOException {
         super(name, null, computerLauncher);
@@ -510,7 +510,7 @@ public class KubernetesSlave extends AbstractCloudSlave {
         private PodTemplate podTemplate;
         private KubernetesCloud cloud;
         private String label;
-        private Integer numExecutors;
+        private int numExecutors;
         private ComputerLauncher computerLauncher;
         private RetentionStrategy retentionStrategy;
 
@@ -563,7 +563,7 @@ public class KubernetesSlave extends AbstractCloudSlave {
          * @param numExecutors The numExecutors the {@link KubernetesSlave} has.
          * @return the current instance for method chaining
          */
-        public Builder numExecutors(Integer numExecutors) {
+        public Builder numExecutors(int numExecutors) {
             this.numExecutors = numExecutors;
             return this;
         }
@@ -610,7 +610,7 @@ public class KubernetesSlave extends AbstractCloudSlave {
                     nodeDescription == null ? podTemplate.getName() : nodeDescription,
                     cloud.name,
                     label == null ? podTemplate.getLabel() : label,
-                    numExecutors == null || numExecutors < 1 ? podTemplate.getNumExecutors() : numExecutors,
+                    numExecutors < 1 ? podTemplate.getNumExecutors() : numExecutors,
                     decorateLauncher(cloud, computerLauncher == null ? new KubernetesLauncher(cloud.getJenkinsTunnel(), null) : computerLauncher),
                     retentionStrategy == null ? determineRetentionStrategy(cloud, podTemplate) : retentionStrategy);
         }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
@@ -149,29 +149,29 @@ public class KubernetesSlave extends AbstractCloudSlave {
      * @deprecated Use {@link Builder} instead.
      */
     @Deprecated
-    public KubernetesSlave(PodTemplate template, String nodeDescription, KubernetesCloud cloud, String labelStr)
+    public KubernetesSlave(PodTemplate template, String nodeDescription, KubernetesCloud cloud, String labelStr, Integer numExecutors)
             throws Descriptor.FormException, IOException {
 
-        this(template, nodeDescription, cloud.name, labelStr, new OnceRetentionStrategy(cloud.getRetentionTimeout()));
+        this(template, nodeDescription, cloud.name, labelStr, numExecutors, new OnceRetentionStrategy(cloud.getRetentionTimeout()));
     }
 
     /**
      * @deprecated Use {@link Builder} instead.
      */
     @Deprecated
-    public KubernetesSlave(PodTemplate template, String nodeDescription, KubernetesCloud cloud, Label label)
+    public KubernetesSlave(PodTemplate template, String nodeDescription, KubernetesCloud cloud, Label label, Integer numExecutors)
             throws Descriptor.FormException, IOException {
-        this(template, nodeDescription, cloud.name, label.toString(), new OnceRetentionStrategy(cloud.getRetentionTimeout())) ;
+        this(template, nodeDescription, cloud.name, label.toString(), numExecutors, new OnceRetentionStrategy(cloud.getRetentionTimeout())) ;
     }
 
     /**
      * @deprecated Use {@link Builder} instead.
      */
     @Deprecated
-    public KubernetesSlave(PodTemplate template, String nodeDescription, KubernetesCloud cloud, String labelStr,
+    public KubernetesSlave(PodTemplate template, String nodeDescription, KubernetesCloud cloud, String labelStr, Integer numExecutors,
                            RetentionStrategy rs)
             throws Descriptor.FormException, IOException {
-        this(template, nodeDescription, cloud.name, labelStr, rs);
+        this(template, nodeDescription, cloud.name, labelStr, numExecutors, rs);
     }
 
     /**
@@ -179,18 +179,18 @@ public class KubernetesSlave extends AbstractCloudSlave {
      */
     @Deprecated
     @DataBoundConstructor // make stapler happy. Not actually used.
-    public KubernetesSlave(PodTemplate template, String nodeDescription, String cloudName, String labelStr,
+    public KubernetesSlave(PodTemplate template, String nodeDescription, String cloudName, String labelStr, Integer numExecutors,
                            RetentionStrategy rs)
             throws Descriptor.FormException, IOException {
-        this(getSlaveName(template), template, nodeDescription, cloudName, labelStr, new KubernetesLauncher(), rs);
+        this(getSlaveName(template), template, nodeDescription, cloudName, labelStr, numExecutors, new KubernetesLauncher(), rs);
     }
 
-    protected KubernetesSlave(String name, @NonNull PodTemplate template, String nodeDescription, String cloudName, String labelStr,
+    protected KubernetesSlave(String name, @NonNull PodTemplate template, String nodeDescription, String cloudName, String labelStr, Integer numExecutors,
                            ComputerLauncher computerLauncher, RetentionStrategy rs)
             throws Descriptor.FormException, IOException {
         super(name, null, computerLauncher);
         setNodeDescription(nodeDescription);
-        setNumExecutors(1);
+        setNumExecutors(numExecutors);
         setMode(template.getNodeUsageMode() != null ? template.getNodeUsageMode() : Node.Mode.NORMAL);
         setLabelString(labelStr);
         setRetentionStrategy(rs);
@@ -510,6 +510,7 @@ public class KubernetesSlave extends AbstractCloudSlave {
         private PodTemplate podTemplate;
         private KubernetesCloud cloud;
         private String label;
+        private Integer numExecutors;
         private ComputerLauncher computerLauncher;
         private RetentionStrategy retentionStrategy;
 
@@ -559,6 +560,15 @@ public class KubernetesSlave extends AbstractCloudSlave {
         }
 
         /**
+         * @param numExecutors The numExecutors the {@link KubernetesSlave} has.
+         * @return the current instance for method chaining
+         */
+        public Builder numExecutors(Integer numExecutors) {
+            this.numExecutors = numExecutors;
+            return this;
+        }
+
+        /**
          * @param computerLauncher The computer launcher to use to launch the {@link KubernetesSlave} instance.
          * @return the current instance for method chaining
          */
@@ -600,6 +610,7 @@ public class KubernetesSlave extends AbstractCloudSlave {
                     nodeDescription == null ? podTemplate.getName() : nodeDescription,
                     cloud.name,
                     label == null ? podTemplate.getLabel() : label,
+                    numExecutors == null || numExecutors < 1 ? podTemplate.getNumExecutors() : numExecutors,
                     decorateLauncher(cloud, computerLauncher == null ? new KubernetesLauncher(cloud.getJenkinsTunnel(), null) : computerLauncher),
                     retentionStrategy == null ? determineRetentionStrategy(cloud, podTemplate) : retentionStrategy);
         }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -118,6 +118,8 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
 
     private int instanceCap = Integer.MAX_VALUE;
 
+    private int numExecutors = 1;
+
     private int slaveConnectTimeout = DEFAULT_SLAVE_JENKINS_CONNECTION_TIMEOUT;
 
     private int idleMinutes;
@@ -350,6 +352,19 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
     }
 
     @DataBoundSetter
+    public void setNumExecutors(int numExecutors) {
+        if (numExecutors < 0) {
+            this.numExecutors = 1;
+        } else {
+            this.numExecutors = numExecutors;
+        }
+    }
+
+    public int getNumExecutors() {
+        return numExecutors;
+    }
+
+    @DataBoundSetter
     public void setSlaveConnectTimeout(int slaveConnectTimeout) {
         if (slaveConnectTimeout <= 0) {
             LOGGER.log(Level.WARNING, "Agent -> Jenkins connection timeout " +
@@ -381,6 +396,24 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
             return "";
         } else {
             return String.valueOf(instanceCap);
+        }
+    }
+
+
+    @DataBoundSetter
+    public void setNumExecutorsStr(String numExecutorsStr) {
+        if (StringUtils.isBlank(numExecutorsStr)) {
+            setNumExecutors(1);
+        } else {
+            setNumExecutors(Integer.parseInt(numExecutorsStr));
+        }
+    }
+
+    public String getNumExecutorsStr() {
+        if (getNumExecutors() == 1) {
+            return "";
+        } else {
+            return String.valueOf(numExecutors);
         }
     }
 
@@ -1000,6 +1033,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
                 "activeDeadlineSeconds",
                 "idleMinutes",
                 "instanceCap",
+                "numExecutors",
                 "slaveConnectTimeout",
         };
 
@@ -1056,6 +1090,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
                 (args == null ? "" : ", args='" + args + '\'') +
                 (remoteFs == null ? "" : ", remoteFs='" + remoteFs + '\'') +
                 (instanceCap == Integer.MAX_VALUE ? "" : ", instanceCap=" + instanceCap) +
+                (numExecutors == 1 ? "" : ", numExecutors='" + numExecutors) +
                 (slaveConnectTimeout == DEFAULT_SLAVE_JENKINS_CONNECTION_TIMEOUT ? "" : ", slaveConnectTimeout=" + slaveConnectTimeout) +
                 (idleMinutes == 0 ? "" : ", idleMinutes=" + idleMinutes) +
                 (activeDeadlineSeconds == 0 ? "" : ", activeDeadlineSeconds=" + activeDeadlineSeconds) +

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
@@ -437,6 +437,9 @@ public class PodTemplateUtils {
         podTemplate.setInstanceCap(template.getInstanceCap() != Integer.MAX_VALUE ?
                                    template.getInstanceCap() : parent.getInstanceCap());
 
+        podTemplate.setNumExecutors(template.getNumExecutors() != 1 ?
+                template.getNumExecutors() : parent.getNumExecutors());
+
         podTemplate.setSlaveConnectTimeout(template.getSlaveConnectTimeout() != PodTemplate.DEFAULT_SLAVE_JENKINS_CONNECTION_TIMEOUT ?
                                            template.getSlaveConnectTimeout() : parent.getSlaveConnectTimeout());
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgent.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgent.java
@@ -50,6 +50,9 @@ public class KubernetesDeclarativeAgent extends RetryableDeclarativeAgent<Kubern
 
     private int idleMinutes;
     private int instanceCap = Integer.MAX_VALUE;
+
+    private int numExecutors = 1;
+
     @CheckForNull
     private String serviceAccount;
     @CheckForNull
@@ -157,6 +160,20 @@ public class KubernetesDeclarativeAgent extends RetryableDeclarativeAgent<Kubern
             this.instanceCap = instanceCap;
         }
     }
+
+    public int getNumExecutors() {
+        return numExecutors;
+    }
+
+    @DataBoundSetter
+    public void setNumExecutors(int numExecutors) {
+        if (numExecutors <= 0) {
+            this.numExecutors = 1;
+        } else {
+            this.numExecutors = numExecutors;
+        }
+    }
+
 
     public String getServiceAccount() {
         return serviceAccount;
@@ -379,6 +396,9 @@ public class KubernetesDeclarativeAgent extends RetryableDeclarativeAgent<Kubern
         }
         if (instanceCap > 0 && instanceCap < Integer.MAX_VALUE) {
             argMap.put("instanceCap", instanceCap);
+        }
+        if (numExecutors > 0 && numExecutors != 1) {
+            argMap.put("numExecutors", numExecutors);
         }
         if (!StringUtils.isEmpty(supplementalGroups)){
             argMap.put("supplementalGroups", supplementalGroups);

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep.java
@@ -67,6 +67,8 @@ public class PodTemplateStep extends Step implements Serializable {
     private List<String> imagePullSecrets = new ArrayList<>();
 
     private Integer instanceCap = Integer.MAX_VALUE;
+
+    private Integer numExecutors = 1;
     private int idleMinutes;
     private int slaveConnectTimeout = PodTemplate.DEFAULT_SLAVE_JENKINS_CONNECTION_TIMEOUT;
     private int activeDeadlineSeconds;
@@ -221,6 +223,19 @@ public class PodTemplateStep extends Step implements Serializable {
             this.instanceCap = Integer.MAX_VALUE;
         } else {
             this.instanceCap = instanceCap;
+        }
+    }
+
+    public Integer getNumExecutors() {
+        return numExecutors;
+    }
+
+    @DataBoundSetter
+    public void setNumExecutors(@CheckForNull Integer numExecutors) {
+        if (numExecutors == null || numExecutors.intValue() <= 0) {
+            this.numExecutors = 1;
+        } else {
+            this.numExecutors = numExecutors;
         }
     }
 
@@ -400,7 +415,7 @@ public class PodTemplateStep extends Step implements Serializable {
     @Extension
     public static class DescriptorImpl extends StepDescriptor {
 
-        static final String[] POD_TEMPLATE_FIELDS = {"name", "namespace", "inheritFrom", "containers", "envVars", "volumes", "annotations", "yaml", "showRawYaml", "instanceCap", "podRetention", "supplementalGroups", "idleMinutes", "activeDeadlineSeconds", "serviceAccount", "nodeSelector", "workingDir", "workspaceVolume"};
+        static final String[] POD_TEMPLATE_FIELDS = {"name", "namespace", "inheritFrom", "containers", "envVars", "volumes", "annotations", "yaml", "showRawYaml", "instanceCap", "numExecutors", "podRetention", "supplementalGroups", "idleMinutes", "activeDeadlineSeconds", "serviceAccount", "nodeSelector", "workingDir", "workspaceVolume"};
 
         public DescriptorImpl() {
             for (String field : POD_TEMPLATE_FIELDS) {
@@ -473,6 +488,7 @@ public class PodTemplateStep extends Step implements Serializable {
         }
 
         public static final Integer defaultInstanceCap = Integer.MAX_VALUE;
+        public static final Integer defaultNumExecutors = 1;
         public static final PodRetention defaultPodRetention = PodRetention.getPodTemplateDefault();
         public static final WorkspaceVolume defaultWorkspaceVolume = WorkspaceVolume.getDefault();
         /** Only used for snippet generation. */

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
@@ -96,6 +96,7 @@ public class PodTemplateStepExecution extends AbstractStepExecutionImpl {
             newTemplate.setInheritFrom(PodTemplateUtils.emptyToNull(step.getInheritFrom()));
         }
         newTemplate.setInstanceCap(step.getInstanceCap());
+        newTemplate.setNumExecutors(step.getNumExecutors());
         newTemplate.setIdleMinutes(step.getIdleMinutes());
         newTemplate.setSlaveConnectTimeout(step.getSlaveConnectTimeout());
         newTemplate.setLabel(label);

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
@@ -54,6 +54,10 @@
       <f:textbox/>
     </f:entry>
 
+    <f:entry field="numExecutorsStr" title="${%Num Executors}">
+      <f:textbox/>
+    </f:entry>
+
     <f:dropdownDescriptorSelector title="${%Pod Retention}" field="podRetention" default="${descriptor.defaultPodRetention}" />
     
     <f:entry field="idleMinutesStr" title="${%Time in minutes to retain agent when idle}">

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/help-numExecutors.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/help-numExecutors.html
@@ -1,0 +1,4 @@
+<p>
+The maximum number of concurrent builds that Jenkins may perform on this agent pod.<br/>
+If set to empty, the default value is 1.
+</p>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgent/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgent/config.jelly
@@ -21,6 +21,9 @@
     <f:entry field="instanceCap" title="${%Max number of instances}">
       <f:textbox default="0"/>
     </f:entry>
+    <f:entry field="numExecutors" title="${%Number of executors}">
+      <f:textbox default="1"/>
+    </f:entry>
     <f:entry title="${%Pod Retention}">
       <f:dropdownDescriptorSelector field="podRetention" default="${descriptor.defaultPodRetention}"/>
     </f:entry>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep/config.jelly
@@ -58,6 +58,9 @@
         <f:entry field="instanceCap" title="${%Maximum number of instances}">
           <f:textbox default="0"/>
         </f:entry>
+        <f:entry field="numExecutors" title="${%Number of executors}">
+          <f:textbox default="1"/>
+        </f:entry>
         <f:entry title="${%Pod Retention}">
           <f:dropdownDescriptorSelector field="podRetention" default="${descriptor.defaultPodRetention}"/>
         </f:entry>

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesProvisioningLimitsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesProvisioningLimitsTest.java
@@ -35,6 +35,7 @@ public class KubernetesProvisioningLimitsTest {
                 PodTemplate pt = new PodTemplate();
                 pt.setName(cloud.name + "-podTemplate-" + j);
                 pt.setInstanceCap(testRandom.nextInt(4)+1);
+                pt.setNumExecutors(testRandom.nextInt(4)+1);
                 cloud.addTemplate(pt);
             }
             j.jenkins.clouds.add(cloud);

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesQueueTaskDispatcherTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesQueueTaskDispatcherTest.java
@@ -69,8 +69,8 @@ public class KubernetesQueueTaskDispatcherTest {
         json2.element("usage-permission-B", true);
         folderB.addProperty(property2.reconfigure(null, json2));
 
-        slaveA = new KubernetesSlave("A", new PodTemplate(), "testA", "A", "dockerA", new KubernetesLauncher(), RetentionStrategy.INSTANCE);
-        slaveB = new KubernetesSlave("B", new PodTemplate(), "testB", "B", "dockerB", new KubernetesLauncher(), RetentionStrategy.INSTANCE);
+        slaveA = new KubernetesSlave("A", new PodTemplate(), "testA", "A", "dockerA", 1, new KubernetesLauncher(), RetentionStrategy.INSTANCE);
+        slaveB = new KubernetesSlave("B", new PodTemplate(), "testB", "B", "dockerB", 1, new KubernetesLauncher(), RetentionStrategy.INSTANCE);
     }
 
     @Test
@@ -96,7 +96,7 @@ public class KubernetesQueueTaskDispatcherTest {
         cloud.setUsageRestricted(false);
         jenkins.jenkins.clouds.add(cloud);
         KubernetesQueueTaskDispatcher dispatcher = new KubernetesQueueTaskDispatcher();
-        KubernetesSlave slave = new KubernetesSlave("C", new PodTemplate(), "testC", "C", "dockerC", new KubernetesLauncher(), RetentionStrategy.INSTANCE);
+        KubernetesSlave slave = new KubernetesSlave("C", new PodTemplate(), "testC", "C", "dockerC", 1, new KubernetesLauncher(), RetentionStrategy.INSTANCE);
 
         assertNull(canTake(dispatcher, slave, project));
     }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest.java
@@ -206,6 +206,7 @@ public class KubernetesTest {
         assertEquals(1, templates.size());
         PodTemplate podTemplate = templates.get(0);
         assertEquals(Integer.MAX_VALUE, podTemplate.getInstanceCap());
+        assertEquals(1, podTemplate.getNumExecutors());
         assertEquals(1, podTemplate.getContainers().size());
         ContainerTemplate containerTemplate = podTemplate.getContainers().get(0);
         assertEquals("jenkins/inbound-agent", containerTemplate.getImage());

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
@@ -253,7 +253,7 @@ public class PodTemplateUtilsTest {
         podTemplate.setImagePullSecrets(asList(SECRET_1));
         podTemplate.setInheritFrom("Inherit");
         podTemplate.setInstanceCap(99);
-        podTemplate.setNumExecutors(10);
+        podTemplate.setNumExecutors(99);
         podTemplate.setSlaveConnectTimeout(99);
         podTemplate.setIdleMinutes(99);
         podTemplate.setActiveDeadlineSeconds(99);
@@ -271,7 +271,7 @@ public class PodTemplateUtilsTest {
         assertEquals(asList(SECRET_1), selfCombined.getImagePullSecrets());
         assertEquals("Inherit", selfCombined.getInheritFrom());
         assertEquals(99, selfCombined.getInstanceCap());
-        assertEquals(10, selfCombined.getNumExecutors());
+        assertEquals(99, selfCombined.getNumExecutors());
         assertEquals(99, selfCombined.getSlaveConnectTimeout());
         assertEquals(99, selfCombined.getIdleMinutes());
         assertEquals(99, selfCombined.getActiveDeadlineSeconds());

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
@@ -253,6 +253,7 @@ public class PodTemplateUtilsTest {
         podTemplate.setImagePullSecrets(asList(SECRET_1));
         podTemplate.setInheritFrom("Inherit");
         podTemplate.setInstanceCap(99);
+        podTemplate.setNumExecutors(10);
         podTemplate.setSlaveConnectTimeout(99);
         podTemplate.setIdleMinutes(99);
         podTemplate.setActiveDeadlineSeconds(99);
@@ -270,6 +271,7 @@ public class PodTemplateUtilsTest {
         assertEquals(asList(SECRET_1), selfCombined.getImagePullSecrets());
         assertEquals("Inherit", selfCombined.getInheritFrom());
         assertEquals(99, selfCombined.getInstanceCap());
+        assertEquals(10, selfCombined.getNumExecutors());
         assertEquals(99, selfCombined.getSlaveConnectTimeout());
         assertEquals(99, selfCombined.getIdleMinutes());
         assertEquals(99, selfCombined.getActiveDeadlineSeconds());

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/casc/CasCTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/casc/CasCTest.java
@@ -41,6 +41,7 @@ public class CasCTest extends RoundTripAbstractTest {
         assertEquals("java", podTemplate.getLabel());
         assertEquals("default-java", podTemplate.getName());
         assertEquals(10, podTemplate.getInstanceCap());
+        assertEquals(1, podTemplate.getNumExecutors());
         assertEquals(123, podTemplate.getSlaveConnectTimeout());
         assertEquals(5, podTemplate.getIdleMinutes());
         assertEquals(66, podTemplate.getActiveDeadlineSeconds());

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
@@ -188,6 +188,7 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
         }
         assertTrue(foundBuildUrl);
         assertEquals(Integer.MAX_VALUE, template.getInstanceCap());
+        assertEquals(1, template.getNumExecutors());
         assertThat(template.getLabelsMap(), hasEntry("jenkins/label", name.getMethodName()));
 
         Pod pod = pods.getItems().get(0);
@@ -221,6 +222,7 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
         PodTemplate template1 = podTemplatesWithLabel(label1, cloud.getAllTemplates()).get(0);
         SemaphoreStep.success("podTemplate1/1", null);
         assertEquals(Integer.MAX_VALUE, template1.getInstanceCap());
+        assertEquals(1, template1.getNumExecutors());
         assertThat(template1.getLabelsMap(), hasEntry("jenkins/label", label1));
         SemaphoreStep.waitForStart("pod1/1", b);
         Map<String, String> labels1 = getLabels(cloud, this, name);
@@ -234,6 +236,7 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
         PodTemplate template2 = podTemplatesWithLabel(label2, cloud.getAllTemplates()).get(0);
         SemaphoreStep.success("podTemplate2/1", null);
         assertEquals(Integer.MAX_VALUE, template2.getInstanceCap());
+        assertEquals(1, template2.getNumExecutors());
         assertThat(template2.getLabelsMap(), hasEntry("jenkins/label", label2));
         assertNull(label2 + " should not inherit from anything", template2.getInheritFrom());
         SemaphoreStep.waitForStart("pod2/1", b);
@@ -260,6 +263,7 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
         assertFalse(templates.isEmpty());
         PodTemplate template = templates.get(0);
         assertEquals(Integer.MAX_VALUE, template.getInstanceCap());
+        assertEquals(1, template.getNumExecutors());
         r.assertBuildStatusSuccess(r.waitForCompletion(b));
         r.assertLogContains("script file contents: ", b);
         r.assertLogNotContains(CONTAINER_ENV_VAR_FROM_SECRET_VALUE, b);
@@ -643,6 +647,7 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
         assertFalse(templates.isEmpty());
         PodTemplate template = templates.get(0);
         assertEquals(Integer.MAX_VALUE, template.getInstanceCap());
+        assertEquals(1, template.getNumExecutors());
         r.assertBuildStatusSuccess(r.waitForCompletion(b));
         r.assertLogContains("whoami", b);
         r.assertLogContains("root", b);

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepTest.java
@@ -35,6 +35,17 @@ public class PodTemplateStepTest {
         st.assertRoundTrip(step, "podTemplate(instanceCap: 7) {\n    // some block\n}");
         step.setInstanceCap(Integer.MAX_VALUE); // make sure this resets instanceCap
         st.assertRoundTrip(step, "podTemplate {\n    // some block\n}");
+        step.setNumExecutors(1);
+        st.assertRoundTrip(step, "podTemplate(numExecutors: 1) {\n    // some block\n}");
+        step.setNumExecutors(0);
+        step.setNumExecutors(2);
+        st.assertRoundTrip(step, "podTemplate(numExecutors: 2) {\n    // some block\n}");
+        step.setNumExecutors(null); // make sure this resets numExecutors
+        st.assertRoundTrip(step, "podTemplate {\n    // some block\n}");
+        step.setNumExecutors(3);
+        st.assertRoundTrip(step, "podTemplate(numExecutors: 3) {\n    // some block\n}");
+        step.setNumExecutors(1); // make sure this resets numExecutors
+        st.assertRoundTrip(step, "podTemplate {\n    // some block\n}");
         step.setLabel("podLabel");
         st.assertRoundTrip(step, "podTemplate(label: 'podLabel') {\n    // some block\n}");
         step.setLabel("");

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepTest.java
@@ -36,7 +36,7 @@ public class PodTemplateStepTest {
         step.setInstanceCap(Integer.MAX_VALUE); // make sure this resets instanceCap
         st.assertRoundTrip(step, "podTemplate {\n    // some block\n}");
         step.setNumExecutors(1);
-        st.assertRoundTrip(step, "podTemplate(numExecutors: 1) {\n    // some block\n}");
+        st.assertRoundTrip(step, "podTemplate {\n    // some block\n}");
         step.setNumExecutors(0);
         step.setNumExecutors(2);
         st.assertRoundTrip(step, "podTemplate(numExecutors: 2) {\n    // some block\n}");

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesRestartTest/upgradeFrom_1_27_1/config.xml
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesRestartTest/upgradeFrom_1_27_1/config.xml
@@ -28,6 +28,7 @@
           <capOnlyOnAlivePods>false</capOnlyOnAlivePods>
           <alwaysPullImage>false</alwaysPullImage>
           <instanceCap>2147483647</instanceCap>
+          <numExecutors>1</numExecutors>
           <slaveConnectTimeout>100</slaveConnectTimeout>
           <idleMinutes>0</idleMinutes>
           <activeDeadlineSeconds>0</activeDeadlineSeconds>

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest/upgradeFrom_0_10/config.xml
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest/upgradeFrom_0_10/config.xml
@@ -22,6 +22,7 @@
           <inheritFrom></inheritFrom>
           <name>maven</name>
           <instanceCap>2147483647</instanceCap>
+          <numExecutors>1</numExecutors>
           <idleMinutes>0</idleMinutes>
           <label>maven</label>
           <nodeSelector></nodeSelector>

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest/upgradeFrom_0_12/config.xml
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest/upgradeFrom_0_12/config.xml
@@ -29,6 +29,7 @@
           <privileged>false</privileged>
           <alwaysPullImage>false</alwaysPullImage>
           <instanceCap>2147483647</instanceCap>
+          <numExecutors>1</numExecutors>
           <slaveConnectTimeout>100</slaveConnectTimeout>
           <idleMinutes>0</idleMinutes>
           <label>java</label>

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest/upgradeFrom_0_8/config.xml
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest/upgradeFrom_0_8/config.xml
@@ -30,6 +30,7 @@
           <args></args>
           <remoteFs>/home/jenkins</remoteFs>
           <instanceCap>2147483647</instanceCap>
+          <numExecutors>1</numExecutors>
           <label>java</label>
           <nodeSelector></nodeSelector>
           <resourceRequestCpu>500m</resourceRequestCpu>

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest/upgradeFrom_1_10/config.xml
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest/upgradeFrom_1_10/config.xml
@@ -31,6 +31,7 @@
           <capOnlyOnAlivePods>false</capOnlyOnAlivePods>
           <alwaysPullImage>false</alwaysPullImage>
           <instanceCap>2147483647</instanceCap>
+          <numExecutors>1</numExecutors>
           <slaveConnectTimeout>100</slaveConnectTimeout>
           <idleMinutes>0</idleMinutes>
           <activeDeadlineSeconds>0</activeDeadlineSeconds>

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest/upgradeFrom_1_15_1/config.xml
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest/upgradeFrom_1_15_1/config.xml
@@ -28,6 +28,7 @@
           <capOnlyOnAlivePods>false</capOnlyOnAlivePods>
           <alwaysPullImage>false</alwaysPullImage>
           <instanceCap>2147483647</instanceCap>
+          <numExecutors>1</numExecutors>
           <slaveConnectTimeout>100</slaveConnectTimeout>
           <idleMinutes>0</idleMinutes>
           <activeDeadlineSeconds>0</activeDeadlineSeconds>

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest/upgradeFrom_1_15_9/config.xml
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest/upgradeFrom_1_15_9/config.xml
@@ -28,6 +28,7 @@
           <capOnlyOnAlivePods>false</capOnlyOnAlivePods>
           <alwaysPullImage>false</alwaysPullImage>
           <instanceCap>2147483647</instanceCap>
+          <numExecutors>1</numExecutors>
           <slaveConnectTimeout>100</slaveConnectTimeout>
           <idleMinutes>0</idleMinutes>
           <activeDeadlineSeconds>0</activeDeadlineSeconds>

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest/upgradeFrom_1_15_9_invalid/config.xml
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest/upgradeFrom_1_15_9_invalid/config.xml
@@ -28,6 +28,7 @@
           <capOnlyOnAlivePods>false</capOnlyOnAlivePods>
           <alwaysPullImage>false</alwaysPullImage>
           <instanceCap>2147483647</instanceCap>
+          <numExecutors>1</numExecutors>
           <slaveConnectTimeout>100</slaveConnectTimeout>
           <idleMinutes>0</idleMinutes>
           <activeDeadlineSeconds>0</activeDeadlineSeconds>

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest/upgradeFrom_1_17_2/config.xml
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesTest/upgradeFrom_1_17_2/config.xml
@@ -28,6 +28,7 @@
           <capOnlyOnAlivePods>false</capOnlyOnAlivePods>
           <alwaysPullImage>false</alwaysPullImage>
           <instanceCap>2147483647</instanceCap>
+          <numExecutors>1</numExecutors>
           <slaveConnectTimeout>100</slaveConnectTimeout>
           <idleMinutes>0</idleMinutes>
           <activeDeadlineSeconds>0</activeDeadlineSeconds>

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/casc/configuration-as-code.yaml
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/casc/configuration-as-code.yaml
@@ -11,6 +11,7 @@ jenkins:
             name: "default-java"
             yamlMergeStrategy: "override"
             instanceCap: 10
+            numExecutors: 1
             slaveConnectTimeout: 123
             idleMinutes: 5
             activeDeadlineSeconds: 66


### PR DESCRIPTION
When triggering a job that relies on the same execution environment, it is possible to directly reuse the currently running agent pod instead of starting a new pod, as starting a new pod would consume a certain amount of time, which can be avoided.

![image](https://github.com/jenkinsci/kubernetes-plugin/assets/15396081/04f108a1-d69b-4d9c-bc29-81ec35686aff)
![image](https://github.com/jenkinsci/kubernetes-plugin/assets/15396081/c375170e-20b8-4bcf-b36f-b6b28565c107)
![image](https://github.com/jenkinsci/kubernetes-plugin/assets/15396081/fe192d51-dc83-4dfc-bea9-88c1895895ba)
![image](https://github.com/jenkinsci/kubernetes-plugin/assets/15396081/b0c4c56b-8ef9-4838-bdce-fd7513d0692c)

[JENKINS-72074](https://issues.jenkins.io/browse/JENKINS-72074)

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
