### PR TITLE
Make Restricted PSS security context work together with agent injection

### DIFF
--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/AbstractGoldenFileTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/AbstractGoldenFileTest.java
@@ -27,10 +27,10 @@ abstract class AbstractGoldenFileTest {
     protected void test(String name) throws IOException {
         var beforeYAML = loadFileAsStream(name + "-before.yaml");
         var before = Serialization.unmarshal(beforeYAML, Pod.class);
-        assertEquals(name + "-before.yaml is not normalized", beforeYAML, Serialization.asYaml(before));
+        assertEquals(name + "-before.yaml is not normalized", Serialization.asYaml(before), beforeYAML);
         var afterYAML = loadFileAsStream(name + "-after.yaml");
         var after = decorator.decorate(cloud, before);
-        assertEquals(name + "-after.yaml processed", afterYAML, Serialization.asYaml(after));
+        assertEquals(name + "-after.yaml processed", Serialization.asYaml(after), afterYAML);
     }
 
     @NonNull

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/RestrictedPssSecurityInjectorTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/RestrictedPssSecurityInjectorTest.java
@@ -30,4 +30,9 @@ public class RestrictedPssSecurityInjectorTest extends AbstractGoldenFileTest {
     public void existingSecurityContext() throws IOException {
         test("existingSecurityContext");
     }
+
+    @Test
+    public void agentInjection() throws IOException {
+        test("agentInjection");
+    }
 }

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/RestrictedPssSecurityInjectorTest/agentInjection-after.yaml
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/RestrictedPssSecurityInjectorTest/agentInjection-after.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: "v1"
+kind: "Pod"
+metadata:
+  name: "simple"
+  namespace: "jenkins"
+spec:
+  containers:
+  - env:
+    - name: "JENKINS_SECRET"
+      value: "my-little-secret"
+    - name: "JENKINS_AGENT_NAME"
+      value: "my-lovely-agent"
+    - name: "REMOTING_OPTS"
+      value: "-noReconnectAfter 1d"
+    - name: "JENKINS_NAME"
+      value: "my-lovely-agent"
+    - name: "JENKINS_AGENT_WORKDIR"
+      value: "/home/jenkins/agent"
+    - name: "JENKINS_URL"
+      value: "http://localhost/"
+    image: "jenkins/inbound-agent"
+    name: "maven"
+    resources:
+      limits:
+        cpu: "1"
+        memory: "768Mi"
+      requests:
+        cpu: "1"
+        memory: "768Mi"
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - "ALL"
+      runAsNonRoot: true
+      seccompProfile:
+        type: "RuntimeDefault"
+    volumeMounts:
+    - mountPath: "/jenkins-agent"
+      name: "jenkins-agent"
+    - mountPath: "/home/jenkins/agent"
+      name: "workspace-volume"
+      readOnly: false
+  initContainers:
+  - command:
+    - "/bin/sh"
+    - "-c"
+    - "cp $(command -v jenkins-agent) /jenkins-agent/jenkins-agent;cp /usr/share/jenkins/agent.jar\
+      \ /jenkins-agent/agent.jar;sed -i 's!-jar .*agent.jar!-jar /jenkins-agent\\\
+      /agent.jar!' /jenkins-agent/jenkins-agent"
+    image: "jenkins/inbound-agent:3261.v9c670a_4748a_9-1"
+    name: "set-up-jenkins-agent"
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - "ALL"
+      runAsNonRoot: true
+      seccompProfile:
+        type: "RuntimeDefault"
+    volumeMounts:
+    - mountPath: "/jenkins-agent"
+      name: "jenkins-agent"
+  volumes:
+  - emptyDir:
+      medium: ""
+    name: "workspace-volume"

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/RestrictedPssSecurityInjectorTest/agentInjection-before.yaml
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/RestrictedPssSecurityInjectorTest/agentInjection-before.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: "v1"
+kind: "Pod"
+metadata:
+  name: "simple"
+  namespace: "jenkins"
+spec:
+  containers:
+  - env:
+    - name: "JENKINS_SECRET"
+      value: "my-little-secret"
+    - name: "JENKINS_AGENT_NAME"
+      value: "my-lovely-agent"
+    - name: "REMOTING_OPTS"
+      value: "-noReconnectAfter 1d"
+    - name: "JENKINS_NAME"
+      value: "my-lovely-agent"
+    - name: "JENKINS_AGENT_WORKDIR"
+      value: "/home/jenkins/agent"
+    - name: "JENKINS_URL"
+      value: "http://localhost/"
+    image: "jenkins/inbound-agent"
+    name: "maven"
+    resources:
+      limits:
+        cpu: "1"
+        memory: "768Mi"
+      requests:
+        cpu: "1"
+        memory: "768Mi"
+    volumeMounts:
+    - mountPath: "/jenkins-agent"
+      name: "jenkins-agent"
+    - mountPath: "/home/jenkins/agent"
+      name: "workspace-volume"
+      readOnly: false
+  initContainers:
+  - command:
+    - "/bin/sh"
+    - "-c"
+    - "cp $(command -v jenkins-agent) /jenkins-agent/jenkins-agent;cp /usr/share/jenkins/agent.jar\
+      \ /jenkins-agent/agent.jar;sed -i 's!-jar .*agent.jar!-jar /jenkins-agent\\\
+      /agent.jar!' /jenkins-agent/jenkins-agent"
+    image: "jenkins/inbound-agent:3261.v9c670a_4748a_9-1"
+    name: "set-up-jenkins-agent"
+    volumeMounts:
+    - mountPath: "/jenkins-agent"
+      name: "jenkins-agent"
+  volumes:
+  - emptyDir:
+      medium: ""
+    name: "workspace-volume"


### PR DESCRIPTION
When using both `agentInjection: true` and the checkbox "Inject restricted PSS security context in agent container definition" in an environment using restricted PSS, then the resulting pod can't be scheduled because the init container doesn't have the proper security context set.

This modifies the existing PSS logic to decorate as well init containers.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
