### PR TITLE
Update kubernetes-client api to 6.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,11 @@
         <version>4.9.3</version>
         <!-- should be aligned with the version provided by okhttp-api-plugin -->
       </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>kubernetes-client-api</artifactId>
+        <version>6.10.0-240.v57880ce8b_0b_2</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -157,7 +162,7 @@
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-server-mock</artifactId>
-      <version>6.8.1</version>
+      <version>6.10.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,14 @@
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>bouncycastle-api</artifactId>
+        <!-- transitive dependency of kubernetes-client-api 6.10.0 to fix upper bound -->
+        <version>2.30.1.77-225.v26ea_c9455fd9</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>kubernetes-client-api</artifactId>
+        <!-- until it gets into BOM -->
         <version>6.10.0-240.v57880ce8b_0b_2</version>
       </dependency>
     </dependencies>


### PR DESCRIPTION
Picks up https://github.com/jenkinsci/kubernetes-client-api-plugin/releases/tag/6.10.0-240.v57880ce8b_0b_2

Necessary because apparently kubernetes-client broke binary compatibility (https://github.com/jenkinsci/kubernetes-client-api-plugin/pull/247#issuecomment-1914301522) even though no source change is required in the plugin.

Closes #1505

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
