### PR TITLE
Update linux samples for PSA "restricted"

### DIFF
--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/samples/declarative.groovy
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/samples/declarative.groovy
@@ -21,6 +21,9 @@ spec:
     - sleep
     args:
     - infinity
+    securityContext:
+      # ubuntu runs as root by default, it is recommended or even mandatory in some environments (such as pod security admission "restricted") to run as a non-root user.
+      runAsUser: 1000
 '''
             // Can also wrap individual steps:
             // container('shell') {


### PR DESCRIPTION
Update examples to be runnable as is when the namespace it runs in is configured with "restricted" PSA.

This assumes that in such a case the option `restrictedPssSecurityContext` at kubernetes cloud level is set to `true`, as it injects automatically part of the required security context for such workload.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
