### PR TITLE
[JENKINS-75720] Fix potential ClassNotFoundException in ContainerExecCallback

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerStepExecution.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerStepExecution.java
@@ -12,11 +12,14 @@ import hudson.slaves.EnvironmentVariablesNodeProperty;
 import hudson.slaves.NodeProperty;
 import hudson.slaves.NodePropertyDescriptor;
 import hudson.util.DescribableList;
+
+import java.io.Closeable;
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback;
 import org.jenkinsci.plugins.workflow.steps.BodyInvoker;
 import org.jenkinsci.plugins.workflow.steps.EnvironmentExpander;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
@@ -88,5 +91,28 @@ public class ContainerStepExecution extends StepExecution {
     public void stop(@NonNull Throwable cause) throws Exception {
         LOGGER.log(Level.FINE, "Stopping container step.");
         closeQuietly(getContext(), decorator);
+    }
+
+    /**
+     * This class has been replaced but is not deleted to prevent {@code ClassNotFoundException}.
+     * See <a href="https://issues.jenkins.io/browse/JENKINS-75720">JENKINS-75720</a>
+     * @deprecated replaced {@link Resources#closeQuietlyCallback(Closeable...)}
+     */
+    @Deprecated
+    @SuppressFBWarnings("SE_BAD_FIELD")
+    private static class ContainerExecCallback extends BodyExecutionCallback.TailCall {
+
+        private static final long serialVersionUID = 6385838254761750483L;
+
+        private final Closeable[] closeables;
+
+        private ContainerExecCallback(Closeable... closeables) {
+            this.closeables = closeables;
+        }
+
+        @Override
+        public void finished(StepContext context) {
+            closeQuietly(context, closeables);
+        }
     }
 }


### PR DESCRIPTION
Add back `ContainerExecCallback` to prevent potential `ClassNotFoundException`.

The class was removed in #1698 to and moved to the `Resources` class.

fixes: JENKINS-75720

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
