### PR TITLE
Add a dummy descriptor for `KubernetesLauncher`

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
@@ -31,7 +31,9 @@ import static java.util.logging.Level.WARNING;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Functions;
+import hudson.model.Descriptor;
 import hudson.model.TaskListener;
+import hudson.slaves.ComputerLauncher;
 import hudson.slaves.JNLPLauncher;
 import hudson.slaves.SlaveComputer;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
@@ -373,4 +375,12 @@ public class KubernetesLauncher extends JNLPLauncher {
     public void setProblem(@CheckForNull Throwable problem) {
         this.problem = problem;
     }
+
+    @Override
+    public Descriptor<ComputerLauncher> getDescriptor() {
+        return new DescriptorImpl();
+    }
+
+    // Only there to avoid throwing unnecessary exceptions. KubernetesLauncher is never instantiated via UI.
+    private static class DescriptorImpl extends Descriptor<ComputerLauncher> {}
 }


### PR DESCRIPTION
`KubernetesLauncher` is a `Describable` but as it is only instantiated programmatically. Not having a matching `Descriptor` class is not a problem for daily operations in the plugin, but some code may request for `computer.launcher.descriptor` and produce walls of exceptions for no good use.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
