### PR TITLE
Apply restricted PSS to all containers when enabled

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/RestrictedPssSecurityContextInjector.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/RestrictedPssSecurityContextInjector.java
@@ -1,0 +1,79 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import io.fabric8.kubernetes.api.model.CapabilitiesBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.SeccompProfileBuilder;
+import io.fabric8.kubernetes.api.model.SecurityContext;
+import java.util.List;
+import java.util.logging.Logger;
+import org.csanchez.jenkins.plugins.kubernetes.pod.decorator.PodDecorator;
+
+/**
+ * <p>
+ * {@link PodDecorator} allowing to inject in all containers a {@code securityContext} allowing to use the
+ * {@code restricted} <a href="https://kubernetes.io/docs/concepts/security/pod-security-standards/">Pod Security Standard</a>.
+ * </p>
+ * <p>
+ * See <a href="https://issues.jenkins.io/browse/JENKINS-71639">JENKINS-71639</a> for more details.
+ * </p>
+ */
+@Extension
+public class RestrictedPssSecurityContextInjector implements PodDecorator {
+    private static final Logger LOGGER = Logger.getLogger(RestrictedPssSecurityContextInjector.class.getName());
+    private static final String SECCOMP_RUNTIME_DEFAULT = "RuntimeDefault";
+    private static final String CAPABILITIES_ALL = "ALL";
+
+    @NonNull
+    @Override
+    public Pod decorate(@NonNull KubernetesCloud kubernetesCloud, @NonNull Pod pod) {
+        if (kubernetesCloud.isRestrictedPssSecurityContext()) {
+            var metadata = pod.getMetadata();
+            if (metadata == null) {
+                // be defensive, this won't happen in real usage
+                LOGGER.warning("No metadata found in the pod, skipping the security context update");
+                return pod;
+            }
+            var ns = metadata.getNamespace();
+            var name = metadata.getName();
+            LOGGER.fine(() -> "Updating pod + " + ns + "/" + name
+                    + "  containers security context due to the configured restricted Pod Security Admission");
+            var spec = pod.getSpec();
+            if (spec == null) {
+                // be defensive, this won't happen in real usage
+                LOGGER.warning("No spec found in the pod, skipping the security context update");
+                return pod;
+            }
+            var containers = spec.getContainers();
+            if (containers != null) {
+                for (var container : containers) {
+                    var securityContext = container.getSecurityContext();
+                    if (securityContext == null) {
+                        securityContext = new SecurityContext();
+                        container.setSecurityContext(securityContext);
+                    }
+                    if (securityContext.getAllowPrivilegeEscalation() == null) {
+                        securityContext.setAllowPrivilegeEscalation(false);
+                    }
+                    if (securityContext.getRunAsNonRoot() == null) {
+                        securityContext.setRunAsNonRoot(true);
+                    }
+                    var seccompProfile = securityContext.getSeccompProfile();
+                    if (seccompProfile == null) {
+                        securityContext.setSeccompProfile(new SeccompProfileBuilder()
+                                .withType(SECCOMP_RUNTIME_DEFAULT)
+                                .build());
+                    }
+                    var capabilities = securityContext.getCapabilities();
+                    if (capabilities == null) {
+                        securityContext.setCapabilities(new CapabilitiesBuilder()
+                                .withDrop(List.of(CAPABILITIES_ALL))
+                                .build());
+                    }
+                }
+            }
+        }
+        return pod;
+    }
+}

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/AbstractGoldenFileTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/AbstractGoldenFileTest.java
@@ -1,0 +1,46 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import static org.junit.Assert.assertEquals;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.client.utils.Serialization;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.io.IOUtils;
+import org.csanchez.jenkins.plugins.kubernetes.pod.decorator.PodDecorator;
+import org.junit.Before;
+
+abstract class AbstractGoldenFileTest {
+
+    protected KubernetesCloud cloud;
+    protected PodDecorator decorator;
+
+    @Before
+    public void setUpCloud() {
+        decorator = newDecorator();
+        cloud = new KubernetesCloud("test");
+    }
+
+    protected abstract PodDecorator newDecorator();
+
+    protected void test(String name) throws IOException {
+        var beforeYAML = loadFileAsStream(name + "-before.yaml");
+        var before = Serialization.unmarshal(beforeYAML, Pod.class);
+        assertEquals(name + "-before.yaml is not normalized", beforeYAML, Serialization.asYaml(before));
+        var afterYAML = loadFileAsStream(name + "-after.yaml");
+        var after = decorator.decorate(cloud, before);
+        assertEquals(name + "-after.yaml processed", afterYAML, Serialization.asYaml(after));
+    }
+
+    @NonNull
+    private String loadFileAsStream(String name) throws IOException {
+        var is = getClass().getResourceAsStream(getClass().getSimpleName() + "/" + name);
+        if (is == null) {
+            throw new IllegalStateException("Test file \"src/test/resources/"
+                    + getClass().getPackageName().replace(".", "/") + "/"
+                    + getClass().getSimpleName() + "/" + name + "\" not found");
+        }
+        return IOUtils.toString(is, StandardCharsets.UTF_8);
+    }
+}

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/RestrictedPssSecurityInjectorTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/RestrictedPssSecurityInjectorTest.java
@@ -25,4 +25,9 @@ public class RestrictedPssSecurityInjectorTest extends AbstractGoldenFileTest {
     public void multiContainer() throws IOException {
         test("multiContainer");
     }
+
+    @Test
+    public void existingSecurityContext() throws IOException {
+        test("existingSecurityContext");
+    }
 }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/RestrictedPssSecurityInjectorTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/RestrictedPssSecurityInjectorTest.java
@@ -1,0 +1,28 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import java.io.IOException;
+import org.csanchez.jenkins.plugins.kubernetes.pod.decorator.PodDecorator;
+import org.junit.Before;
+import org.junit.Test;
+
+public class RestrictedPssSecurityInjectorTest extends AbstractGoldenFileTest {
+    @Before
+    public void configureCloud() {
+        cloud.setRestrictedPssSecurityContext(true);
+    }
+
+    @Override
+    protected PodDecorator newDecorator() {
+        return new RestrictedPssSecurityContextInjector();
+    }
+
+    @Test
+    public void simple() throws IOException {
+        test("simple");
+    }
+
+    @Test
+    public void multiContainer() throws IOException {
+        test("multiContainer");
+    }
+}

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/RestrictedPssSecurityInjectorTest/existingSecurityContext-after.yaml
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/RestrictedPssSecurityInjectorTest/existingSecurityContext-after.yaml
@@ -28,18 +28,14 @@ spec:
       requests:
         cpu: "1"
         memory: "768Mi"
-    volumeMounts:
-    - mountPath: "/home/jenkins/agent"
-      name: "workspace-volume"
-      readOnly: false
-  - args:
-    - "infinity"
-    command:
-    - "sleep"
-    image: "maven"
-    name: "maven"
     securityContext:
-      runAsUser: 1000
+      allowPrivilegeEscalation: true
+      capabilities:
+        drop:
+        - "ALL"
+      runAsNonRoot: true
+      seccompProfile:
+        type: "Localhost"
     volumeMounts:
     - mountPath: "/home/jenkins/agent"
       name: "workspace-volume"

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/RestrictedPssSecurityInjectorTest/existingSecurityContext-before.yaml
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/RestrictedPssSecurityInjectorTest/existingSecurityContext-before.yaml
@@ -28,18 +28,10 @@ spec:
       requests:
         cpu: "1"
         memory: "768Mi"
-    volumeMounts:
-    - mountPath: "/home/jenkins/agent"
-      name: "workspace-volume"
-      readOnly: false
-  - args:
-    - "infinity"
-    command:
-    - "sleep"
-    image: "maven"
-    name: "maven"
     securityContext:
-      runAsUser: 1000
+      allowPrivilegeEscalation: true
+      seccompProfile:
+        type: "Localhost"
     volumeMounts:
     - mountPath: "/home/jenkins/agent"
       name: "workspace-volume"

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/RestrictedPssSecurityInjectorTest/multiContainer-after.yaml
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/RestrictedPssSecurityInjectorTest/multiContainer-after.yaml
@@ -52,6 +52,7 @@ spec:
         drop:
         - "ALL"
       runAsNonRoot: true
+      runAsUser: 1000
       seccompProfile:
         type: "RuntimeDefault"
     volumeMounts:

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/RestrictedPssSecurityInjectorTest/multiContainer-after.yaml
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/RestrictedPssSecurityInjectorTest/multiContainer-after.yaml
@@ -1,0 +1,64 @@
+---
+apiVersion: "v1"
+kind: "Pod"
+metadata:
+  name: "simple"
+  namespace: "jenkins"
+spec:
+  containers:
+  - env:
+    - name: "JENKINS_SECRET"
+      value: "my-little-secret"
+    - name: "JENKINS_AGENT_NAME"
+      value: "my-lovely-agent"
+    - name: "REMOTING_OPTS"
+      value: "-noReconnectAfter 1d"
+    - name: "JENKINS_NAME"
+      value: "my-lovely-agent"
+    - name: "JENKINS_AGENT_WORKDIR"
+      value: "/home/jenkins/agent"
+    - name: "JENKINS_URL"
+      value: "http://localhost/"
+    image: "jenkins/inbound-agent"
+    name: "jnlp"
+    resources:
+      limits:
+        cpu: "1"
+        memory: "768Mi"
+      requests:
+        cpu: "1"
+        memory: "768Mi"
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - "ALL"
+      runAsNonRoot: true
+      seccompProfile:
+        type: "RuntimeDefault"
+    volumeMounts:
+    - mountPath: "/home/jenkins/agent"
+      name: "workspace-volume"
+      readOnly: false
+  - args:
+    - "infinity"
+    command:
+    - "sleep"
+    image: "maven"
+    name: "maven"
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - "ALL"
+      runAsNonRoot: true
+      seccompProfile:
+        type: "RuntimeDefault"
+    volumeMounts:
+    - mountPath: "/home/jenkins/agent"
+      name: "workspace-volume"
+      readOnly: false
+  volumes:
+  - emptyDir:
+      medium: ""
+    name: "workspace-volume"

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/RestrictedPssSecurityInjectorTest/multiContainer-before.yaml
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/RestrictedPssSecurityInjectorTest/multiContainer-before.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: "v1"
+kind: "Pod"
+metadata:
+  name: "simple"
+  namespace: "jenkins"
+spec:
+  containers:
+  - env:
+    - name: "JENKINS_SECRET"
+      value: "my-little-secret"
+    - name: "JENKINS_AGENT_NAME"
+      value: "my-lovely-agent"
+    - name: "REMOTING_OPTS"
+      value: "-noReconnectAfter 1d"
+    - name: "JENKINS_NAME"
+      value: "my-lovely-agent"
+    - name: "JENKINS_AGENT_WORKDIR"
+      value: "/home/jenkins/agent"
+    - name: "JENKINS_URL"
+      value: "http://localhost/"
+    image: "jenkins/inbound-agent"
+    name: "jnlp"
+    resources:
+      limits:
+        cpu: "1"
+        memory: "768Mi"
+      requests:
+        cpu: "1"
+        memory: "768Mi"
+    volumeMounts:
+    - mountPath: "/home/jenkins/agent"
+      name: "workspace-volume"
+      readOnly: false
+  - args:
+    - "infinity"
+    command:
+    - "sleep"
+    image: "maven"
+    name: "maven"
+    volumeMounts:
+    - mountPath: "/home/jenkins/agent"
+      name: "workspace-volume"
+      readOnly: false
+  volumes:
+  - emptyDir:
+      medium: ""
+    name: "workspace-volume"

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/RestrictedPssSecurityInjectorTest/simple-after.yaml
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/RestrictedPssSecurityInjectorTest/simple-after.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: "v1"
+kind: "Pod"
+metadata:
+  name: "simple"
+  namespace: "jenkins"
+spec:
+  containers:
+  - env:
+    - name: "JENKINS_SECRET"
+      value: "my-little-secret"
+    - name: "JENKINS_AGENT_NAME"
+      value: "my-lovely-agent"
+    - name: "REMOTING_OPTS"
+      value: "-noReconnectAfter 1d"
+    - name: "JENKINS_NAME"
+      value: "my-lovely-agent"
+    - name: "JENKINS_AGENT_WORKDIR"
+      value: "/home/jenkins/agent"
+    - name: "JENKINS_URL"
+      value: "http://localhost/"
+    image: "jenkins/inbound-agent"
+    name: "jnlp"
+    resources:
+      limits:
+        cpu: "1"
+        memory: "768Mi"
+      requests:
+        cpu: "1"
+        memory: "768Mi"
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - "ALL"
+      runAsNonRoot: true
+      seccompProfile:
+        type: "RuntimeDefault"
+    volumeMounts:
+    - mountPath: "/home/jenkins/agent"
+      name: "workspace-volume"
+      readOnly: false
+  volumes:
+  - emptyDir:
+      medium: ""
+    name: "workspace-volume"

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/RestrictedPssSecurityInjectorTest/simple-before.yaml
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/RestrictedPssSecurityInjectorTest/simple-before.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: "v1"
+kind: "Pod"
+metadata:
+  name: "simple"
+  namespace: "jenkins"
+spec:
+  containers:
+  - env:
+    - name: "JENKINS_SECRET"
+      value: "my-little-secret"
+    - name: "JENKINS_AGENT_NAME"
+      value: "my-lovely-agent"
+    - name: "REMOTING_OPTS"
+      value: "-noReconnectAfter 1d"
+    - name: "JENKINS_NAME"
+      value: "my-lovely-agent"
+    - name: "JENKINS_AGENT_WORKDIR"
+      value: "/home/jenkins/agent"
+    - name: "JENKINS_URL"
+      value: "http://localhost/"
+    image: "jenkins/inbound-agent"
+    name: "jnlp"
+    resources:
+      limits:
+        cpu: "1"
+        memory: "768Mi"
+      requests:
+        cpu: "1"
+        memory: "768Mi"
+    volumeMounts:
+    - mountPath: "/home/jenkins/agent"
+      name: "workspace-volume"
+      readOnly: false
+  volumes:
+  - emptyDir:
+      medium: ""
+    name: "workspace-volume"


### PR DESCRIPTION
When `restrictedPssSecurityContext = true` in a kubernetes cloud, all created containers will be augmented with a security context compatible with "restricted" Pod Security Admission.

If a security context individual field has been manually set earlier, this won't be overridden. In such case, the pod will be rejected and the user should correct its pod definition.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
