### PR TITLE
[JENKINS-73789] empty certificate is valid now

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -702,7 +702,7 @@ public class KubernetesCloud extends Cloud implements PodTemplateGroup {
             return;
         }
         if (StringUtils.isBlank(serverCertificate)) {
-            throw new IllegalArgumentException(Messages.KubernetesCloud_serverCertificateKeyEmpty());
+            return; // JENKINS-73789, no certificate is accepted
         }
         try {
             PEMEncodable pem = PEMEncodable.decode(serverCertificate);

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudFIPSTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudFIPSTest.java
@@ -61,6 +61,10 @@ public class KubernetesCloudFIPSTest {
     @LocalData
     public void nonCompliantCloudsAreCleanedTest() {
         assertThat("compliant-cloud is loaded", r.jenkins.getCloud("compliant-cloud"), notNullValue());
+        assertThat(
+                "no certificate is a valid cloud",
+                r.jenkins.getCloud("no-certificate-compliant-cloud"),
+                notNullValue());
         assertThat("with-skip-tls is not loaded", r.jenkins.getCloud("with-skip-tls"), nullValue());
         assertThat("with-http-endpoint is not loaded", r.jenkins.getCloud("with-http-endpoint"), nullValue());
         assertThat("with-invalid-cert is not loaded", r.jenkins.getCloud("with-invalid-cert"), nullValue());

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudFIPSTest/nonCompliantCloudsAreCleanedTest/config.xml
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudFIPSTest/nonCompliantCloudsAreCleanedTest/config.xml
@@ -150,6 +150,27 @@ ovacsJACHC8VSwu0hEqevytqT7HH9E/DCMYORANJBZz5GyY=
       <waitForPodSec>600</waitForPodSec>
       <podRetention class="org.csanchez.jenkins.plugins.kubernetes.pod.retention.Never"/>
     </org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud>
+    <org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud plugin="kubernetes@999999-SNAPSHOT">
+        <name>no-certificate-compliant-cloud</name>
+        <templates/>
+        <serverUrl>https://example.org</serverUrl>
+        <useJenkinsProxy>false</useJenkinsProxy>
+        <skipTlsVerify>false</skipTlsVerify>
+        <addMasterProxyEnvVars>false</addMasterProxyEnvVars>
+        <capOnlyOnAlivePods>false</capOnlyOnAlivePods>
+        <restrictedPssSecurityContext>false</restrictedPssSecurityContext>
+        <webSocket>false</webSocket>
+        <directConnection>false</directConnection>
+        <containerCap>10</containerCap>
+        <retentionTimeout>5</retentionTimeout>
+        <connectTimeout>5</connectTimeout>
+        <readTimeout>15</readTimeout>
+        <podLabels/>
+        <usageRestricted>false</usageRestricted>
+        <maxRequestsPerHost>32</maxRequestsPerHost>
+        <waitForPodSec>600</waitForPodSec>
+        <podRetention class="org.csanchez.jenkins.plugins.kubernetes.pod.retention.Never"/>
+    </org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud>
   </clouds>
   <scmCheckoutRetryCount>0</scmCheckoutRetryCount>
   <views>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
https://issues.jenkins.io/browse/JENKINS-73789

This change updates the FIPS check, so now empty certificates are accepted. Certificates using an invalid key algorithm / size will still be rejected.

### Testing done
Added a new cloud creation in existing test with no certificate and checked it's created. 
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
