### PR TITLE
Improved container logs

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodContainerSource.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodContainerSource.java
@@ -9,11 +9,10 @@ import io.fabric8.kubernetes.api.model.ContainerStatus;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.PodStatus;
-import org.apache.commons.lang.StringUtils;
-
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import org.apache.commons.lang.StringUtils;
 
 /**
  * Pod container sources are responsible to locating details about Pod containers.

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodContainerSourceTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodContainerSourceTest.java
@@ -8,9 +8,8 @@ import io.fabric8.kubernetes.api.model.ContainerStatus;
 import io.fabric8.kubernetes.api.model.EphemeralContainer;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
-import java.util.Optional;
-
 import io.fabric8.kubernetes.api.model.PodStatus;
+import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Rule;
 import org.junit.Test;
@@ -178,7 +177,5 @@ public class PodContainerSourceTest {
                     .filter(cs -> StringUtils.equals(cs.getName(), containerName))
                     .findFirst();
         }
-
-
     }
 }


### PR DESCRIPTION
This change updateds `KubernetesComputer` container logs endpoint by supporting `PodContainerSource` extensions and handing slave not found, pod not found, container not found, and terminated containers.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
