### PR TITLE
Require 2.426.1 LTS or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,8 @@
     <connectorHost />
     <jenkins.host.address />
     <slaveAgentPort />
-    <jenkins.version>2.415</jenkins.version>
-    <bom>2.414.x</bom>
+    <jenkins.version>2.426.1</jenkins.version>
+    <bom>2.426.x</bom>
     <bom.version>2571.vede9dc5a_2e23</bom.version>
     <no-test-jar>false</no-test-jar>
     <useBeta>true</useBeta>


### PR DESCRIPTION
Now that the baseline is available in LTS form, prefer it for the reasons given in [the documentation](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/).