### PR TITLE
Option to disable diagnostic pod provisioning in build logs

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
@@ -54,6 +54,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import jenkins.metrics.api.Metrics;
+import jenkins.util.SystemProperties;
 import org.apache.commons.lang.StringUtils;
 import org.csanchez.jenkins.plugins.kubernetes.pod.decorator.PodDecoratorException;
 import org.csanchez.jenkins.plugins.kubernetes.pod.retention.Reaper;
@@ -72,6 +73,9 @@ public class KubernetesLauncher extends JNLPLauncher {
     private static final Logger LOGGER = Logger.getLogger(KubernetesLauncher.class.getName());
 
     private volatile boolean launched = false;
+
+    private static final boolean DISABLE_DIAGNOSTIC_LOGS =
+            SystemProperties.getBoolean(KubernetesLauncher.class.getName() + ".disableDiagnosticLogs", false);
 
     /**
      * Provisioning exception if any.
@@ -146,7 +150,9 @@ public class KubernetesLauncher extends JNLPLauncher {
             node.setNamespace(namespace);
 
             // register a namespace informer (if not registered yet) to show relevant pod events in build logs
-            cloud.registerPodInformer(node);
+            if (!DISABLE_DIAGNOSTIC_LOGS) {
+                cloud.registerPodInformer(node);
+            }
 
             // if the controller was interrupted after creating the pod but before it connected back, then
             // the pod might already exist and the creating logic must be skipped.


### PR DESCRIPTION
Start Jenkins with `-Dorg.csanchez.jenkins.plugins.kubernetes.KubernetesLauncher.disableDiagnosticLogs=true` to disable diagnostic pod provisioning in build logs.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
