### PR TITLE
Use current context for validation functions

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -945,6 +945,7 @@ public class KubernetesCloud extends Cloud implements PodTemplateGroup {
         @RequirePOST
         @SuppressWarnings("unused") // used by jelly
         public FormValidation doTestConnection(
+                @AncestorInPath ItemGroup owner,
                 @QueryParameter String name,
                 @QueryParameter String serverUrl,
                 @QueryParameter String credentialsId,
@@ -953,9 +954,11 @@ public class KubernetesCloud extends Cloud implements PodTemplateGroup {
                 @QueryParameter String namespace,
                 @QueryParameter int connectionTimeout,
                 @QueryParameter int readTimeout,
-                @QueryParameter boolean useJenkinsProxy)
-                throws Exception {
-            Jenkins.get().checkPermission(Jenkins.MANAGE);
+                @QueryParameter boolean useJenkinsProxy) {
+
+            AccessControlled _context = (owner instanceof AccessControlled ? (AccessControlled) owner : Jenkins.get());
+
+            checkPermission(_context);
 
             if (StringUtils.isBlank(name)) return FormValidation.error("name is required");
 
@@ -964,6 +967,7 @@ public class KubernetesCloud extends Cloud implements PodTemplateGroup {
                             namespace,
                             Util.fixEmpty(serverCertificate),
                             Util.fixEmpty(credentialsId),
+                            owner,
                             skipTlsVerify,
                             connectionTimeout,
                             readTimeout,
@@ -994,8 +998,11 @@ public class KubernetesCloud extends Cloud implements PodTemplateGroup {
         @RequirePOST
         @SuppressWarnings({"unused", "lgtm[jenkins/csrf]"
         }) // used by jelly and already fixed jenkins security scan warning
-        public FormValidation doCheckSkipTlsVerify(@QueryParameter boolean skipTlsVerify) {
-            Jenkins.get().checkPermission(Jenkins.MANAGE);
+        public FormValidation doCheckSkipTlsVerify(
+                @AncestorInPath AccessControlled owner, @QueryParameter boolean skipTlsVerify) {
+            if (!hasPermission(owner)) {
+                return FormValidation.ok();
+            }
             try {
                 ensureSkipTlsVerifyInFipsMode(skipTlsVerify);
             } catch (IllegalArgumentException ex) {
@@ -1007,8 +1014,11 @@ public class KubernetesCloud extends Cloud implements PodTemplateGroup {
         @RequirePOST
         @SuppressWarnings({"unused", "lgtm[jenkins/csrf]"
         }) // used by jelly and already fixed jenkins security scan warning
-        public FormValidation doCheckServerCertificate(@QueryParameter String serverCertificate) {
-            Jenkins.get().checkPermission(Jenkins.MANAGE);
+        public FormValidation doCheckServerCertificate(
+                @AncestorInPath AccessControlled owner, @QueryParameter String serverCertificate) {
+            if (!hasPermission(owner)) {
+                return FormValidation.ok();
+            }
             try {
                 ensureServerCertificateInFipsMode(serverCertificate);
             } catch (IllegalArgumentException ex) {
@@ -1019,8 +1029,11 @@ public class KubernetesCloud extends Cloud implements PodTemplateGroup {
 
         @RequirePOST
         @SuppressWarnings("unused") // used by jelly
-        public FormValidation doCheckServerUrl(@QueryParameter String serverUrl) {
-            Jenkins.get().checkPermission(Jenkins.MANAGE);
+        public FormValidation doCheckServerUrl(
+                @AncestorInPath AccessControlled owner, @QueryParameter String serverUrl) {
+            if (!hasPermission(owner)) {
+                return FormValidation.ok();
+            }
             try {
                 ensureKubernetesUrlInFipsMode(serverUrl);
             } catch (IllegalArgumentException ex) {
@@ -1032,13 +1045,13 @@ public class KubernetesCloud extends Cloud implements PodTemplateGroup {
         @RequirePOST
         @SuppressWarnings("unused") // used by jelly
         public ListBoxModel doFillCredentialsIdItems(
-                @AncestorInPath ItemGroup context, @QueryParameter String serverUrl) {
-            Jenkins.get().checkPermission(Jenkins.MANAGE);
+                @AncestorInPath ItemGroup owner, @QueryParameter String serverUrl) {
+            checkPermission((owner instanceof AccessControlled ? (AccessControlled) owner : Jenkins.get()));
             StandardListBoxModel result = new StandardListBoxModel();
             result.includeEmptyValue();
             result.includeMatchingAs(
                     ACL.SYSTEM,
-                    context,
+                    owner,
                     StandardCredentials.class,
                     serverUrl != null ? URIRequirementBuilder.fromUri(serverUrl).build() : Collections.EMPTY_LIST,
                     CredentialsMatchers.anyOf(AuthenticationTokens.matcher(KubernetesAuth.class)));
@@ -1120,7 +1133,7 @@ public class KubernetesCloud extends Cloud implements PodTemplateGroup {
         private static boolean hasPermission(AccessControlled owner) {
             if (owner instanceof Jenkins) {
                 // Regular cloud
-                return owner.hasPermission(Jenkins.ADMINISTER);
+                return owner.hasPermission(Jenkins.MANAGE);
             } else if (owner instanceof Item) {
                 // Shared cloud (CloudBees CI)
                 return owner.hasPermission(Item.CONFIGURE);
@@ -1131,6 +1144,21 @@ public class KubernetesCloud extends Cloud implements PodTemplateGroup {
                                 + Stapler.getCurrentRequest().getOriginalRequestURI()
                                 + "). Please report this issue to the plugin maintainers.");
                 return false;
+            }
+        }
+
+        private static void checkPermission(AccessControlled owner) {
+            if (owner instanceof Jenkins) {
+                // Regular cloud
+                owner.checkPermission(Jenkins.MANAGE);
+            } else if (owner instanceof Item) {
+                // Shared cloud (CloudBees CI)
+                owner.checkPermission(Item.CONFIGURE);
+            } else {
+                throw new IllegalArgumentException(
+                        "Unsupported owner type " + (owner == null ? "null" : owner.getClass()) + " (url: "
+                                + Stapler.getCurrentRequest().getOriginalRequestURI()
+                                + "). Please report this issue to the plugin maintainers.");
             }
         }
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -1133,7 +1133,7 @@ public class KubernetesCloud extends Cloud implements PodTemplateGroup {
         private static boolean hasPermission(AccessControlled owner) {
             if (owner instanceof Jenkins) {
                 // Regular cloud
-                return owner.hasPermission(Jenkins.MANAGE);
+                return owner.hasPermission(Jenkins.ADMINISTER);
             } else if (owner instanceof Item) {
                 // Shared cloud (CloudBees CI)
                 return owner.hasPermission(Item.CONFIGURE);
@@ -1150,7 +1150,7 @@ public class KubernetesCloud extends Cloud implements PodTemplateGroup {
         private static void checkPermission(AccessControlled owner) {
             if (owner instanceof Jenkins) {
                 // Regular cloud
-                owner.checkPermission(Jenkins.MANAGE);
+                owner.checkPermission(Jenkins.ADMINISTER);
             } else if (owner instanceof Item) {
                 // Shared cloud (CloudBees CI)
                 owner.checkPermission(Item.CONFIGURE);

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudFIPSTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloudFIPSTest.java
@@ -81,26 +81,32 @@ public class KubernetesCloudFIPSTest {
                 .orElseGet(KubernetesCloud.DescriptorImpl::new);
         assertThat(
                 "Valid url doesn't raise error",
-                descriptor.doCheckServerUrl("https://eample.org").getMessage(),
+                descriptor.doCheckServerUrl(r.jenkins, "https://eample.org").getMessage(),
                 nullValue());
         assertThat(
                 "Invalid url raises error",
-                descriptor.doCheckServerUrl("http://eample.org").getMessage(),
+                descriptor.doCheckServerUrl(r.jenkins, "http://eample.org").getMessage(),
                 notNullValue());
         assertThat(
                 "Valid cert doesn't raise error",
-                descriptor.doCheckServerCertificate(getCert("rsa2048")).getMessage(),
+                descriptor
+                        .doCheckServerCertificate(r.jenkins, getCert("rsa2048"))
+                        .getMessage(),
                 nullValue());
         assertThat(
                 "Invalid cert raises error",
-                descriptor.doCheckServerCertificate(getCert("rsa1024")).getMessage(),
+                descriptor
+                        .doCheckServerCertificate(r.jenkins, getCert("rsa1024"))
+                        .getMessage(),
                 notNullValue());
         assertThat(
                 "No TLS skip doesn't raise error",
-                descriptor.doCheckSkipTlsVerify(false).getMessage(),
+                descriptor.doCheckSkipTlsVerify(r.jenkins, false).getMessage(),
                 nullValue());
         assertThat(
-                "TLS skip raises error", descriptor.doCheckSkipTlsVerify(true).getMessage(), notNullValue());
+                "TLS skip raises error",
+                descriptor.doCheckSkipTlsVerify(r.jenkins, true).getMessage(),
+                notNullValue());
     }
 
     private String getCert(String alg) throws IOException {


### PR DESCRIPTION
Following https://github.com/jenkinsci/kubernetes-plugin/pull/746. Using the context is useful in CloudBees plugin that allow managing Kubernetes Cloud within folders.

cc @Vlatombe @jglick 

### Testing done

* Tested creation of new cloud under **Manage Jenkins > Cloud**
* Tested configuration of new cloud under **Manage Jenkins > Cloud**
* Tested creation of new Kubernetes Shared Cloud in a folder (CloudBees instance)
* Tested configuration of new Kubernetes Shared Cloud in a folder (CloudBees instance)

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
