### PR TITLE
[JENKINS-73788] Reduce metrics bloat relating to provisioning requests

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -2,7 +2,6 @@ package org.csanchez.jenkins.plugins.kubernetes;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.commons.lang.StringUtils.isEmpty;
-import static org.csanchez.jenkins.plugins.kubernetes.MetricNames.metricNameForLabel;
 
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
@@ -599,7 +598,6 @@ public class KubernetesCloud extends Cloud implements PodTemplateGroup {
             @NonNull final Cloud.CloudState state, final int excessWorkload) {
         var limitRegistrationResults = new LimitRegistrationResults(this);
         try {
-            Metrics.metricRegistry().meter(metricNameForLabel(state.getLabel())).mark(excessWorkload);
             Label label = state.getLabel();
             // Planned nodes, will be launched on the next round of NodeProvisioner
             int plannedCapacity = state.getAdditionalPlannedCapacity();

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/MetricNames.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/MetricNames.java
@@ -1,6 +1,5 @@
 package org.csanchez.jenkins.plugins.kubernetes;
 
-import hudson.model.Label;
 import java.util.Locale;
 
 public class MetricNames {
@@ -20,10 +19,5 @@ public class MetricNames {
     public static String metricNameForPodStatus(String status) {
         String formattedStatus = status == null ? "null" : status.toLowerCase(Locale.getDefault());
         return PREFIX + ".pods.launch.status." + formattedStatus;
-    }
-
-    public static String metricNameForLabel(Label label) {
-        String labelText = (label == null) ? "nolabel" : label.getDisplayName();
-        return String.format("%s.%s.provision.request", PREFIX, labelText);
     }
 }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/MetricNamesTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/MetricNamesTest.java
@@ -1,6 +1,5 @@
 package org.csanchez.jenkins.plugins.kubernetes;
 
-import hudson.model.labels.LabelAtom;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -26,22 +25,6 @@ public class MetricNamesTest {
     public void metricNameForPodStatusChangeStatusToLowercase() {
         String expected = "kubernetes.cloud.pods.launch.status.failed";
         String actual = MetricNames.metricNameForPodStatus("FaIlEd");
-
-        Assert.assertEquals(expected, actual);
-    }
-
-    @Test
-    public void metricNameForLabelAddsNoLabelIfLabelIsNull() {
-        String expected = "kubernetes.cloud.nolabel.provision.request";
-        String actual = MetricNames.metricNameForLabel(null);
-
-        Assert.assertEquals(expected, actual);
-    }
-
-    @Test
-    public void metricNameForLabelAddsLabelValue() {
-        String expected = "kubernetes.cloud.java.provision.request";
-        String actual = MetricNames.metricNameForLabel(new LabelAtom("java"));
 
         Assert.assertEquals(expected, actual);
     }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
@@ -252,10 +252,6 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
                 emptyIterable());
 
         assertTrue(Metrics.metricRegistry().counter(MetricNames.PODS_LAUNCHED).getCount() > 0);
-        assertTrue(Metrics.metricRegistry()
-                        .meter(MetricNames.metricNameForLabel(Label.parseExpression("runInPod")))
-                        .getCount()
-                > 0);
     }
 
     @Test


### PR DESCRIPTION
See https://issues.jenkins.io/browse/JENKINS-73788 for details

### Testing done

Compiled+unittested the plugin.
Installed to local Jenkins without issues.
Small scale test indicates that the troublesome metrics are no longer collected. I can roll this out to a larger Jenkins instance for more thorough (live) testing, but that will have to wait for our maintenance window.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
