### PR TITLE
Add `PodTemplateGroup#addTemplate`

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -703,6 +703,7 @@ public class KubernetesCloud extends Cloud implements PodTemplateGroup {
      * Add a new template to the cloud
      * @param t docker template
      */
+    @Override
     public void addTemplate(PodTemplate t) {
         this.templates.add(t);
         // t.parent = this;

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateGroup.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateGroup.java
@@ -3,6 +3,13 @@ package org.csanchez.jenkins.plugins.kubernetes;
  * A group of pod templates that can be saved together.
  */
 public interface PodTemplateGroup {
+
+    /**
+     * Add the template to the group.
+     * @param podTemplate the template to add
+     */
+    void addTemplate(PodTemplate podTemplate);
+
     /**
      * Replaces the old template with the new template.
      * @param oldTemplate the old template to replace


### PR DESCRIPTION
While recently working on downstream consumers of `PodTemplateGroup`, I noticed that there is a not actually a `PodTemplateGroup#addTemplate`, though there is a `KubernetesCloud#addTemplate`... I think that it make more sense that this method be declared in `PodTemplateGroup`.

### Testing done

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```