### PR TITLE
Enforce consistent versions for mock libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,8 +69,8 @@
       <dependency>
         <groupId>com.squareup.okhttp3</groupId>
         <artifactId>mockwebserver</artifactId>
-        <version>4.9.3</version>
-        <!-- should be aligned with the version provided by okhttp-api-plugin -->
+        <!-- transitive dep of io.fabric8:kubernetes-server-mock, needs alignment with okhttp-api -->
+        <version>4.11.0</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
@@ -328,6 +328,28 @@
             <org.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution.verbose>true</org.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution.verbose>
           </systemProperties>
         </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-okhttp-consistency</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireSameVersions>
+                  <dependencies>
+                    <dependency>com.squareup.okhttp3:mockwebserver</dependency>
+                    <dependency>com.squareup.okhttp3:okhttp:jar</dependency>
+                    <dependency>com.squareup.okhttp3:logging-interceptor</dependency>
+                  </dependencies>
+                </requireSameVersions>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -346,6 +346,12 @@
                     <dependency>com.squareup.okhttp3:logging-interceptor</dependency>
                   </dependencies>
                 </requireSameVersions>
+                <requireSameVersions>
+                  <dependencies>
+                    <dependency>io.fabric8:kubernetes-server-mock</dependency>
+                    <dependency>io.fabric8:kubernetes-client</dependency>
+                  </dependencies>
+                </requireSameVersions>
               </rules>
             </configuration>
           </execution>


### PR DESCRIPTION
We depend on mock libraries part of kubernetes-client or okhttp3, and these need to be kept in sync with the main library.

This adds enforcer executions that will fail the build if these start diverging.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
