### PR TITLE
Pod connection issue reproducer

### DIFF
--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineRJRTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineRJRTest.java
@@ -31,8 +31,8 @@ public class KubernetesPipelineRJRTest extends AbstractKubernetesPipelineRJRTest
         // the pod is created, but not connected yet
         rjr.runRemotely(new AssertBuildLogMessage("Created Pod", build));
         // restart
-        rjr.stopJenkins();
-        rjr.startJenkins();
+        //rjr.stopJenkins();
+        //rjr.startJenkins();
         // update k8s to make a node suitable to schedule (add disktype=special to the node)
         System.out.println("Adding label to node....");
         try (KubernetesClient client = new KubernetesClientBuilder().build()) {

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/restartDuringPodLaunch.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/restartDuringPodLaunch.groovy
@@ -2,6 +2,15 @@ podTemplate(yaml: '''
 apiVersion: v1
 kind: Pod
 spec:
+  containers:
+  - name: jnlp
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 100m
+        memory: 256Mi
   nodeSelector:
     disktype: special
 ''') {


### PR DESCRIPTION
For some reason I don't understand the pod jnlp container thinks it's connected but the controller thinks it's not and keeps waiting for it.

`jnlp` container logs:

```
May 29, 2024 9:41:09 AM org.jenkinsci.remoting.engine.WorkDirManager initializeWorkDir
INFO: Using /home/jenkins/agent/remoting as a remoting work directory
May 29, 2024 9:41:12 AM org.jenkinsci.remoting.engine.WorkDirManager setupLogging
INFO: Both error and output logs will be printed to /home/jenkins/agent/remoting
May 29, 2024 9:41:12 AM hudson.remoting.Launcher createEngine
INFO: Setting up agent: test0-1-0jmg0-hp6gs-0hjx9
May 29, 2024 9:41:13 AM hudson.remoting.Engine startEngine
INFO: Using Remoting version: 3248.v65ecb_254c298
May 29, 2024 9:41:13 AM org.jenkinsci.remoting.engine.WorkDirManager initializeWorkDir
INFO: Using /home/jenkins/agent/remoting as a remoting work directory
May 29, 2024 9:41:21 AM hudson.remoting.Launcher$CuiListener status
INFO: Locating server among [http://jenkins.kubernetes-plugin-test.svc.cluster.local:24289/jenkins/]
May 29, 2024 9:41:23 AM org.jenkinsci.remoting.engine.JnlpAgentEndpointResolver resolve
INFO: Remoting server accepts the following protocols: [JNLP4-connect, Ping]
May 29, 2024 9:41:23 AM hudson.remoting.Launcher$CuiListener status
INFO: Agent discovery successful
  Agent address: jenkins.kubernetes-plugin-test.svc.cluster.local
  Agent port:    24290
  Identity:      2f:8b:3e:9a:28:e7:d0:c5:24:25:18:72:60:8f:aa:b5
May 29, 2024 9:41:23 AM hudson.remoting.Launcher$CuiListener status
INFO: Handshaking
May 29, 2024 9:41:23 AM hudson.remoting.Launcher$CuiListener status
INFO: Connecting to jenkins.kubernetes-plugin-test.svc.cluster.local:24290
May 29, 2024 9:41:24 AM hudson.remoting.Launcher$CuiListener status
INFO: Server reports protocol JNLP4-connect-proxy not supported, skipping
May 29, 2024 9:41:24 AM hudson.remoting.Launcher$CuiListener status
INFO: Trying protocol: JNLP4-connect
May 29, 2024 9:41:26 AM org.jenkinsci.remoting.protocol.impl.BIONetworkLayer$Reader run
INFO: Waiting for ProtocolStack to start.
May 29, 2024 9:41:31 AM hudson.remoting.Launcher$CuiListener status
INFO: Remote identity confirmed: 2f:8b:3e:9a:28:e7:d0:c5:24:25:18:72:60:8f:aa:b5
May 29, 2024 9:41:32 AM hudson.remoting.Launcher$CuiListener status
INFO: Connected
```

Controller logs:

```
2024-05-29 09:41:00.737+0000 [id=128]	INFO	o.c.j.p.k.KubernetesLauncher#launch: Pod is running: kubernetes kubernetes-plugin-test/test0-1-0jmg0-hp6gs-0hjx9
2024-05-29 09:41:23.418+0000 [id=166]	INFO	h.TcpSlaveAgentListener$ConnectionHandler#run: Connection #2 from /10.244.0.14:36382 failed: null
2024-05-29 09:41:26.810+0000 [id=172]	INFO	h.TcpSlaveAgentListener$ConnectionHandler#run: Accepted JNLP4-connect connection #3 from /10.244.0.14:36398
2024-05-29 09:41:31.115+0000 [id=128]	INFO	o.c.j.p.k.KubernetesLauncher#launch: Waiting for agent to connect (30/1,000): test0-1-0jmg0-hp6gs-0hjx9
2024-05-29 09:42:01.438+0000 [id=128]	INFO	o.c.j.p.k.KubernetesLauncher#launch: Waiting for agent to connect (60/1,000): test0-1-0jmg0-hp6gs-0hjx9
```

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
