### PR TITLE
Handle case where a node is launched with an invalid template

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
@@ -111,8 +111,9 @@ public class KubernetesLauncher extends JNLPLauncher {
         }
 
         String cloudName = node.getCloudName();
-        final PodTemplate template = node.getTemplate();
+
         try {
+            PodTemplate template = node.getTemplate();
             KubernetesCloud cloud = node.getKubernetesCloud();
             KubernetesClient client = cloud.connect();
             Pod pod = template.build(node);
@@ -279,7 +280,9 @@ public class KubernetesLauncher extends JNLPLauncher {
             setProblem(ex);
             Functions.printStackTrace(ex, node.getRunListener().error("Failed to launch " + node.getPodName()));
             LOGGER.log(
-                    Level.WARNING, String.format("Error in provisioning; agent=%s, template=%s", node, template), ex);
+                    Level.WARNING,
+                    String.format("Error in provisioning; agent=%s, template=%s", node, node.getTemplateId()),
+                    ex);
             LOGGER.log(Level.FINER, "Removing Jenkins node: {0}", node.getNodeName());
             try {
                 node.terminate();


### PR DESCRIPTION
Could happen if somehow `PodTemplateStepExecution#onResume` doesn't run after a restart, or if the pipeline run gets deleted and the agent still exists ?

In such a case, the agent will attempt to connect forever but won't be able to resolve a pod template reference.

I've seen the case on a real instance but I don't know how to reproduce it though.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
