### PR TITLE
Better `toString` for `KubernetesComputer` and `KubernetesSlave`

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesComputer.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesComputer.java
@@ -155,9 +155,10 @@ public class KubernetesComputer extends AbstractCloudComputer<KubernetesSlave> {
         new LargeText(outputStream, false).doProgressText(req, rsp);
     }
 
+    // TODO delete after https://github.com/jenkinsci/jenkins/pull/10595
     @Override
     public String toString() {
-        return String.format("KubernetesComputer name: %s agent: %s", getName(), getNode());
+        return String.format("KubernetesComputer[%s]", getNode());
     }
 
     @Override

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
@@ -456,11 +456,6 @@ public class KubernetesSlave extends AbstractCloudSlave {
     }
 
     @Override
-    public String toString() {
-        return String.format("KubernetesSlave name: %s", name);
-    }
-
-    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;


### PR DESCRIPTION
Complementing https://github.com/jenkinsci/jenkins/pull/10595. `KubernetesSlave.super.toString()` was already fine. `KubernetesComputer.toString()` currently includes the node name twice.