### PR TITLE
Added `DirectConnectionTest`, downgrading agent image

### DIFF
--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/Dockerfile
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/Dockerfile
@@ -1,1 +1,1 @@
-FROM jenkins/inbound-agent:3180.v3dd999d24861-1
+FROM jenkins/inbound-agent:3174.v2c9e67f8f9df-1

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
@@ -424,7 +424,9 @@ public class PodTemplateBuilderTest {
             assertThat(jnlp.getArgs(), empty());
             if(directConnection) {
               envVars.add(new EnvVar("JENKINS_PROTOCOLS", JENKINS_PROTOCOLS, null));
-              envVars.add(new EnvVar("JENKINS_DIRECT_CONNECTION", "localhost:" + Jenkins.get().getTcpSlaveAgentListener().getAdvertisedPort(), null));
+              envVars.add(new EnvVar("JENKINS_DIRECT_CONNECTION",
+                System.getProperty("hudson.TcpSlaveAgentListener.hostName", "localhost") + ":" +
+                Jenkins.get().getTcpSlaveAgentListener().getAdvertisedPort(), null));
               envVars.add(new EnvVar("JENKINS_INSTANCE_IDENTITY", Jenkins.get().getTcpSlaveAgentListener().getIdentityPublicKey(), null));
             } else {
               envVars.add(new EnvVar("JENKINS_URL", JENKINS_URL, null));

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/DirectConnectionTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/DirectConnectionTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 CloudBees, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.csanchez.jenkins.plugins.kubernetes.pipeline;
+
+import java.util.logging.Level;
+import org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil;
+import org.csanchez.jenkins.plugins.kubernetes.PodTemplateBuilder;
+import org.junit.Before;
+import org.junit.Test;
+
+public final class DirectConnectionTest extends AbstractKubernetesPipelineTest {
+
+    @Before
+    public void setUp() throws Exception {
+        KubernetesTestUtil.deletePods(cloud.connect(), KubernetesTestUtil.getLabels(cloud, this, name), false);
+        cloud.setDirectConnection(true);
+        logs.record(PodTemplateBuilder.class, Level.FINEST);
+    }
+
+    @Test
+    public void directConnectionAgent() throws Exception {
+        r.assertBuildStatusSuccess(r.waitForCompletion(createJobThenScheduleRun()));
+    }
+
+}

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/directConnectionAgent.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/directConnectionAgent.groovy
@@ -1,0 +1,5 @@
+podTemplate {
+    node(POD_LABEL) {
+        sh 'echo OK running'
+    }
+}

--- a/test-in-k8s.sh
+++ b/test-in-k8s.sh
@@ -31,6 +31,8 @@ kubectl exec jenkins -- \
         -Dport=$http_port \
         -DslaveAgentPort=$tcp_port \
         -Djenkins.host.address=jenkins.kubernetes-plugin-test.svc.cluster.local \
+        `# TODO perhaps PodTemplateBuilder should default host from KubernetesCloud.jenkinsUrl when this is unset? ` \
+        -Dhudson.TcpSlaveAgentListener.hostName=jenkins.kubernetes-plugin-test.svc.cluster.local \
         -Dmaven.test.failure.ignore \
         verify \
         "$@"


### PR DESCRIPTION
@dduportal reported a regression in the latest Remoting images, which I was able to confirm as a regression in https://github.com/jenkinsci/remoting/pull/677 (exact cause still unknown):

```
kubernetes-plugin-test/direct-connection-agent-1-dbxfx-1c3pg-jndq9 Container jnlp was terminated (Exit Code: 1, Reason: Error)

- jnlp -- terminated (1)
-----Logs-------------
Oct 23, 2023 12:57:35 PM org.jenkinsci.remoting.engine.WorkDirManager initializeWorkDir
INFO: Using /home/jenkins/agent/remoting as a remoting work directory
Oct 23, 2023 12:57:35 PM org.jenkinsci.remoting.engine.WorkDirManager setupLogging
INFO: Both error and output logs will be printed to /home/jenkins/agent/remoting
Exception in thread "main" java.io.EOFException: unexpected stream termination
	at hudson.remoting.ChannelBuilder.negotiate(ChannelBuilder.java:459)
	at hudson.remoting.ChannelBuilder.build(ChannelBuilder.java:404)
	at hudson.remoting.Launcher.main(Launcher.java:878)
	at hudson.remoting.Launcher.runWithStdinStdout(Launcher.java:826)
	at hudson.remoting.Launcher.run(Launcher.java:428)
	at hudson.remoting.Launcher.main(Launcher.java:377)
<===[JENKINS REMOTING CAPACITY]===>rO0ABXNyABpodWRzb24ucmVtb3RpbmcuQ2FwYWJpbGl0eQAAAAAAAAABAgABSgAEbWFza3hwAAAAAAAAAf4=
ERROR: Failed to launch direct-connection-agent-1-dbxfx-1c3pg-jndq9
java.lang.IllegalStateException: Containers are terminated with exit codes: {jnlp=1}
	at org.csanchez.jenkins.plugins.kubernetes.KubernetesLauncher.checkTerminatedContainers(KubernetesLauncher.java:274)
	at org.csanchez.jenkins.plugins.kubernetes.KubernetesLauncher.launch(KubernetesLauncher.java:223)
	at hudson.slaves.SlaveComputer.lambda$_connect$0(SlaveComputer.java:298)
	at jenkins.util.ContextResettingExecutorService$2.call(ContextResettingExecutorService.java:46)
	at jenkins.security.ImpersonatingExecutorService$2.call(ImpersonatingExecutorService.java:80)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
```

Affects direct connection mode only, which previously lacked test coverage. https://github.com/jenkinsci/kubernetes-plugin/pull/1450#issuecomment-1775052192 CC @basil @Vlatombe
