### PR TITLE
Introduce `KubernetesDeclarativeAgentRJRTest`

### DIFF
--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgentRJRTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgentRJRTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024 CloudBees, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.csanchez.jenkins.plugins.kubernetes.pipeline;
+
+import java.net.UnknownHostException;
+import org.csanchez.jenkins.plugins.kubernetes.pipeline.steps.AssertBuildStatusSuccess;
+import org.csanchez.jenkins.plugins.kubernetes.pipeline.steps.SetupCloud;
+import org.junit.Test;
+
+public final class KubernetesDeclarativeAgentRJRTest extends AbstractKubernetesPipelineRJRTest {
+
+    public KubernetesDeclarativeAgentRJRTest() throws UnknownHostException {
+        super(new SetupCloud());
+    }
+
+    @Test
+    public void declarative() throws Throwable {
+        rjr.runRemotely(new AssertBuildStatusSuccess(runId));
+    }
+}


### PR DESCRIPTION
https://github.com/jenkinsci/workflow-cps-plugin/pull/538#issuecomment-1883256755 not successful yet despite

```diff
diff --git pom.xml pom.xml
index df3627bc..f95064a8 100644
--- pom.xml
+++ pom.xml
@@ -134,6 +134,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
+      <version>3832.vc43e04d6d68c</version>
       <optional>true</optional>
     </dependency>
     <dependency>
```

but it seems appropriate to at least have _some_ test coverage here.
