### PR TITLE
Improve accuracy of PodTemplate's instance cap help-text

### DIFF
--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/help-instanceCap.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/help-instanceCap.html
@@ -1,5 +1,5 @@
 <p>
 The maximum number of concurrently running agent pods created from this template that are permitted in the Kubernetes Cloud.<br/>
 The number of running agents will never exceed the global concurrency limit sets at the Cloud Configuration level.<br/>
-If set to empty, zero or negative number it means no limit.
+If set to empty or a negative number it means no limit.
 </p>


### PR DESCRIPTION
https://github.com/jenkinsci/kubernetes-plugin/pull/919 updated the help text for a PodTemplate's instanceCap to indicate that '0' is an unlimited value. In practice, while '0' does act as unlimited for the **cloud** containerCap, it really means "zero instances" for a pod template.

The PodTemplate treatment of a 0 instanceCap is determined by [PodTemplate.setInstanceCap](https://github.com/jenkinsci/kubernetes-plugin/blob/8b0d329ed8ec4e30bb5540553bf279541ee4bcba/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java#L377-L384), where we only get `Integer.MAX_VALUE if instanceCap < 0`. To make things extra confusing, this is different from the [same setter for the podTemplate pipeline step](https://github.com/jenkinsci/kubernetes-plugin/blob/8b0d329ed8ec4e30bb5540553bf279541ee4bcba/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep.java#L246-L253), where we get `Integer.MAX_VALUE if instanceCap <= 0`.

Even though the current behavior is inconsistent, I guess it would be a bad idea to try and change the actual behavior of a 0 instanceCap, as that would activate any templates that people might currently be keeping inactive with the setting. So instead, we can at least provide accurate help text for the pod template instanceCap.

### Testing done

With the latest version of the kubernetes-plugin installed, I create a single pod template in the global cloud config with no instance cap configured. With no other jobs running, I can trigger a build using that template's label and the node is immediately provisioned. If I modify the pod template configuration to have an instanceCap of "0", then no node is ever provisioned. The current help text for the instanceCap setting indicates it should still provision the node.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
