### PR TITLE
Make KubernetesNodeContext public

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesNodeContext.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesNodeContext.java
@@ -16,48 +16,89 @@
 
 package org.csanchez.jenkins.plugins.kubernetes.pipeline;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.AbortException;
 import hudson.model.Node;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.PodResource;
 import java.io.IOException;
 import java.io.Serializable;
 import org.csanchez.jenkins.plugins.kubernetes.KubernetesSlave;
+import org.jenkinsci.plugins.kubernetes.auth.KubernetesAuthException;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 
 /**
  * helper class for steps running in a kubernetes `node` context
  */
-class KubernetesNodeContext implements Serializable {
+public class KubernetesNodeContext implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private StepContext context;
+    private final StepContext context;
+    private final String podName;
 
-    private String podName;
-    private String namespace;
+    @CheckForNull
+    private final String namespace;
 
-    KubernetesNodeContext(StepContext context) throws Exception {
+    /**
+     * Create new Kubernetes context
+     * @param context step context, not null
+     * @throws Exception if {@link Node} context not instance of {@link KubernetesSlave} or interrupted.
+     */
+    public KubernetesNodeContext(@NonNull StepContext context) throws Exception {
         this.context = context;
         KubernetesSlave agent = getKubernetesSlave();
         this.podName = agent.getPodName();
         this.namespace = agent.getNamespace();
     }
 
-    // TODO remove the Exception thrown
-    String getPodName() throws Exception {
+    /**
+     * Kubernetes Pod name.
+     * @return pod name, never {@code null}
+     */
+    @NonNull
+    public String getPodName() {
         return podName;
     }
 
-    // TODO remove the Exception thrown
-    public String getNamespace() throws Exception {
+    /**
+     * Kubernetes namespace Pod is running in.
+     * @return kubernetes namespace or {@code null}
+     */
+    @Nullable
+    public String getNamespace() {
         return namespace;
+    }
+
+    /**
+     * Get node {@link PodResource}.
+     * @return client pod resource, never {@code null}
+     * @throws IOException if IO exception
+     * @throws InterruptedException if interrupted
+     * @throws KubernetesAuthException if authentication failure
+     * @see org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud#getPodResource(String, String)
+     */
+    @NonNull
+    public PodResource getPodResource() throws IOException, InterruptedException, KubernetesAuthException {
+        return getKubernetesSlave().getKubernetesCloud().getPodResource(namespace, podName);
     }
 
     KubernetesClient connectToCloud() throws Exception {
         return getKubernetesSlave().getKubernetesCloud().connect();
     }
 
-    private KubernetesSlave getKubernetesSlave() throws IOException, InterruptedException {
+    /**
+     * Get {@link Node} from the {@link StepContext}. If the context instance is instance of
+     * {@link KubernetesSlave} it will be returned otherwise an exception is thrown.
+     * @return kubernetes slave node context, never {@code null}
+     * @throws IOException if IO exception
+     * @throws InterruptedException if interrupted
+     * @throws AbortException if {@link Node} context is not instance of {@link KubernetesSlave}
+     */
+    @NonNull
+    public final KubernetesSlave getKubernetesSlave() throws IOException, InterruptedException {
         Node node = context.get(Node.class);
         if (!(node instanceof KubernetesSlave)) {
             throw new AbortException(

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesNodeContextTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesNodeContextTest.java
@@ -1,0 +1,63 @@
+package org.csanchez.jenkins.plugins.kubernetes.pipeline;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import hudson.AbortException;
+import hudson.model.Node;
+import io.fabric8.kubernetes.client.dsl.PodResource;
+import org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud;
+import org.csanchez.jenkins.plugins.kubernetes.KubernetesSlave;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class KubernetesNodeContextTest {
+
+    @Mock
+    private StepContext context;
+
+    @Mock
+    private KubernetesSlave slave;
+
+    @Mock
+    private KubernetesCloud cloud;
+
+    @Mock
+    private PodResource podResource;
+
+    @Before
+    public void setup() {
+        when(slave.getKubernetesCloud()).thenReturn(cloud);
+        when(slave.getPodName()).thenReturn("foo");
+        when(slave.getNamespace()).thenReturn("bar");
+    }
+
+    @Test
+    public void createContext() throws Exception {
+        when(cloud.getPodResource("bar", "foo")).thenReturn(podResource);
+        when(context.get(Node.class)).thenReturn(slave);
+        KubernetesNodeContext knc = new KubernetesNodeContext(context);
+        assertEquals("foo", knc.getPodName());
+        assertEquals("bar", knc.getNamespace());
+        assertSame(slave, knc.getKubernetesSlave());
+        assertSame(podResource, knc.getPodResource());
+    }
+
+    @Test
+    public void notKubernetesSlaveInstance() throws Exception {
+        Node node = mock(Node.class);
+        when(context.get(Node.class)).thenReturn(node);
+        try {
+            new KubernetesNodeContext(context);
+            fail("expected abort exception");
+        } catch (AbortException ae) {
+            assertTrue(ae.getMessage().startsWith("Node is not a Kubernetes node"));
+        }
+    }
+}


### PR DESCRIPTION
Refactor `KubernetesNodeContext` to make it public for extensions to make use of `ContainerExecDecorator`. This refactor introduces a new method `getPodResource()` to get access to the associated `PodResource` from the client. This reduces the need for direct access to `KubernetesClient` and the `connectToCloud()` method.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
