### PR TITLE
JENKINS-74950 - Improve the K8s Maven sample to run in resources limited environments

### DIFF
--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/samples/maven.groovy
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/samples/maven.groovy
@@ -12,6 +12,11 @@ spec:
   - name: maven
     # In a real Jenkinsfile, it is recommended to pin to a specific version and use Dependabot or Renovate to bump it.
     image: maven:latest
+    resources:
+      requests:
+        memory: "256Mi"
+      limits:
+        memory: "512Mi"
     command:
     - sleep
     args:


### PR DESCRIPTION
[JENKINS-74950 - Improve the K8s Maven sample to run in resources limited environments](https://issues.jenkins.io/browse/JENKINS-74950)

The sample "kubernetes-maven.groovy" does not specify any  request or limit.

In resource limited environments it could fail due to OOM events.

We have reproduced this issue by running it in a pod with memoty limited to 256Mi.

We have modified the current sample to add requests and limits for memory.

```
spec:
  containers:
  - resources:
      requests:
        memory: "256Mi"
      limits:
        memory: "512Mi" 
```
<!-- Please describe your pull request here. -->

### Testing done
Manual test have been performed to confirm the script works properly in limited environments that was failing with the original sample.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes --> Does not apply
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
