### PR TITLE
[JENKINS-72314] Fix cloud save and roundtrip test

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -148,7 +148,7 @@ public class KubernetesCloud extends Cloud implements PodTemplateGroup {
     public KubernetesCloud(String name) {
         super(name);
         setMaxRequestsPerHost(DEFAULT_MAX_REQUESTS_PER_HOST);
-        setPodLabels(PodLabel.fromMap(DEFAULT_POD_LABELS));
+        setPodLabels(null);
     }
 
     /**
@@ -466,9 +466,7 @@ public class KubernetesCloud extends Cloud implements PodTemplateGroup {
     @DataBoundSetter
     public void setPodLabels(@CheckForNull List<PodLabel> labels) {
         this.podLabels = new ArrayList<>();
-        if (labels != null) {
-            this.podLabels.addAll(labels);
-        }
+        this.podLabels.addAll(labels == null || labels.isEmpty() ? PodLabel.fromMap(DEFAULT_POD_LABELS) : labels);
     }
 
     /**
@@ -999,8 +997,8 @@ public class KubernetesCloud extends Cloud implements PodTemplateGroup {
         if (waitForPodSec == null) {
             waitForPodSec = DEFAULT_WAIT_FOR_POD_SEC;
         }
-        if (podLabels == null && labels != null) {
-            setPodLabels(PodLabel.fromMap(labels));
+        if (podLabels == null) {
+            setPodLabels(labels == null ? null : PodLabel.fromMap(labels));
         }
         if (containerCap != null && containerCap == 0) {
             containerCap = null;

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -147,6 +147,7 @@ public class KubernetesCloud extends Cloud implements PodTemplateGroup {
     public KubernetesCloud(String name) {
         super(name);
         setMaxRequestsPerHost(DEFAULT_MAX_REQUESTS_PER_HOST);
+        setPodLabels(PodLabel.fromMap(DEFAULT_POD_LABELS));
     }
 
     /**
@@ -215,7 +216,7 @@ public class KubernetesCloud extends Cloud implements PodTemplateGroup {
 
     @DataBoundSetter
     public void setDefaultsProviderTemplate(String defaultsProviderTemplate) {
-        this.defaultsProviderTemplate = defaultsProviderTemplate;
+        this.defaultsProviderTemplate = Util.fixEmpty(defaultsProviderTemplate);
     }
 
     @NonNull
@@ -243,7 +244,7 @@ public class KubernetesCloud extends Cloud implements PodTemplateGroup {
 
     @DataBoundSetter
     public void setServerUrl(@NonNull String serverUrl) {
-        this.serverUrl = serverUrl;
+        this.serverUrl = Util.fixEmpty(serverUrl);
     }
 
     public String getServerCertificate() {
@@ -455,7 +456,7 @@ public class KubernetesCloud extends Cloud implements PodTemplateGroup {
      */
     @NonNull
     public List<PodLabel> getPodLabels() {
-        return podLabels == null || podLabels.isEmpty() ? PodLabel.fromMap(DEFAULT_POD_LABELS) : podLabels;
+        return podLabels == null ? List.of() : podLabels;
     }
 
     /**

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -26,6 +26,7 @@ import hudson.Main;
 import hudson.model.ItemGroup;
 import hudson.util.XStream2;
 import jenkins.metrics.api.Metrics;
+import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
 import org.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateMap;
 import org.csanchez.jenkins.plugins.kubernetes.pod.retention.Default;
@@ -1005,6 +1006,14 @@ public class KubernetesCloud extends Cloud implements PodTemplateGroup {
             containerCap = null;
         }
         return this;
+    }
+
+    @Override
+    public Cloud reconfigure(@NonNull StaplerRequest req, JSONObject form) throws Descriptor.FormException {
+        // cloud configuration doesn't contain templates anymore, so just keep existing ones.
+        var newInstance = (KubernetesCloud) super.reconfigure(req, form);
+        newInstance.setTemplates(this.templates);
+        return newInstance;
     }
 
     @Extension

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudTest.java
@@ -5,8 +5,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import hudson.util.VersionNumber;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -15,18 +13,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
 import jenkins.model.Jenkins;
-import org.htmlunit.ElementNotFoundException;
-import org.htmlunit.html.DomElement;
-import org.htmlunit.html.DomNodeList;
-import org.htmlunit.html.HtmlAnchor;
-import org.htmlunit.html.HtmlButton;
-import org.htmlunit.html.HtmlElement;
-import org.htmlunit.html.HtmlForm;
-import org.htmlunit.html.HtmlFormUtil;
-import org.htmlunit.html.HtmlInput;
-import org.htmlunit.html.HtmlPage;
+import jenkins.model.JenkinsLocationConfiguration;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
@@ -36,15 +24,18 @@ import org.csanchez.jenkins.plugins.kubernetes.pod.retention.PodRetention;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.EmptyDirVolume;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.PodVolume;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.workspace.WorkspaceVolume;
+import org.htmlunit.html.DomElement;
+import org.htmlunit.html.DomNodeList;
+import org.htmlunit.html.HtmlElement;
+import org.htmlunit.html.HtmlForm;
+import org.htmlunit.html.HtmlInput;
+import org.htmlunit.html.HtmlPage;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.LoggerRule;
 import org.jvnet.hudson.test.recipes.LocalData;
-
-import jenkins.model.JenkinsLocationConfiguration;
-import org.xml.sax.SAXException;
 
 public class KubernetesCloudTest {
 
@@ -62,18 +53,16 @@ public class KubernetesCloudTest {
 
     @Test
     public void configRoundTrip() throws Exception {
-        KubernetesCloud cloud = new KubernetesCloud("kubernetes");
-        PodTemplate podTemplate = new PodTemplate();
+        var cloud = new KubernetesCloud("kubernetes");
+        var podTemplate = new PodTemplate();
         podTemplate.setName("test-template");
         podTemplate.setLabel("test");
         cloud.addTemplate(podTemplate);
-        j.jenkins.clouds.add(cloud);
-        j.jenkins.save();
-        JenkinsRule.WebClient wc = j.createWebClient();
-        HtmlPage p = wc.goTo("cloud/kubernetes/configure");
-        HtmlForm f = p.getFormByName("config");
-        j.submit(f);
-        assertEquals("PodTemplate{id='"+podTemplate.getId()+"', name='test-template', label='test'}", podTemplate.toString());
+        var jenkins = j.jenkins;
+        jenkins.clouds.add(cloud);
+        jenkins.save();
+        j.submit(j.createWebClient().goTo("cloud/kubernetes/configure").getFormByName("config"));
+        assertEquals(cloud, jenkins.clouds.get(KubernetesCloud.class));
     }
 
     @Test


### PR DESCRIPTION
https://issues.jenkins.io/browse/JENKINS-72314

Roundtrip test was bogus so it didn't catch the regression introduced by #1443

Also fixed a few setters causing incorrect `KubernetesCloud` equality.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
