### PR TITLE
`KubernetesAgentErrorCondition` failed to handle DR

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesAgentErrorCondition.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesAgentErrorCondition.java
@@ -128,7 +128,7 @@ public class KubernetesAgentErrorCondition extends ErrorCondition {
                 }
                 Set<String> terminationReasons =
                         ExtensionList.lookupSingleton(Reaper.class).terminationReasons(node);
-                if (terminationReasons.stream().allMatch(IGNORED_CONTAINER_TERMINATION_REASONS::contains)) {
+                if (!terminationReasons.isEmpty() && terminationReasons.stream().allMatch(IGNORED_CONTAINER_TERMINATION_REASONS::contains)) {
                     listener.getLogger()
                             .println("Ignored termination reason(s) for " + node + " for purposes of retry: "
                                     + terminationReasons);

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesAgentErrorCondition.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesAgentErrorCondition.java
@@ -128,7 +128,8 @@ public class KubernetesAgentErrorCondition extends ErrorCondition {
                 }
                 Set<String> terminationReasons =
                         ExtensionList.lookupSingleton(Reaper.class).terminationReasons(node);
-                if (!terminationReasons.isEmpty() && terminationReasons.stream().allMatch(IGNORED_CONTAINER_TERMINATION_REASONS::contains)) {
+                if (!terminationReasons.isEmpty()
+                        && terminationReasons.stream().allMatch(IGNORED_CONTAINER_TERMINATION_REASONS::contains)) {
                     listener.getLogger()
                             .println("Ignored termination reason(s) for " + node + " for purposes of retry: "
                                     + terminationReasons);


### PR DESCRIPTION
I ran a disaster recover scenario where a controller started in a fresh cluster with no record of old `Pod`s. Of course the agent used by a running build did not reattach, but then the log printed

```
Ignored termination reason(s) for …-f8fp6-qkfpk-htdxt for purposes of retry: []
```

and did not retry the stage. In this scenario we do not expect there to be any recorded termination reasons, so we _do_ want to retry. I suspect this is a regression from #1582.

([CloudBees-internal reference](https://cloudbees.atlassian.net/browse/BEE-53208))