### PR TITLE
Ensure retry if `EvictionByEvictionAPI` is found on termination reasons

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesAgentErrorCondition.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesAgentErrorCondition.java
@@ -128,7 +128,7 @@ public class KubernetesAgentErrorCondition extends ErrorCondition {
                 }
                 Set<String> terminationReasons =
                         ExtensionList.lookupSingleton(Reaper.class).terminationReasons(node);
-                if (terminationReasons.stream().anyMatch(IGNORED_CONTAINER_TERMINATION_REASONS::contains)) {
+                if (terminationReasons.stream().allMatch(IGNORED_CONTAINER_TERMINATION_REASONS::contains)) {
                     listener.getLogger()
                             .println("Ignored termination reason(s) for " + node + " for purposes of retry: "
                                     + terminationReasons);


### PR DESCRIPTION
See https://github.com/jenkinsci/kubernetes-plugin/pull/1560#issuecomment-2196805834 for details

I saw some cases where some container in pods return completed status even when eviction api used

```
[14:14:36.964+02:00] - *******-m5g2b Containers flux,jf,jnlp,kubedock,maven,oc were terminated. Pod was evicted by the Kubernetes Eviction API.
```

```
[14:14:37.130+02:00] - - flux -- terminated (137)
[14:14:37.130+02:00] - -----Logs-------------
[14:14:37.130+02:00] - - jf -- terminated (137)
[14:14:37.130+02:00] - -----Logs-------------
[14:14:37.130+02:00] - - jnlp -- terminated (143)
[14:14:37.130+02:00] - -----Logs-------------
[14:14:37.130+02:00] - - kubedock -- terminated (0)
[14:14:37.130+02:00] - -----Logs-------------
[14:14:37.130+02:00] - - maven -- terminated (137)
[14:14:37.130+02:00] - -----Logs-------------
[14:14:37.130+02:00] - - oc -- terminated (137)
[14:14:37.130+02:00] - -----Logs-------------
```

So reasons like `[Completed, EvictionByEvictionAPI, Error]` must NOT be ignored. Changing to all match to be ignored.

### Testing done

Just compile on my machine. Will let the CI test this PR, but I don't expect any side effect.

Not sure if can be easily tested using integration tests

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
