### PR TITLE
Use configured registry for jenkins-agent when running in agent-injection mode

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -331,13 +331,13 @@ public class PodTemplateBuilder {
         pod.getSpec().getContainers().stream()
                 .filter(c -> c.getWorkingDir() == null)
                 .forEach(c -> c.setWorkingDir(workingDir));
+        String agentImage = DEFAULT_AGENT_IMAGE;
+        if (cloud != null && StringUtils.isNotEmpty(cloud.getJnlpregistry())) {
+            agentImage = Util.ensureEndsWith(cloud.getJnlpregistry(), "/") + agentImage;
+        } else if (StringUtils.isNotEmpty(DEFAULT_JNLP_DOCKER_REGISTRY_PREFIX)) {
+            agentImage = Util.ensureEndsWith(DEFAULT_JNLP_DOCKER_REGISTRY_PREFIX, "/") + agentImage;
+        }
         if (StringUtils.isBlank(agentContainer.getImage())) {
-            String agentImage = DEFAULT_AGENT_IMAGE;
-            if (cloud != null && StringUtils.isNotEmpty(cloud.getJnlpregistry())) {
-                agentImage = Util.ensureEndsWith(cloud.getJnlpregistry(), "/") + agentImage;
-            } else if (StringUtils.isNotEmpty(DEFAULT_JNLP_DOCKER_REGISTRY_PREFIX)) {
-                agentImage = Util.ensureEndsWith(DEFAULT_JNLP_DOCKER_REGISTRY_PREFIX, "/") + agentImage;
-            }
             agentContainer.setImage(agentImage);
         }
         Map<String, EnvVar> envVars = new HashMap<>();
@@ -352,7 +352,7 @@ public class PodTemplateBuilder {
             var oldInitContainers = pod.getSpec().getInitContainers();
             var jenkinsAgentInitContainer = new ContainerBuilder()
                     .withName("set-up-jenkins-agent")
-                    .withImage(DEFAULT_AGENT_IMAGE)
+                    .withImage(agentImage)
                     .withCommand(
                             "/bin/sh",
                             "-c",


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

I was previously using an ECR Pull Through Cache for the `inbound-agent` image, but this wasn't respected when using `agentInjection: true`. This PR fixes that

### Testing done

Added a unit test, and tested on my own Jenkins instance - expected behaviour present

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
