### PR TITLE
Refactor ContainerTemplate command split function

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
@@ -32,6 +32,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -53,6 +54,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.lang.StringUtils;
+import org.apache.tools.ant.types.Commandline;
 import org.csanchez.jenkins.plugins.kubernetes.model.TemplateEnvVar;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.PodVolume;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.workspace.WorkspaceVolume;
@@ -739,6 +741,27 @@ public class PodTemplateUtils {
     /** TODO perhaps enforce https://docs.docker.com/engine/reference/commandline/tag/#extended-description */
     public static boolean validateImage(String image) {
         return image != null && image.matches("\\S+");
+    }
+
+    /**
+     * Split a command in the parts that Docker need
+     *
+     * @param commandLine docker command to parse
+     * @return command split by arguments, {@code null} if {@code commandLine} is {@code null} or empty
+     */
+    public static @Nullable List<String> splitCommandLine(@Nullable String commandLine) {
+        if (commandLine == null || commandLine.isEmpty()) {
+            return null;
+        }
+
+        String[] args = Commandline.translateCommandline(commandLine);
+        if (SUBSTITUTE_ENV) {
+            for (int i = 0; i < args.length; i++) {
+                args[i] = substituteEnv(args[i]);
+            }
+        }
+
+        return Arrays.asList(args);
     }
 
     /**

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
@@ -8,7 +8,6 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 
@@ -57,7 +56,6 @@ import org.jvnet.hudson.test.FlagRule;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.LoggerRule;
-import org.jvnet.hudson.test.WithoutJenkins;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnit;
@@ -97,36 +95,6 @@ public class PodTemplateBuilderTest {
     @Before
     public void setUp() {
         when(slave.getKubernetesCloud()).thenReturn(cloud);
-    }
-
-    @WithoutJenkins
-    @Test
-    public void testParseDockerCommand() {
-        assertNull(parseDockerCommand(""));
-        assertNull(parseDockerCommand(null));
-        assertEquals(Collections.singletonList("bash"), parseDockerCommand("bash"));
-        assertEquals(
-                Collections.unmodifiableList(Arrays.asList("bash", "-c", "x y")),
-                parseDockerCommand("bash -c \"x y\""));
-        assertEquals(Collections.unmodifiableList(Arrays.asList("a", "b", "c", "d")), parseDockerCommand("a b c d"));
-    }
-
-    @WithoutJenkins
-    @Test
-    public void testParseLivenessProbe() {
-        assertNull(parseLivenessProbe(""));
-        assertNull(parseLivenessProbe(null));
-        assertEquals(Collections.unmodifiableList(Arrays.asList("docker", "info")), parseLivenessProbe("docker info"));
-        assertEquals(
-                Collections.unmodifiableList(Arrays.asList("echo", "I said: 'I am alive'")),
-                parseLivenessProbe("echo \"I said: 'I am alive'\""));
-        assertEquals(
-                Collections.unmodifiableList(Arrays.asList("docker", "--version")),
-                parseLivenessProbe("docker --version"));
-        assertEquals(
-                Collections.unmodifiableList(
-                        Arrays.asList("curl", "-k", "--silent", "--output=/dev/null", "https://localhost:8080")),
-                parseLivenessProbe("curl -k --silent --output=/dev/null \"https://localhost:8080\""));
     }
 
     @Test


### PR DESCRIPTION
This change delegates `PodTemplateBuilder` command line split functions to a new `PodTemplateUtils#splitCommandLine` function. This new function improves command line quote handling, including support for single quotes.

This new function was moved to `PodTemplateUtils` so it is in the same class as `substituteEnv`, which it depends on, and so it can be used extensions that might need to build a fabric8 model from a `ContainerTemplate`.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
