### PR TITLE
(feat) support explicit fsGroup

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -188,6 +188,8 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
 
     private Long terminationGracePeriodSeconds;
 
+    private Long fsGroup;
+
     /**
      * Persisted yaml fragment
      */
@@ -912,6 +914,14 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
         this.terminationGracePeriodSeconds = terminationGracePeriodSeconds;
     }
 
+    public Long getFsGroup() {
+        return fsGroup;
+    }
+
+    public void setFsGroup(Long fsGroup) {
+        this.fsGroup = fsGroup;
+    }
+
     protected Object readResolve() {
         if (containers == null) {
             // upgrading from 0.8
@@ -1135,6 +1145,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
                 + (!privileged ? "" : ", privileged=" + privileged)
                 + (runAsUser == null ? "" : ", runAsUser=" + runAsUser)
                 + (runAsGroup == null ? "" : ", runAsGroup=" + runAsGroup)
+                + (fsGroup == null ? "": " ,runAsUser=" + runAsUser)
                 + (!isHostNetwork() ? "" : ", hostNetwork=" + hostNetwork)
                 + (!alwaysPullImage ? "" : ", alwaysPullImage=" + alwaysPullImage)
                 + (command == null ? "" : ", command='" + command + '\'')

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -279,7 +279,8 @@ public class PodTemplateBuilder {
         Long runAsUser = template.getRunAsUserAsLong();
         Long runAsGroup = template.getRunAsGroupAsLong();
         String supplementalGroups = template.getSupplementalGroups();
-        if (runAsUser != null || runAsGroup != null || supplementalGroups != null) {
+        Long fsGroup = template.getFsGroup();
+        if (runAsUser != null || runAsGroup != null || supplementalGroups != null || fsGroup != null) {
             var securityContext = builder.editOrNewSecurityContext();
             if (runAsUser != null) {
                 securityContext.withRunAsUser(runAsUser);
@@ -289,6 +290,9 @@ public class PodTemplateBuilder {
             }
             if (supplementalGroups != null) {
                 securityContext.withSupplementalGroups(parseSupplementalGroupList(supplementalGroups));
+            }
+            if (fsGroup != null) {
+                securityContext.withFsGroup(fsGroup);
             }
             securityContext.endSecurityContext();
         }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
@@ -435,6 +435,22 @@ public class PodTemplateUtils {
                                                     .getSecurityContext()
                                                     .getRunAsGroup()
                                             : null))
+                    .withFsGroup(
+                        template.getSpec().getSecurityContext() != null
+                                            && template.getSpec()
+                                                            .getSecurityContext()
+                                                            .getFsGroup() 
+                                                    != null
+                                    ? template.getSpec().getSecurityContext().getFsGroup()
+                                    : (parent.getSpec().getSecurityContext() != null
+                                                    && parent.getSpec()
+                                                                    .getSecurityContext()
+                                                                    .getFsGroup()
+                                                            != null
+                                            ? parent.getSpec()
+                                                    .getSecurityContext()
+                                                    .getFsGroup()
+                                            : null))
                     .endSecurityContext();
         }
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep.java
@@ -106,6 +106,9 @@ public class PodTemplateStep extends Step implements Serializable {
     @CheckForNull
     private String supplementalGroups;
 
+    @CheckForNull
+    private String fsGroup;
+
     @DataBoundConstructor
     public PodTemplateStep() {}
 
@@ -415,6 +418,16 @@ public class PodTemplateStep extends Step implements Serializable {
         this.supplementalGroups = Util.fixEmpty(supplementalGroups);
     }
 
+    @CheckForNull
+    public String getFsGroup() {
+        return this.fsGroup;
+    }
+
+    @DataBoundSetter
+    public void setFsGroup(String fsGroup) {
+        this.fsGroup = fsGroup;
+    }
+
     @Extension
     public static class DescriptorImpl extends StepDescriptor {
 
@@ -436,7 +449,8 @@ public class PodTemplateStep extends Step implements Serializable {
             "serviceAccount",
             "nodeSelector",
             "workingDir",
-            "workspaceVolume"
+            "workspaceVolume",
+            "fsGroup"
         };
 
         public DescriptorImpl() {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
@@ -147,6 +147,10 @@ public class PodTemplateStepExecution extends AbstractStepExecutionImpl {
             newTemplate.setActiveDeadlineSeconds(step.getActiveDeadlineSeconds());
         }
 
+        if (step.getFsGroup() != null) {
+            newTemplate.setFsGroup(Long.valueOf(step.getFsGroup()));
+        }
+
         for (ContainerTemplate container : newTemplate.getContainers()) {
             if (!PodTemplateUtils.validateContainerName(container.getName())) {
                 throw new AbortException(Messages.RFC1123_error(container.getName()));

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
@@ -130,4 +130,8 @@ THE SOFTWARE.
 
   <f:descriptorList title="${%Node Properties}" descriptors="${h.getNodePropertyDescriptors(descriptor.clazz)}" field="nodeProperties" />
 
+  <f:entry field="fsGroup" title="${%FS Group ID}">
+    <f:textbox/>
+  </f:entry>
+
 </j:jelly>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/help-fsGroup.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/help-fsGroup.html
@@ -1,0 +1,1 @@
+Specify the gid for the filesystem.

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep/config.jelly
@@ -83,5 +83,8 @@
         <f:entry field="workspaceVolume" title="${%Workspace Volume}">
             <f:dropdownDescriptorSelector field="workspaceVolume" default="${descriptor.defaultWorkspaceVolume}"/>
         </f:entry>
+        <f:entry field="fsGroup" title="${%FS Group ID}">
+          <f:textbox/>
+        </f:entry>
 	</f:advanced>
 </j:jelly>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep/help-fsGroup.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep/help-fsGroup.html
@@ -1,0 +1,1 @@
+Specify the gid for the filesystem.


### PR DESCRIPTION
added support to explicitly define the `fsGroup` according to https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context
I know that in theory it could be overwritten in yaml declaration but there seems to be an xor with limit definitions. explicitly setting it works

### Testing done

For testing i created a jenkins job with the following spec: 

```
podTemplate(cloud: 'test', containers: [containerTemplate(args: '9999999', command: 'sleep', image: 'jenkins/inbound-agent:3248.v65ecb_254c298-5', livenessProbe: containerLivenessProbe(execArgs: '', failureThreshold: 0, initialDelaySeconds: 0, periodSeconds: 0, successThreshold: 0, timeoutSeconds: 0), name: 'jnlp', resourceLimitCpu: '', resourceLimitEphemeralStorage: '', resourceLimitMemory: '', resourceRequestCpu: '', resourceRequestEphemeralStorage: '', resourceRequestMemory: '', workingDir: '/home/jenkins/agent')], fsGroup: '1000', name: 'test', namespace: 'default') {
    node(POD_LABEL) {
        stage('test') {
            echo "hello world"
        }
    }
}
```

and checked if the securityContext of the resulting pod is set to the expected fsGroup:

```yaml
  securityContext:
    fsGroup: 1000
```
which was set as expected

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
