### PR TITLE
[JENKINS-72886] fix `command` & `args` are lost when combining container templates

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
@@ -203,8 +203,12 @@ public class PodTemplateUtils {
         String workingDir = isNullOrEmpty(template.getWorkingDir())
                 ? (isNullOrEmpty(parent.getWorkingDir()) ? DEFAULT_WORKING_DIR : parent.getWorkingDir())
                 : template.getWorkingDir();
-        List<String> command = template.getCommand() == null || template.getCommand().isEmpty() ? parent.getCommand() : template.getCommand();
-        List<String> args = template.getArgs() == null || template.getArgs().isEmpty() ? parent.getArgs() : template.getArgs();
+        List<String> command =
+                template.getCommand() == null || template.getCommand().isEmpty()
+                        ? parent.getCommand()
+                        : template.getCommand();
+        List<String> args =
+                template.getArgs() == null || template.getArgs().isEmpty() ? parent.getArgs() : template.getArgs();
         Boolean tty = template.getTty() != null ? template.getTty() : parent.getTty();
         Map<String, Quantity> requests = combineResources(parent, template, ResourceRequirements::getRequests);
         Map<String, Quantity> limits = combineResources(parent, template, ResourceRequirements::getLimits);

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
@@ -203,8 +203,8 @@ public class PodTemplateUtils {
         String workingDir = isNullOrEmpty(template.getWorkingDir())
                 ? (isNullOrEmpty(parent.getWorkingDir()) ? DEFAULT_WORKING_DIR : parent.getWorkingDir())
                 : template.getWorkingDir();
-        List<String> command = template.getCommand() == null ? parent.getCommand() : template.getCommand();
-        List<String> args = template.getArgs() == null ? parent.getArgs() : template.getArgs();
+        List<String> command = template.getCommand() == null || template.getCommand().isEmpty() ? parent.getCommand() : template.getCommand();
+        List<String> args = template.getArgs() == null || template.getArgs().isEmpty() ? parent.getArgs() : template.getArgs();
         Boolean tty = template.getTty() != null ? template.getTty() : parent.getTty();
         Map<String, Quantity> requests = combineResources(parent, template, ResourceRequirements::getRequests);
         Map<String, Quantity> limits = combineResources(parent, template, ResourceRequirements::getLimits);

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
@@ -937,4 +937,16 @@ public class PodTemplateUtilsTest {
                         .get(0)
                         .getMode());
     }
+
+    @Test
+    @Issue("JENKINS-72886")
+    public void shouldIgnoreContainerEmptyArgs() {
+        Container parent = new Container();
+        parent.setArgs(List.of("arg1", "arg2"));
+        parent.setCommand(List.of("parent command"));
+        Container child = new Container();
+        Container result = combine(parent, child);
+        assertEquals(List.of("arg1", "arg2"), result.getArgs());
+        assertEquals(List.of("parent command"), result.getCommand());
+    }
 }


### PR DESCRIPTION
The issue is described in detail here - https://issues.jenkins.io/browse/JENKINS-72886

This PR adds checks for empty Lists because `args` and `command` fields are initialized as empty lists by default, and they can't be `null`. Before this change `args` and `command` from parent template were overridden with empty values, because `null` check always returned `false`. 

After this change `args` and `command` fields will be preserved from parent template if child don't provide any. This is the expected behavior.

### Testing done

I've added simple unit test which failed before this change and now passes successfully. It check that fields from parent container template are present if child template doesn't contain these fields  

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
