### PR TITLE
[JENKINS-72441] Prevent lock contention on `KubernetesLauncher#isLaunchSupported`

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
@@ -49,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -69,7 +70,7 @@ public class KubernetesLauncher extends JNLPLauncher {
 
     private static final Logger LOGGER = Logger.getLogger(KubernetesLauncher.class.getName());
 
-    private boolean launched;
+    private final AtomicBoolean launched = new AtomicBoolean(false);
 
     /**
      * Provisioning exception if any.
@@ -87,8 +88,8 @@ public class KubernetesLauncher extends JNLPLauncher {
     }
 
     @Override
-    public synchronized boolean isLaunchSupported() {
-        return !launched;
+    public boolean isLaunchSupported() {
+        return !launched.get();
     }
 
     @Override
@@ -105,7 +106,7 @@ public class KubernetesLauncher extends JNLPLauncher {
         if (node == null) {
             throw new IllegalStateException("Node has been removed, cannot launch " + computer.getName());
         }
-        if (launched) {
+        if (launched.get()) {
             LOGGER.log(INFO, "Agent has already been launched, activating: {0}", node.getNodeName());
             computer.setAcceptingTasks(true);
             return;
@@ -241,7 +242,7 @@ public class KubernetesLauncher extends JNLPLauncher {
             }
 
             computer.setAcceptingTasks(true);
-            launched = true;
+            launched.set(true);
             try {
                 // We need to persist the "launched" setting...
                 node.save();


### PR DESCRIPTION
[JENKINS-72441](https://issues.jenkins.io/browse/JENKINS-72441)

As per https://github.com/jenkinsci/kubernetes-plugin/pull/1392#discussion_r1389995902

Remove the `synchronized` - that was added to fix a spotbug warning - causing lock contention on accessors. And use an AtomicBoolean instead to make spotbugs happy.

### Testing done

**Testing agent low to launch**

* Create a pipeline:

```
pipeline {
    agent none
    stages {
        stage('Hello') {
            steps {
                podTemplate(envVars: [envVar(key: 'JENKINS_TUNNEL', value: ':50999')]) {
                    node(POD_LABEL) {
                        // some block
                        sh "echo 'Hello World'"
                    }
                }
            }
        }
    }
}
```

* Run it
* Follow the link to the agent created from the console out
* Validate that the agent page is accessible

**Testing normal launch**

* Create a pipeline:

```
pipeline {
    agent none
    stages {
        stage('Hello') {
            steps {
                podTemplate {
                    node(POD_LABEL) {
                        // some block
                        sh "echo 'Hello World'"
                    }
                }
            }
        }
    }
}
```

* Run it
* Follow the link to the agent created from the console out
* Validate that the agent page is accessible and that the build completes


```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```