### PR TITLE
[JENKINS-75712] Test Jackson 2.19.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,8 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jackson2-api</artifactId>
+      <!-- Test https://issues.jenkins.io/browse/JENKINS-75712 -->
+      <version>2.19.0-404.vb_b_0fd2fea_e10</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -180,6 +182,12 @@
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <version>4.3.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <!-- Test https://issues.jenkins.io/browse/JENKINS-75712 - wild guess -->
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>cloudbees-bitbucket-branch-source</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
## [JENKINS-75712] Test Jackson 2.19.0 - DRAFT - do not review 

[JENKINS-75712](https://issues.jenkins.io/browse/JENKINS-75712) reports a serialization exception in the Kubernetes plugin when used with Jackson 2 API 2.19.0.

[Plugin BOM release](https://github.com/jenkinsci/bom/issues/5076) had issues with class loader and Jackson 2.19.0 that might hint at other class loading problems.

Draft pull request in order to run the tests on ci.jenkins.io.

### Testing done

Confirmed that tests pass locally on my environment, but my environment does not have access to a Kubernetes cluster.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
