### PR TITLE
Run tests locally provisioning in Kind

### DIFF
--- a/kind-local/README.md
+++ b/kind-local/README.md
@@ -1,0 +1,12 @@
+This contains the setup to run `mvn test` locally and provisioning build pods in a locally running Kind cluster.
+
+It's basically the same than `test-in-k8s.sh` but the Jenkins instance runs on the host instead of a Kind pod.
+
+`dockerhost.yaml` is a trick to allow pods to contact the Jenkins instance which runs on the host.
+
+Usage:
+```shell
+./test-local.sh KubernetesPipelineRJRTest#basicPipeline
+```
+
+Note that this requires a locally running Kind cluster (defaults are ok, just `kind create cluster`).

--- a/kind-local/dockerhost.yaml
+++ b/kind-local/dockerhost.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: dockerhost
+subsets:
+- addresses:
+  - ip: @GATEWAY_IP@ # this is the gateway IP in the "kind" docker network
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dockerhost
+spec:
+  clusterIP: None

--- a/kind-local/test-local.sh
+++ b/kind-local/test-local.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+gateway_ip=$(docker network inspect kind | jq '[.[].IPAM.Config[].Gateway][0]')
+sed "s/@GATEWAY_IP@/$gateway_ip/g" < dockerhost.yaml | kubectl apply -f -
+
+mvn -f ../pom.xml test -Dtest="$@" -Djenkins.host.address=dockerhost -Dhudson.TcpSlaveAgentListener.hostName=dockerhost -DconnectorHost=0.0.0.0


### PR DESCRIPTION
The existing `test-in-k8s.sh` script runs tests in Kind (`mvn test` in a pod). Sometimes it's convenient to have the controller running locally while still provisioning pods in Kind.

Just in case it's useful for others.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
