### PR TITLE
[JENKINS-73276] do not allow user without admin permission to save empty form

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFolderProperty.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFolderProperty.java
@@ -74,15 +74,16 @@ public class KubernetesFolderProperty extends AbstractFolderProperty<AbstractFol
 
     @Override
     public AbstractFolderProperty<?> reconfigure(StaplerRequest req, JSONObject form) throws FormException {
-        if (form == null) {
-            return null;
-        }
-
         // ignore modifications silently and return the unmodified object if the user
         // does not have the ADMINISTER Permission
         if (!userHasAdministerPermission()) {
             return this;
         }
+
+        if (form == null) {
+            return null;
+        }
+
         // Backwards compatibility: this method was expecting a set of entries PREFIX_USAGE_PERMISSION+cloudName -->
         // true | false
         // Now we're getting a set of permitted cloud names inside permittedClouds entry


### PR DESCRIPTION
https://issues.jenkins.io/browse/JENKINS-73276

The fix is to not allow user without admin permission to save empty form.

<!-- Please describe your pull request here. -->

### Testing done

Manually tested using steps from the Jira.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
