### PR TITLE
handleNonKubernetes true in kubernetesAgent condition

### DIFF
--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgentScript.groovy
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgentScript.groovy
@@ -74,7 +74,7 @@ public class KubernetesDeclarativeAgentScript extends DeclarativeAgentScript<Kub
                     }
                 }
                 if (describable.retries > 1) {
-                    script.retry(count: describable.retries, conditions: [script.kubernetesAgent(), script.nonresumable()]) {
+                    script.retry(count: describable.retries, conditions: [script.kubernetesAgent(handleNonKubernetes: true), script.nonresumable()]) {
                         run.call()
                     }
                 } else {


### PR DESCRIPTION
I'm not sure if this flag is for default true, but I think it could be the problem why many people is having problems with the retry when a spot instance goes down?

Ref:
https://community.jenkins.io/t/how-to-retry-a-jenkins-pipeline-stage-with-an-agent-condition/3667/5
