### PR TITLE
Add `--noReconnectAfter 1d` option when available in the agent image.

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -102,6 +102,8 @@ public class PodTemplateBuilder {
     public static final Pattern FROM_DIRECTIVE = Pattern.compile("^FROM (.*)$");
 
     public static final String LABEL_KUBERNETES_CONTROLLER = "kubernetes.jenkins.io/controller";
+    private static final String NO_RECONNECT_AFTER_TIMEOUT =
+            SystemProperties.getString(PodTemplateBuilder.class.getName() + ".noReconnectAfter", "1d");
 
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "tests")
     @Restricted(NoExternalUse.class)
@@ -458,6 +460,7 @@ public class PodTemplateBuilder {
                     env.put("JENKINS_PROTOCOLS", "JNLP4-connect");
                     env.put("JENKINS_INSTANCE_IDENTITY", tcpSlaveAgentListener.getIdentityPublicKey());
                 }
+                env.put("REMOTING_OPTS", "-noReconnectAfter " + NO_RECONNECT_AFTER_TIMEOUT);
             }
         }
         Map<String, EnvVar> envVarsMap = new HashMap<>();
@@ -504,6 +507,8 @@ public class PodTemplateBuilder {
             remotingOptions.add("-instanceIdentity");
             remotingOptions.add(tcpSlaveAgentListener.getIdentityPublicKey());
         }
+        remotingOptions.add("-noReconnectAfter");
+        remotingOptions.add(NO_RECONNECT_AFTER_TIMEOUT);
         if (EXTRA_REMOTING_OPTS != null) {
             remotingOptions.addAll(Arrays.asList(EXTRA_REMOTING_OPTS.split(" ")));
         }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -61,7 +61,6 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -139,11 +138,6 @@ public class PodTemplateBuilder {
             System.getProperty(PodTemplateStepExecution.class.getName() + ".defaultContainer.defaultMemoryLimit");
     static final String DEFAULT_JNLP_CONTAINER_CPU_LIMIT =
             System.getProperty(PodTemplateStepExecution.class.getName() + ".defaultContainer.defaultCpuLimit");
-
-    private static final boolean USE_REMOTING_OPTS =
-            SystemProperties.getBoolean(PodTemplateBuilder.class.getName() + ".useRemotingOpts");
-    private static final String EXTRA_REMOTING_OPTS =
-            SystemProperties.getString(PodTemplateBuilder.class.getName() + ".extraRemotingOpts");
 
     private static final String JNLPMAC_REF = "\\$\\{computer.jnlpmac\\}";
     private static final String NAME_REF = "\\$\\{computer.name\\}";
@@ -414,7 +408,7 @@ public class PodTemplateBuilder {
         return envVarsMap;
     }
 
-    private Map<String, EnvVar> jnlpEnvVars(@CheckForNull String workingDir) {
+    private Map<String, EnvVar> jnlpEnvVars(String workingDir) {
         if (workingDir == null) {
             workingDir = ContainerTemplate.DEFAULT_WORKING_DIR;
         }
@@ -422,97 +416,45 @@ public class PodTemplateBuilder {
         HashMap<String, String> env = new HashMap<>();
 
         if (agent != null) {
-            if (USE_REMOTING_OPTS) {
-                contributeRemotingOptions(workingDir, env);
+            SlaveComputer computer = agent.getComputer();
+            if (computer != null) {
+                // Add some default env vars for Jenkins
+                env.put("JENKINS_SECRET", computer.getJnlpMac());
+                // JENKINS_AGENT_NAME is default in jnlp-slave
+                // JENKINS_NAME only here for backwords compatability
+                env.put("JENKINS_NAME", computer.getName());
+                env.put("JENKINS_AGENT_NAME", computer.getName());
             } else {
-                // TODO: legacy, remove when we require a minimum version of inbound agent containing
-                // https://github.com/jenkinsci/docker-agent/pull/809
-                SlaveComputer computer = agent.getComputer();
-                if (computer != null) {
-                    // Add some default env vars for Jenkins
-                    env.put("JENKINS_SECRET", computer.getJnlpMac());
-                    // JENKINS_AGENT_NAME is default in jnlp-slave
-                    // JENKINS_NAME only here for backwords compatability
-                    env.put("JENKINS_NAME", computer.getName());
-                    env.put("JENKINS_AGENT_NAME", computer.getName());
-                } else {
-                    LOGGER.log(Level.INFO, "Computer is null for agent: {0}", agent.getNodeName());
-                }
-
-                env.put("JENKINS_AGENT_WORKDIR", workingDir);
-
-                KubernetesCloud cloud = agent.getKubernetesCloud();
-
-                if (!StringUtils.isBlank(cloud.getJenkinsTunnel())) {
-                    env.put("JENKINS_TUNNEL", cloud.getJenkinsTunnel());
-                }
-
-                if (!cloud.isDirectConnection()) {
-                    env.put("JENKINS_URL", cloud.getJenkinsUrlOrDie());
-                    if (cloud.isWebSocket()) {
-                        env.put("JENKINS_WEB_SOCKET", "true");
-                    }
-                } else {
-                    TcpSlaveAgentListener tcpSlaveAgentListener = Jenkins.get().getTcpSlaveAgentListener();
-                    String host = tcpSlaveAgentListener.getAdvertisedHost();
-                    int port = tcpSlaveAgentListener.getAdvertisedPort();
-                    env.put("JENKINS_DIRECT_CONNECTION", host + ":" + port);
-                    env.put("JENKINS_PROTOCOLS", "JNLP4-connect");
-                    env.put("JENKINS_INSTANCE_IDENTITY", tcpSlaveAgentListener.getIdentityPublicKey());
-                }
-                env.put("REMOTING_OPTS", "-noReconnectAfter " + NO_RECONNECT_AFTER_TIMEOUT);
+                LOGGER.log(Level.INFO, "Computer is null for agent: {0}", agent.getNodeName());
             }
+
+            env.put("JENKINS_AGENT_WORKDIR", workingDir);
+
+            KubernetesCloud cloud = agent.getKubernetesCloud();
+
+            if (!StringUtils.isBlank(cloud.getJenkinsTunnel())) {
+                env.put("JENKINS_TUNNEL", cloud.getJenkinsTunnel());
+            }
+
+            if (!cloud.isDirectConnection()) {
+                env.put("JENKINS_URL", cloud.getJenkinsUrlOrDie());
+                if (cloud.isWebSocket()) {
+                    env.put("JENKINS_WEB_SOCKET", "true");
+                }
+            } else {
+                TcpSlaveAgentListener tcpSlaveAgentListener = Jenkins.get().getTcpSlaveAgentListener();
+                String host = tcpSlaveAgentListener.getAdvertisedHost();
+                int port = tcpSlaveAgentListener.getAdvertisedPort();
+                env.put("JENKINS_DIRECT_CONNECTION", host + ":" + port);
+                env.put("JENKINS_PROTOCOLS", "JNLP4-connect");
+                env.put("JENKINS_INSTANCE_IDENTITY", tcpSlaveAgentListener.getIdentityPublicKey());
+            }
+            env.put("REMOTING_OPTS", "-noReconnectAfter " + NO_RECONNECT_AFTER_TIMEOUT);
         }
         Map<String, EnvVar> envVarsMap = new HashMap<>();
 
         env.entrySet().forEach(item -> envVarsMap.put(item.getKey(), new EnvVar(item.getKey(), item.getValue(), null)));
         return envVarsMap;
-    }
-
-    private void contributeRemotingOptions(@NonNull String workingDir, @NonNull Map<String, String> env) {
-        SlaveComputer computer = agent.getComputer();
-        var remotingOptions = new ArrayList<String>();
-        if (computer != null) {
-            remotingOptions.add("-secret");
-            remotingOptions.add(computer.getJnlpMac());
-            remotingOptions.add("-name");
-            remotingOptions.add(computer.getName());
-        } else {
-            LOGGER.log(Level.INFO, "Computer is null for agent: {0}", agent.getNodeName());
-        }
-
-        remotingOptions.add("-workDir");
-        remotingOptions.add(workingDir);
-
-        KubernetesCloud cloud = agent.getKubernetesCloud();
-
-        if (!StringUtils.isBlank(cloud.getJenkinsTunnel())) {
-            remotingOptions.add("-tunnel");
-            remotingOptions.add(cloud.getJenkinsTunnel());
-        }
-
-        if (!cloud.isDirectConnection()) {
-            remotingOptions.add("-url");
-            remotingOptions.add(cloud.getJenkinsUrlOrDie());
-            if (cloud.isWebSocket()) {
-                remotingOptions.add("-webSocket");
-            }
-        } else {
-            TcpSlaveAgentListener tcpSlaveAgentListener = Jenkins.get().getTcpSlaveAgentListener();
-            remotingOptions.add("-direct");
-            remotingOptions.add(
-                    tcpSlaveAgentListener.getAdvertisedHost() + ":" + tcpSlaveAgentListener.getAdvertisedPort());
-            remotingOptions.add("-protocols");
-            remotingOptions.add("JNLP4-connect");
-            remotingOptions.add("-instanceIdentity");
-            remotingOptions.add(tcpSlaveAgentListener.getIdentityPublicKey());
-        }
-        remotingOptions.add("-noReconnectAfter");
-        remotingOptions.add(NO_RECONNECT_AFTER_TIMEOUT);
-        if (EXTRA_REMOTING_OPTS != null) {
-            remotingOptions.addAll(Arrays.asList(EXTRA_REMOTING_OPTS.split(" ")));
-        }
-        env.put("REMOTING_OPTS", String.join(" ", remotingOptions));
     }
 
     private Container createContainer(

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -101,7 +101,7 @@ public class PodTemplateBuilder {
     public static final Pattern FROM_DIRECTIVE = Pattern.compile("^FROM (.*)$");
 
     public static final String LABEL_KUBERNETES_CONTROLLER = "kubernetes.jenkins.io/controller";
-    private static final String NO_RECONNECT_AFTER_TIMEOUT =
+    static final String NO_RECONNECT_AFTER_TIMEOUT =
             SystemProperties.getString(PodTemplateBuilder.class.getName() + ".noReconnectAfter", "1d");
 
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "tests")

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/Dockerfile
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/Dockerfile
@@ -1,1 +1,1 @@
-FROM jenkins/inbound-agent:3206.vb_15dcf73f6a_9-2
+FROM jenkins/inbound-agent:3248.v65ecb_254c298-2

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
@@ -451,8 +451,8 @@ public class PodTemplateBuilderTest {
             if ("jnlp".equals(c.getName())) {
                 validateJnlpContainer(c, slave, directConnection);
             } else {
-                List<EnvVar> env = c.getEnv();
-                assertThat(env.stream().map(EnvVar::getName).collect(toList()), everyItem(not(isIn(exclusions))));
+                assertThat(
+                        c.getEnv().stream().map(EnvVar::getName).collect(toList()), everyItem(not(is(in(exclusions)))));
             }
         }
     }
@@ -480,6 +480,7 @@ public class PodTemplateBuilderTest {
             envVars.add(new EnvVar("JENKINS_NAME", AGENT_NAME, null));
             envVars.add(new EnvVar("JENKINS_AGENT_NAME", AGENT_NAME, null));
             envVars.add(new EnvVar("JENKINS_AGENT_WORKDIR", ContainerTemplate.DEFAULT_WORKING_DIR, null));
+            envVars.add(new EnvVar("REMOTING_OPTS", "-noReconnectAfter " + NO_RECONNECT_AFTER_TIMEOUT, null));
         } else {
             assertThat(jnlp.getArgs(), empty());
         }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
@@ -451,8 +451,8 @@ public class PodTemplateBuilderTest {
             if ("jnlp".equals(c.getName())) {
                 validateJnlpContainer(c, slave, directConnection);
             } else {
-                assertThat(
-                        c.getEnv().stream().map(EnvVar::getName).collect(toList()), everyItem(not(is(in(exclusions)))));
+                List<EnvVar> env = c.getEnv();
+                assertThat(env.stream().map(EnvVar::getName).collect(toList()), everyItem(not(isIn(exclusions))));
             }
         }
     }


### PR DESCRIPTION
https://github.com/jenkinsci/docker-agent/pull/809 added support for `REMOTING_OPTS` in order to pass custom remoting options to the agent.

This makes use of the new option to pass `--noReconnectAfter 1d`, allowing the agent to bail out after 1 day of not being able to contact the controller.

This can be tweaked using `-Dorg.csanchez.jenkins.plugins.kubernetes.PodTemplateBuilder.noReconnectAfter=30d` using the syntax allowed by the agent per https://github.com/jenkinsci/remoting/pull/738

Tested using `mvn hpi:run -Dorg.csanchez.jenkins.plugins.kubernetes.PodTemplateBuilder.noReconnectAfter=1m`, launching a kubernetes agent, then turning off the controller. The agent bails out after 1 minute in that case.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
