### PR TITLE
[JENKINS-72112] Allow merge strategy inheritance in PodTemplates

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -195,16 +195,22 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
         return yamlMergeStrategy;
     }
 
+    public YamlMergeStrategy getResolvedYamlMergeStrategy() {
+        return getYamlMergeStrategy() != null ? getYamlMergeStrategy() : YamlMergeStrategy.defaultStrategy();
+    }
+
     @DataBoundSetter
     public void setYamlMergeStrategy(YamlMergeStrategy yamlMergeStrategy) {
         this.yamlMergeStrategy = yamlMergeStrategy;
     }
 
-    private YamlMergeStrategy yamlMergeStrategy = YamlMergeStrategy.defaultStrategy();
+    private YamlMergeStrategy yamlMergeStrategy;
 
     public Pod getYamlsPod() {
-        return yamlMergeStrategy.merge(getYamls());
+        return getResolvedYamlMergeStrategy().merge(getYamls());
     }
+
+    private Boolean inheritYamlMergeStrategy;
 
     private Boolean showRawYaml;
 
@@ -950,9 +956,6 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
             yamls = null;
         }
 
-        if (yamlMergeStrategy == null) {
-            yamlMergeStrategy = YamlMergeStrategy.defaultStrategy();
-        }
         if (id == null) {
             // Use the label and a digest of the current object representation to get the same value every restart if
             // the object isn't saved.
@@ -984,6 +987,15 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
     public String getDescriptionForLogging() {
         return String.format(
                 "Agent specification [%s] (%s): %n%s", getName(), getLabel(), getContainersDescriptionForLogging());
+    }
+
+    public boolean isInheritYamlMergeStrategy() {
+        return inheritYamlMergeStrategy != null ? inheritYamlMergeStrategy.booleanValue() : false;
+    }
+
+    @DataBoundSetter
+    public void setInheritYamlMergeStrategy(boolean inheritYamlMergeStrategy) {
+        this.inheritYamlMergeStrategy = Boolean.valueOf(inheritYamlMergeStrategy);
     }
 
     boolean isShowRawYamlSet() {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
@@ -510,7 +510,11 @@ public class PodTemplateUtils {
         podTemplate.setAnnotations(new ArrayList<>(podAnnotations));
         podTemplate.setNodeProperties(nodeProperties);
         podTemplate.setNodeUsageMode(nodeUsageMode);
-        podTemplate.setYamlMergeStrategy(template.getYamlMergeStrategy());
+        podTemplate.setYamlMergeStrategy(
+                template.getYamlMergeStrategy() == null && parent.isInheritYamlMergeStrategy()
+                        ? parent.getYamlMergeStrategy()
+                        : template.getYamlMergeStrategy());
+        podTemplate.setInheritYamlMergeStrategy(parent.isInheritYamlMergeStrategy());
         podTemplate.setInheritFrom(
                 !isNullOrEmpty(template.getInheritFrom()) ? template.getInheritFrom() : parent.getInheritFrom());
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgent.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgent.java
@@ -91,6 +91,8 @@ public class KubernetesDeclarativeAgent extends RetryableDeclarativeAgent<Kubern
 
     private YamlMergeStrategy yamlMergeStrategy;
 
+    private Boolean inheritYamlMergeStrategy;
+
     @CheckForNull
     private WorkspaceVolume workspaceVolume;
 
@@ -316,6 +318,15 @@ public class KubernetesDeclarativeAgent extends RetryableDeclarativeAgent<Kubern
         this.yamlMergeStrategy = yamlMergeStrategy;
     }
 
+    public boolean isInheritYamlMergeStrategy() {
+        return inheritYamlMergeStrategy != null ? inheritYamlMergeStrategy.booleanValue() : false;
+    }
+
+    @DataBoundSetter
+    public void setInheritYamlMergeStrategy(boolean inheritYamlMergeStrategy) {
+        this.inheritYamlMergeStrategy = Boolean.valueOf(inheritYamlMergeStrategy);
+    }
+
     public WorkspaceVolume getWorkspaceVolume() {
         return workspaceVolume == null ? PodTemplateStep.DescriptorImpl.defaultWorkspaceVolume : this.workspaceVolume;
     }
@@ -366,6 +377,9 @@ public class KubernetesDeclarativeAgent extends RetryableDeclarativeAgent<Kubern
         }
         if (yamlMergeStrategy != null) {
             argMap.put("yamlMergeStrategy", yamlMergeStrategy);
+        }
+        if (inheritYamlMergeStrategy != null) {
+            argMap.put("inheritYamlMergeStrategy", inheritYamlMergeStrategy);
         }
         if (workspaceVolume != null) {
             argMap.put("workspaceVolume", workspaceVolume);

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep.java
@@ -86,7 +86,9 @@ public class PodTemplateStep extends Step implements Serializable {
     @CheckForNull
     private String yaml;
 
-    private YamlMergeStrategy yamlMergeStrategy = YamlMergeStrategy.defaultStrategy();
+    private YamlMergeStrategy yamlMergeStrategy;
+
+    private Boolean inheritYamlMergeStrategy;
 
     @CheckForNull
     private PodRetention podRetention;
@@ -359,6 +361,15 @@ public class PodTemplateStep extends Step implements Serializable {
     public void setPodRetention(@CheckForNull PodRetention podRetention) {
         this.podRetention =
                 (podRetention == null || podRetention.equals(DescriptorImpl.defaultPodRetention)) ? null : podRetention;
+    }
+
+    public boolean isInheritYamlMergeStrategy() {
+        return inheritYamlMergeStrategy != null ? inheritYamlMergeStrategy.booleanValue() : false;
+    }
+
+    @DataBoundSetter
+    public void setInheritYamlMergeStrategy(boolean inheritYamlMergeStrategy) {
+        this.inheritYamlMergeStrategy = Boolean.valueOf(inheritYamlMergeStrategy);
     }
 
     boolean isShowRawYamlSet() {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
@@ -118,6 +118,7 @@ public class PodTemplateStepExecution extends AbstractStepExecutionImpl {
         newTemplate.setListener(listener);
         newTemplate.setYamlMergeStrategy(step.getYamlMergeStrategy());
         if (run != null) {
+            newTemplate.setInheritYamlMergeStrategy(step.isInheritYamlMergeStrategy());
             String url = cloud.getJenkinsUrlOrNull();
             if (url != null) {
                 newTemplate.getAnnotations().add(new PodAnnotation("buildUrl", url + run.getUrl()));

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
@@ -90,7 +90,7 @@ THE SOFTWARE.
     <f:dropdownDescriptorSelector title="${%Yaml merge strategy}" field="yamlMergeStrategy" default="${descriptor.defaultYamlMergeStrategy}" />
 
     <f:entry field="inheritYamlMergeStrategy" title="${%Inherit yaml merge strategy}" >
-      <f:checkbox default="false"/>
+      <f:checkbox/>
     </f:entry>
 
   <f:entry field="showRawYaml" title="${%Show raw yaml in console}" >

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
@@ -87,7 +87,7 @@ THE SOFTWARE.
     <f:textarea/>
   </f:entry>
 
-    <f:dropdownDescriptorSelector title="${%Yaml merge strategy}" field="yamlMergeStrategy" default="${descriptor.defaultYamlMergeStrategy}" />
+  <f:dropdownDescriptorSelector title="${%Yaml merge strategy}" field="yamlMergeStrategy" default="${descriptor.defaultYamlMergeStrategy}" />
 
     <f:entry field="inheritYamlMergeStrategy" title="${%Inherit yaml merge strategy}" >
       <f:checkbox/>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
@@ -87,7 +87,11 @@ THE SOFTWARE.
     <f:textarea/>
   </f:entry>
 
-  <f:dropdownDescriptorSelector title="${%Yaml merge strategy}" field="yamlMergeStrategy" default="${descriptor.defaultYamlMergeStrategy}" />
+    <f:dropdownDescriptorSelector title="${%Yaml merge strategy}" field="yamlMergeStrategy" default="${descriptor.defaultYamlMergeStrategy}" />
+
+    <f:entry field="inheritYamlMergeStrategy" title="${%Inherit yaml merge strategy}" >
+      <f:checkbox default="false"/>
+    </f:entry>
 
   <f:entry field="showRawYaml" title="${%Show raw yaml in console}" >
     <f:checkbox default="true"/>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/help-inheritYamlMergeStrategy.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/help-inheritYamlMergeStrategy.html
@@ -1,1 +1,1 @@
-False by default
+Controls whether the defined yaml merge strategy will be inherited if another defined pod template is configured to inherit from the current one.

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/help-inheritYamlMergeStrategy.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/help-inheritYamlMergeStrategy.html
@@ -1,0 +1,1 @@
+False by default

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/casc/CasCTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/casc/CasCTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.isA;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import io.jenkins.plugins.casc.misc.RoundTripAbstractTest;
@@ -43,7 +44,8 @@ public class CasCTest extends RoundTripAbstractTest {
         assertEquals(123, podTemplate.getSlaveConnectTimeout());
         assertEquals(5, podTemplate.getIdleMinutes());
         assertEquals(66, podTemplate.getActiveDeadlineSeconds());
-        assertThat(podTemplate.getYamlMergeStrategy(), isA(Overrides.class));
+        assertNull(podTemplate.getYamlMergeStrategy());
+        assertThat(podTemplate.getResolvedYamlMergeStrategy(), isA(Overrides.class));
         podTemplate = templates.get(1);
         assertFalse(podTemplate.isHostNetwork());
         assertEquals("dynamic-pvc", podTemplate.getLabel());

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/casc/configuration-as-code.yaml
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/casc/configuration-as-code.yaml
@@ -9,7 +9,6 @@ jenkins:
           - hostNetwork: false
             label: "java"
             name: "default-java"
-            yamlMergeStrategy: "override"
             instanceCap: 10
             slaveConnectTimeout: 123
             idleMinutes: 5


### PR DESCRIPTION
Ticket: https://issues.jenkins.io/browse/JENKINS-72112

### Note

**This Pull Request is taken from https://github.com/jenkinsci/kubernetes-plugin/pull/1448 and the changes done there!**
I was not quite sure what the workflow in such cases is, I could also open a PR on the fork so that the first forker can update the PR here, I just assumed it is simpler this way.

### Testing done

Testing done in https://github.com/jenkinsci/kubernetes-plugin/pull/1448, I am fixing (at least I try ;-) ) the automated tests that prevent it from merging.


```[tasklist]
### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```