### PR TITLE
Extract pod name generation functions

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
@@ -34,7 +34,6 @@ import io.fabric8.kubernetes.client.utils.Serialization;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.HashSet;
-import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -47,7 +46,6 @@ import java.util.logging.Logger;
 import jenkins.metrics.api.Metrics;
 import jenkins.model.Jenkins;
 import jenkins.security.MasterToSlaveCallable;
-import org.apache.commons.lang.RandomStringUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.Validate;
 import org.csanchez.jenkins.plugins.kubernetes.pod.retention.PodRetention;
@@ -302,19 +300,16 @@ public class KubernetesSlave extends AbstractCloudSlave {
     }
 
     static String getSlaveName(PodTemplate template) {
-        String randString = RandomStringUtils.random(5, "bcdfghjklmnpqrstvwxz0123456789");
         String name = template.getName();
         if (StringUtils.isEmpty(name)) {
-            return String.format("%s-%s", DEFAULT_AGENT_PREFIX, randString);
+            name = DEFAULT_AGENT_PREFIX;
         }
-        // no spaces
-        name = name.replaceAll("[ _]", "-").toLowerCase(Locale.getDefault());
-        // keep it under 63 chars (62 is used to account for the '-')
-        name = name.substring(0, Math.min(name.length(), 62 - randString.length()));
-        String slaveName = String.format("%s-%s", name, randString);
-        if (!slaveName.matches("[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*")) {
-            return String.format("%s-%s", DEFAULT_AGENT_PREFIX, randString);
+
+        String slaveName = PodUtils.createNameWithRandomSuffix(name);
+        if (!PodUtils.isValidName(slaveName)) {
+            slaveName = PodUtils.createNameWithRandomSuffix(DEFAULT_AGENT_PREFIX);
         }
+
         return slaveName;
     }
 

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodUtilsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodUtilsTest.java
@@ -1,0 +1,59 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.IntStream;
+import org.apache.commons.lang.StringUtils;
+import org.junit.Test;
+
+public class PodUtilsTest {
+
+    @Test
+    public void generateRandomSuffix() {
+        List<String> generated = IntStream.range(0, 100)
+                .mapToObj(i -> PodUtils.generateRandomSuffix())
+                .toList();
+        Set<String> unique = new HashSet<>(generated);
+        assertEquals(generated.size(), unique.size());
+
+        for (String suffix : generated) {
+            assertEquals(5, suffix.length());
+            assertTrue(PodUtils.isValidName(suffix));
+        }
+    }
+
+    @Test
+    public void createNameWithRandomSuffix() {
+        String name = PodUtils.createNameWithRandomSuffix("foo");
+        assertEquals(9, name.length());
+        assertTrue(name.startsWith("foo-"));
+        assertTrue(PodUtils.isValidName(name));
+
+        // names with invalid characters
+        name = PodUtils.createNameWithRandomSuffix("foo bar_cat");
+        assertEquals(17, name.length());
+        assertTrue(name.startsWith("foo-bar-cat-"));
+
+        // very long names
+        name = PodUtils.createNameWithRandomSuffix(StringUtils.repeat("a", 70));
+        assertEquals(63, name.length());
+        assertTrue(name.startsWith(StringUtils.repeat("a", 57) + "-"));
+    }
+
+    @Test
+    public void isValidName() {
+        assertTrue(PodUtils.isValidName("foo"));
+        assertTrue(PodUtils.isValidName("foo-bar"));
+        assertTrue(PodUtils.isValidName("foo.bar"));
+        assertTrue(PodUtils.isValidName("foo.123"));
+        assertTrue(PodUtils.isValidName("123-foo"));
+        assertFalse(PodUtils.isValidName("foo bar"));
+        assertFalse(PodUtils.isValidName("-foo"));
+        assertFalse(PodUtils.isValidName(".foo"));
+    }
+}


### PR DESCRIPTION
Extract pod name generation functions to PodUtils for better testability and
reusability.

> This pull request is part of a series of small changes and enhancements to support a new plugin to add ephemeral container support to Kubernetes agents. This feature was originally built as an enhancement to this plugin and has been running in live production environment for a few years. CloudBees engineers suggested we create a new plugin rather than contribute here. https://github.com/jenkinsci/kubernetes-plugin/compare/master...cronik:kubernetes-plugin:feature/ephemeral-containers


### Testing done

Added unit tests and have been running in production environment for a few years.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
