### PR TITLE
Print pod last lines to system logs on failure

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/retention/Reaper.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/retention/Reaper.java
@@ -547,6 +547,9 @@ public class Reaper extends ComputerListener {
             String lines = PodUtils.logLastLines(pod, node.getKubernetesCloud().connect());
             if (lines != null) {
                 runListener.getLogger().print(lines);
+                String ns = pod.getMetadata().getNamespace();
+                String name = pod.getMetadata().getName();
+                LOGGER.fine(() -> ns + "/" + name + " log:\n" + lines);
             }
         } catch (KubernetesAuthException e) {
             LOGGER.log(Level.FINE, e, () -> "Unable to get logs after pod failed event");


### PR DESCRIPTION
Minor enhancement to Reaper to improve debugging of Pod failures. In many cases the TaskListener returned by the slave is a NULL instance so the pod last lines are not visible. This change makes these logs available as "FINE" system logs.


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
