### PR TITLE
Remove reference to `MIME_TYPES`

### DIFF
--- a/src/test/java/org/jvnet/hudson/test/JenkinsRuleNonLocalhost.java
+++ b/src/test/java/org/jvnet/hudson/test/JenkinsRuleNonLocalhost.java
@@ -81,7 +81,6 @@ public class JenkinsRuleNonLocalhost extends JenkinsRule {
         context.addBean(new NoListenerConfiguration(context));
         JettyWebSocketServletContainerInitializer.configure(context, null);
         server.setHandler(context);
-        context.setMimeTypes(MIME_TYPES);
         context.getSecurityHandler().setLoginService(configureUserRealm());
         context.setResourceBase(WarExploder.getExplodedDir().getPath());
 


### PR DESCRIPTION
See https://github.com/jenkinsci/jenkins-test-harness/pull/764. `MIME_TYPES` just has `text/javascript`, which is already the default in Jetty anyway, so this does nothing. Simpler to remove this field eventually rather than to try and adapt it for Jetty 12 calling conventions. This PR gets us closer to being able to remove it.

### Testing done

CI build