### PR TITLE
Unwrap advanced configuration section

### DIFF
--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/config.jelly
@@ -23,106 +23,101 @@ THE SOFTWARE.
     <f:entry title="${%Name}" field="name">
       <f:textbox default="kubernetes" clazz="required"/>
     </f:entry>
-    
-    <f:advanced title="Kubernetes Cloud details">
 
-      <f:entry title="${%Kubernetes URL}" field="serverUrl">
-        <f:textbox/>
-      </f:entry>
+    <f:entry title="${%Kubernetes URL}" field="serverUrl">
+      <f:textbox/>
+    </f:entry>
 
-      <f:entry title="${%Use Jenkins Proxy}" field="useJenkinsProxy">
-        <f:checkbox/>
-      </f:entry>
+    <f:entry title="${%Use Jenkins Proxy}" field="useJenkinsProxy">
+      <f:checkbox/>
+    </f:entry>
 
-      <f:entry title="${%Kubernetes server certificate key}" field="serverCertificate">
-        <f:textarea/>
-      </f:entry>
+    <f:entry title="${%Kubernetes server certificate key}" field="serverCertificate">
+      <f:textarea/>
+    </f:entry>
 
-      <f:entry title="${%Disable https certificate check}" field="skipTlsVerify">
-        <f:checkbox />
-      </f:entry>
+    <f:entry title="${%Disable https certificate check}" field="skipTlsVerify">
+      <f:checkbox />
+    </f:entry>
 
-      <f:entry title="${%Kubernetes Namespace}" field="namespace">
-        <f:textbox/>
-      </f:entry>
+    <f:entry title="${%Kubernetes Namespace}" field="namespace">
+      <f:textbox/>
+    </f:entry>
 
-      <f:entry title="${%Agent Docker Registry}" field="jnlpregistry">
-        <f:textbox/>
-      </f:entry>
+    <f:entry title="${%Agent Docker Registry}" field="jnlpregistry">
+      <f:textbox/>
+    </f:entry>
 
-      <f:entry title="${%Inject restricted PSS security context in agent container definition}" field="restrictedPssSecurityContext">
-        <f:checkbox/>
-      </f:entry>
+    <f:entry title="${%Inject restricted PSS security context in agent container definition}" field="restrictedPssSecurityContext">
+      <f:checkbox/>
+    </f:entry>
 
-      <f:entry title="${%Credentials}" field="credentialsId">
-        <c:select/>
-      </f:entry>
+    <f:entry title="${%Credentials}" field="credentialsId">
+      <c:select/>
+    </f:entry>
 
-      <f:validateButton title="${%Test Connection}" progress="${%Testing...}" method="testConnection" with="name,serverUrl,credentialsId,serverCertificate,skipTlsVerify,namespace,connectTimeout,readTimeout,useJenkinsProxy" />
+    <f:validateButton title="${%Test Connection}" progress="${%Testing...}" method="testConnection" with="name,serverUrl,credentialsId,serverCertificate,skipTlsVerify,namespace,connectTimeout,readTimeout,useJenkinsProxy" />
 
-      <f:entry title="${%WebSocket}" field="webSocket">
-        <f:checkbox/>
-      </f:entry>
+    <f:entry title="${%WebSocket}" field="webSocket">
+      <f:checkbox/>
+    </f:entry>
 
-      <f:entry title="${%Direct Connection}" field="directConnection">
-        <f:checkbox default="false" />
-      </f:entry>
+    <f:entry title="${%Direct Connection}" field="directConnection">
+      <f:checkbox default="false" />
+    </f:entry>
 
-      <f:entry title="${%Jenkins URL}" field="jenkinsUrl">
-        <f:textbox />
-      </f:entry>
+    <f:entry title="${%Jenkins URL}" field="jenkinsUrl">
+      <f:textbox />
+    </f:entry>
 
-      <f:entry title="${%Jenkins tunnel}" field="jenkinsTunnel">
-        <f:textbox />
-      </f:entry>
+    <f:entry title="${%Jenkins tunnel}" field="jenkinsTunnel">
+      <f:textbox />
+    </f:entry>
 
-      <f:entry title="${%Connection Timeout (seconds)}" field="connectTimeout">
-        <f:number min="${descriptor.defaultConnectTimeout}" default="${descriptor.defaultConnectTimeout}" checkMethod="post"/>
-      </f:entry>
+    <f:entry title="${%Connection Timeout (seconds)}" field="connectTimeout">
+      <f:number min="${descriptor.defaultConnectTimeout}" default="${descriptor.defaultConnectTimeout}" checkMethod="post"/>
+    </f:entry>
 
-      <f:entry title="${%Read Timeout (seconds)}" field="readTimeout">
-        <f:number min="${descriptor.defaultReadTimeout}" default="${descriptor.defaultReadTimeout}" checkMethod="post"/>
-      </f:entry>
+    <f:entry title="${%Read Timeout (seconds)}" field="readTimeout">
+      <f:number min="${descriptor.defaultReadTimeout}" default="${descriptor.defaultReadTimeout}" checkMethod="post"/>
+    </f:entry>
 
-      <f:entry title="${%Concurrency Limit}" field="containerCapStr">
-        <f:number default="10"/>
-      </f:entry>
+    <f:entry title="${%Concurrency Limit}" field="containerCapStr">
+      <f:number default="10"/>
+    </f:entry>
 
-      <f:entry title="${%Pod Labels}" field="podLabels">
-        <f:repeatableHeteroProperty field="podLabels" hasHeader="true" addCaption="${%Add Pod Label}"
-                                    deleteCaption="${%Delete Pod Label}" />
-      </f:entry>
+    <f:entry title="${%Pod Labels}" field="podLabels">
+      <f:repeatableHeteroProperty field="podLabels" hasHeader="true" addCaption="${%Add Pod Label}"
+                                  deleteCaption="${%Delete Pod Label}" />
+    </f:entry>
 
-      <f:advanced title="${%Pod Retention}">
-        <f:dropdownDescriptorSelector title="${%Pod Retention}" field="podRetention" 
-            descriptors="${descriptor.allowedPodRetentions}" default="${descriptor.defaultPodRetention}" /> 
-      </f:advanced>
-
-      <f:entry title="${%Max connections to Kubernetes API}" field="maxRequestsPerHostStr">
-        <f:number default="32" checkMethod="post"/>
-      </f:entry>
-
-      <f:entry title="Seconds to wait for pod to be running" field="waitForPodSec">
-        <f:number clazz="required number" min="0" step="1" default="${descriptor.defaultWaitForPod}"/>
-      </f:entry>
-
-      <f:advanced>
-        <f:entry title="${%Container Cleanup Timeout (minutes)}" field="retentionTimeout">
-            <f:number min="${descriptor.defaultRetentionTimeout}" default="${descriptor.defaultRetentionTimeout}" checkMethod="post"/>
-        </f:entry>
-
-        <f:entry title="${%Transfer proxy related environment variables from controller to agent}" field="addMasterProxyEnvVars">
-          <f:checkbox />
-        </f:entry>
-
-        <f:entry title="${%Restrict pipeline support to authorized folders}" field="usageRestricted">
-            <f:checkbox />
-        </f:entry>
-
-        <f:entry title="${%Defaults Provider Template Name}" field="defaultsProviderTemplate">
-          <f:textbox default=""/>
-        </f:entry>
-      </f:advanced>
+    <f:advanced title="${%Pod Retention}">
+      <f:dropdownDescriptorSelector title="${%Pod Retention}" field="podRetention"
+          descriptors="${descriptor.allowedPodRetentions}" default="${descriptor.defaultPodRetention}" />
     </f:advanced>
+
+    <f:entry title="${%Max connections to Kubernetes API}" field="maxRequestsPerHostStr">
+      <f:number default="32" checkMethod="post"/>
+    </f:entry>
+
+    <f:entry title="Seconds to wait for pod to be running" field="waitForPodSec">
+      <f:number clazz="required number" min="0" step="1" default="${descriptor.defaultWaitForPod}"/>
+    </f:entry>
+
+    <f:entry title="${%Container Cleanup Timeout (minutes)}" field="retentionTimeout">
+        <f:number min="${descriptor.defaultRetentionTimeout}" default="${descriptor.defaultRetentionTimeout}" checkMethod="post"/>
+    </f:entry>
+
+    <f:entry title="${%Transfer proxy related environment variables from controller to agent}" field="addMasterProxyEnvVars">
+      <f:checkbox />
+    </f:entry>
+
+    <f:entry title="${%Restrict pipeline support to authorized folders}" field="usageRestricted">
+        <f:checkbox />
+    </f:entry>
+
+    <f:entry title="${%Defaults Provider Template Name}" field="defaultsProviderTemplate">
+      <f:textbox default=""/>
+    </f:entry>
 
 </j:jelly>


### PR DESCRIPTION
Now that `KubernetesCloud` has its own configuration page, it is no longer necessary to hide its configuration by default.

To be reviewed [ignoring whitespaces](https://github.com/jenkinsci/kubernetes-plugin/pull/1541/files?w=1).

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
