### PR TITLE
[JENKINS-70217] Default ContainerTemplate command and arg to empty string when using casc.

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
@@ -46,9 +46,9 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
 
     private String workingDir;
 
-    private String command;
+    private String command = "";
 
-    private String args;
+    private String args = "";
 
     private boolean ttyEnabled;
 

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/casc/CasCTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/casc/CasCTest.java
@@ -64,7 +64,7 @@ public class CasCTest extends RoundTripAbstractTest {
         assertThat(podTemplate.getYamlMergeStrategy(), isA(Merge.class));
         List<ContainerTemplate> containers = podTemplate.getContainers();
         assertNotNull(containers);
-        assertEquals(1, containers.size());
+        assertEquals(2, containers.size());
         ContainerTemplate container = containers.get(0);
         assertEquals("cat", container.getArgs());
         assertEquals("/bin/sh -c", container.getCommand());
@@ -78,6 +78,9 @@ public class CasCTest extends RoundTripAbstractTest {
         assertEquals("maven",container.getName());
         assertTrue(container.isTtyEnabled());
         assertEquals("/src", container.getWorkingDir());
+        var containerTemplate = containers.get(1);
+        assertEquals("", containerTemplate.getCommand());
+        assertEquals("", containerTemplate.getArgs());
 
     }
 

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/casc/configuration-as-code.yaml
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/casc/configuration-as-code.yaml
@@ -36,6 +36,8 @@ jenkins:
                 name: "maven"
                 ttyEnabled: true
                 workingDir: "/src"
+              - name: "maven-with-default-entrypoint"
+                image: "maven:3.6.3-jdk-8"
             hostNetwork: false
             label: "test"
             name: "test"


### PR DESCRIPTION
https://issues.jenkins.io/browse/JENKINS-70217

When defining a container template using Casc and unspecified command and arg, it seems more natural that the default entrypoint and args are executed. So setting these to empty string when constructing a new instance seems more natural.

This doesn't change the behaviour of creating a new container template using the UI, as the default value will come from jelly because the ContainerTemplate instance will be null when populating the jelly fragment.

Flagged as a bug because in the previous state, both fields were left to `null` when unspecified by casc, and the UI roundtrip would replace them by `sleep` and `999999`, due to the default jelly attribute.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
