### PR TITLE
[JENKINS-71956] Octal notation fixes

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
@@ -74,6 +74,7 @@ public class PodTemplateUtils {
      * If true, all modes permissions provided to pods are expected to be provided in decimal notation.
      * Otherwise, the plugin will consider they are written in octal notation.
      */
+    @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "tests & emergency admin")
     public static /* almost final*/ boolean DISABLE_OCTAL_MODES =
             Boolean.getBoolean(PodTemplateUtils.class.getName() + ".DISABLE_OCTAL_MODES");
 

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest/decimal.yaml
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest/decimal.yaml
@@ -1,0 +1,29 @@
+# Identical to octal.yaml with values converted to decimal
+apiVersion: "v1"
+kind: "Pod"
+spec:
+  volumes:
+    - configMap:
+        name: cm1
+        defaultMode: 493
+      name: "volume1"
+    - secret:
+        secretName: secret1
+        defaultMode: 484
+      name: "volume2"
+    - projected:
+        sources:
+          - configMap:
+              name: cm2
+              items:
+                - key: username
+                  path: my-group/my-username
+                  mode: 256
+          - secret:
+              name: secret2
+              items:
+                - key: username
+                  path: my-group/my-username
+                  mode: 384
+        defaultMode: 420
+      name: "volume3"

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest/octal.yaml
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest/octal.yaml
@@ -1,0 +1,29 @@
+# Octal modes
+apiVersion: "v1"
+kind: "Pod"
+spec:
+  volumes:
+    - configMap:
+        name: cm1
+        defaultMode: 0755
+      name: "volume1"
+    - secret:
+        secretName: secret1
+        defaultMode: 0744
+      name: "volume2"
+    - projected:
+        sources:
+          - configMap:
+              name: cm2
+              items:
+                - key: username
+                  path: my-group/my-username
+                  mode: 0400
+          - secret:
+              name: secret2
+              items:
+                - key: username
+                  path: my-group/my-username
+                  mode: 0600
+        defaultMode: 0644
+      name: "volume3"


### PR DESCRIPTION
**Context**
Kubernetes-client uses jackson-databind to parse yaml into objects, using snakeyaml. 
Kubernetes-client has migrated their serialization methods to use SnakeYAML engine (https://github.com/fabric8io/kubernetes-client/pull/4836)

The problem is that snakeyaml uses yaml 1.1 while snakeyaml-engine only supports yaml 1.2.

This causes inconsistencies when dealing with integer with the octal notation, as there are breaking changes between these two versions. Additionally, https://github.com/FasterXML/jackson-dataformats-text/issues/3 documents that octal notation is not properly supported through jackson.

**Plugin perspective**

This follows up https://github.com/jenkinsci/kubernetes-plugin/pull/1342, already providing some octal notation conversion.

User yaml is still expected to use yaml 1.1, using the `0xxx` notation for octal integers. For a series of known paths in the pod spec, an automatic conversion will happen.

This behaviour can be disabled using `-Dorg.csanchez.jenkins.plugins.kubernetes.PodTemplateUtils.DISABLE_OCTAL_MODES=true` in case users have converted their yaml manifests to use decimal notation instead. A best effort is attempted to keep modes that have been provided using decimal notation, but this can't be foolproof.

Going forward, jackson 3.0 will use SnakeYAML engine so hopefully we will eventually get a more consistent behaviour, but I expect possible new breaking changes when it happens.

This adds a few paths I missed when I initially addressed this kubernetes-client upgrade in https://github.com/jenkinsci/kubernetes-plugin/pull/1342, as well as providing unit tests.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
