### PR TITLE
Update documentation

### DIFF
--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/help-image.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate/help-image.html
@@ -1,5 +1,5 @@
 Docker image ID for a jenkins JNLP agent.
 This image is responsible to run a jenkins jnlp bootstrap agent and connect to Jenkins controller.
 Secret key and agent name as well as jenkins callback URL are passed as argument as expected
-by <code>hudson.remoting.jnlp.Main</code>.
+by <code>hudson.remoting.Launcher</code>.
 

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/help-directConnection.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/help-directConnection.html
@@ -12,13 +12,14 @@
   <p>
   Here is an example how the connect on agent side would look like. Most parameters are provided automatically when you enable the <i>Direct Connection</i> option.
   <pre>
-  java -cp agent.jar hudson.remoting.jnlp.Main \
+  java -jar agent.jar \
+    -secret &lt;SECRET_STRING&gt; \
+    -name &lt;AGENT_NAME&gt; \
     -headless \
     -workDir &lt;WORK_DIRECTORY&gt; \
     -direct &lt;MASTER_HOST:TCP_AGENT_LISTENER_PORT&gt; \
     -protocols JNLP4-connect \
-    -instanceIdentity &lt;INSTANCE_IDENTITY&gt; \
-    &lt;SECRET_STRING&gt; &lt;AGENT_NAME&gt;
+    -instanceIdentity &lt;INSTANCE_IDENTITY&gt;
   </pre>
   </p>
   


### PR DESCRIPTION
Remove outdated references to `hudson.remoting.jnlp.Main` from documentation.

### Testing done

Viewed the HTML files in my browser.