### PR TITLE
Handle Pod decorator failure by aborting the pending queue item.

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
@@ -4,6 +4,7 @@ import static org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud.JNLP_NAME;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.FilePath;
@@ -221,7 +222,7 @@ public class KubernetesSlave extends AbstractCloudSlave {
         this.namespace = namespace;
     }
 
-    @NonNull
+    @Nullable
     public String getNamespace() {
         return namespace;
     }
@@ -423,7 +424,10 @@ public class KubernetesSlave extends AbstractCloudSlave {
         listener.getLogger().println(msg);
     }
 
-    private void deleteSlavePod(TaskListener listener, KubernetesClient client) throws IOException {
+    private void deleteSlavePod(TaskListener listener, KubernetesClient client) {
+        if (getNamespace() == null) {
+            return;
+        }
         try {
             boolean deleted = client.pods()
                             .inNamespace(getNamespace())

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -10,6 +10,7 @@ import hudson.model.Descriptor;
 import hudson.model.DescriptorVisibilityFilter;
 import hudson.model.Label;
 import hudson.model.Node;
+import hudson.model.Run;
 import hudson.model.Saveable;
 import hudson.model.TaskListener;
 import hudson.model.labels.LabelAtom;
@@ -79,6 +80,13 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
 
     public static final String JENKINS_LABEL = "jenkins/label";
     public static final String JENKINS_LABEL_DIGEST = "jenkins/label-digest";
+
+    /**
+     * The run this pod template is associated with.
+     * Only applicable to pod templates defined by the `podTemplate` step.
+     */
+    @CheckForNull
+    private transient Run<?, ?> run;
 
     /**
      * Digest function that is used to compute the kubernetes label "jenkins/label-digest"
@@ -1057,6 +1065,15 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
 
     public void setReadonlyFromUi(boolean readonlyFromUi) {
         this.readonlyFromUi = readonlyFromUi;
+    }
+
+    public void setRun(Run<?, ?> run) {
+        this.run = run;
+    }
+
+    @CheckForNull
+    public Run<?, ?> getRun() {
+        return run;
     }
 
     @Extension

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
@@ -132,6 +132,7 @@ public class PodTemplateStepExecution extends AbstractStepExecutionImpl {
                 newTemplate.getAnnotations().add(new PodAnnotation(POD_ANNOTATION_BUILD_URL, url + run.getUrl()));
                 newTemplate.getAnnotations().add(new PodAnnotation(POD_ANNOTATION_RUN_URL, run.getUrl()));
             }
+            newTemplate.setRun(run);
         }
         newTemplate.setImagePullSecrets(step.getImagePullSecrets().stream()
                 .map(x -> new PodImagePullSecret(x))
@@ -240,6 +241,7 @@ public class PodTemplateStepExecution extends AbstractStepExecutionImpl {
             KubernetesCloud cloud = resolveCloud(cloudName);
             TaskListener listener = getContext().get(TaskListener.class);
             newTemplate.setListener(listener);
+            newTemplate.setRun(getContext().get(Run.class));
             LOGGER.log(Level.FINE, "Re-registering template with id=" + newTemplate.getId() + " after resume");
             if (VERBOSE) {
                 listener.getLogger()

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/decorator/PodDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/decorator/PodDecorator.java
@@ -11,8 +11,15 @@ import org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud;
  */
 public interface PodDecorator extends ExtensionPoint {
 
+    /**
+     * Goes through all the {@link PodDecorator} extensions and decorates the pod.
+     * @param kubernetesCloud The cloud this pod will be scheduled as context.
+     * @param pod the initial pod definition before decoration.
+     * @return The modified pod definition.
+     * @throws PodDecoratorException Should any of the decorators fail to decorate the pod.
+     */
     @NonNull
-    static Pod decorateAll(@NonNull KubernetesCloud kubernetesCloud, @NonNull Pod pod) {
+    static Pod decorateAll(@NonNull KubernetesCloud kubernetesCloud, @NonNull Pod pod) throws PodDecoratorException {
         for (PodDecorator decorator : ExtensionList.lookup(PodDecorator.class)) {
             pod = decorator.decorate(kubernetesCloud, pod);
         }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/decorator/PodDecoratorException.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/decorator/PodDecoratorException.java
@@ -1,0 +1,14 @@
+package org.csanchez.jenkins.plugins.kubernetes.pod.decorator;
+
+/**
+ * A fatal exception raised by a {@link PodDecorator} implementation.
+ */
+public class PodDecoratorException extends RuntimeException {
+    public PodDecoratorException(String message) {
+        super(message);
+    }
+
+    public PodDecoratorException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/decoratorFailure.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/decoratorFailure.groovy
@@ -1,0 +1,5 @@
+podTemplate {
+  node(POD_LABEL) {
+    sh 'true'
+  }
+}


### PR DESCRIPTION
Only handles dynamic pod templates, not static pod templates.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
