### PR TITLE
[JENKINS-74992] Avoid NPE on informers

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/watch/PodStatusEventHandler.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/watch/PodStatusEventHandler.java
@@ -50,7 +50,9 @@ public class PodStatusEventHandler implements ResourceEventHandler<Pod> {
             // not interesting
             return "";
         }
-        String formatted = String.format("%n\tPod [%s][%s] %s", phase, c.getReason(), c.getMessage());
+        String message = c.getMessage();
+        String formatted =
+                String.format("%n\tPod [%s][%s] %s", phase, c.getReason(), message != null ? message : "No message");
         return sb.indexOf(formatted) == -1 ? formatted : "";
     }
 


### PR DESCRIPTION
I found out when working on a CloudBees proprietary feature that `KubernetesCloud#readResolve` is not always called on deserialization. I think this will not happen in OSS, but let's stay on the safe side and initialize the field before using it.

Following up https://github.com/jenkinsci/kubernetes-plugin/pull/1627

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
