### PR TITLE
fix(PodTemplateUtils): override parent activeDeadlineSeconds by child value if not null

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
@@ -289,6 +289,9 @@ public class PodTemplateUtils {
                 ? parent.getSpec().getSchedulerName()
                 : template.getSpec().getSchedulerName();
 
+        Long activeDeadlineSeconds = template.getSpec().getActiveDeadlineSeconds() != null
+                ? template.getSpec().getActiveDeadlineSeconds()
+                : parent.getSpec().getActiveDeadlineSeconds();
         Boolean hostNetwork = template.getSpec().getHostNetwork() != null
                 ? template.getSpec().getHostNetwork()
                 : parent.getSpec().getHostNetwork();
@@ -345,6 +348,7 @@ public class PodTemplateUtils {
                 .withServiceAccount(serviceAccount) //
                 .withServiceAccountName(serviceAccountName) //
                 .withSchedulerName(schedulerName)
+                .withActiveDeadlineSeconds(activeDeadlineSeconds) //
                 .withHostNetwork(hostNetwork) //
                 .withContainers(combinedContainers) //
                 .withInitContainers(combinedInitContainers) //

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
@@ -421,6 +421,47 @@ public class PodTemplateUtilsTest {
     }
 
     @Test
+    public void childShouldOverrideParentActiveDeadlineSeconds() {
+        Pod parentPod = new PodBuilder()
+                .withNewMetadata()
+                .endMetadata()
+                .withNewSpec()
+                .withActiveDeadlineSeconds(1L)
+                .endSpec()
+                .build();
+        Pod childPod = new PodBuilder()
+                .withNewMetadata()
+                .endMetadata()
+                .withNewSpec()
+                .withActiveDeadlineSeconds(2L)
+                .endSpec()
+                .build();
+
+        Pod combinedPod = combine(parentPod, childPod);
+        assertEquals(combinedPod.getSpec().getActiveDeadlineSeconds(), Long.valueOf(2L));
+    }
+
+    @Test
+    public void shouldCombineActiveDeadlineSeconds() {
+        Pod parentPod = new PodBuilder()
+                .withNewMetadata()
+                .endMetadata()
+                .withNewSpec()
+                .withActiveDeadlineSeconds(1L)
+                .endSpec()
+                .build();
+        Pod childPod = new PodBuilder()
+                .withNewMetadata()
+                .endMetadata()
+                .withNewSpec()
+                .endSpec()
+                .build();
+
+        Pod combinedPod = combine(parentPod, childPod);
+        assertEquals(combinedPod.getSpec().getActiveDeadlineSeconds(), Long.valueOf(1L));
+    }
+
+    @Test
     public void shouldFilterOutNullOrEmptyPodKeyValueEnvVars() {
         PodTemplate template1 = new PodTemplate();
         KeyValueEnvVar podEnvVar1 = new KeyValueEnvVar("", "value-1");


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

`activeDeadlineSeconds` in `combine` for template Pods was ignored, parent value always use in combined Pod. 
```plain
Aug 04, 2024 3:53:41 PM FINEST org.csanchez.jenkins.plugins.kubernetes.PodTemplateUtils
Combining pods, parent: ---
apiVersion: "v1"
kind: "Pod"
metadata: {}
spec:
  activeDeadlineSeconds: 1800
  containers:
    ...
 template: ---
apiVersion: "v1"
kind: "Pod"
metadata: {}
spec:
  activeDeadlineSeconds: 43200
  containers:
    ...

Aug 04, 2024 3:53:41 PM FINEST org.csanchez.jenkins.plugins.kubernetes.PodTemplateUtils
Pods combined: ---
apiVersion: "v1"
kind: "Pod"
metadata: {}
spec:
  activeDeadlineSeconds: 1800
  containers:
    ...
```

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

I have added a case where the child value overrides the parent value. And the case when the template inherits the parent value.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
