### PR TITLE
Add retention strategy on pod eviction

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ Either way it provides access to the following fields:
 * **annotations** Annotations to apply to the pod.
 * **inheritFrom** List of one or more pod templates to inherit from *(more details below)*.
 * **slaveConnectTimeout** Timeout in seconds for an agent to be online *(more details below)*.
-* **podRetention** Controls the behavior of keeping agent pods. Can be 'never()', 'onFailure()', 'always()', or 'default()' - if empty will default to deleting the pod after `activeDeadlineSeconds` has passed.
+* **podRetention** Controls the behavior of keeping agent pods. Can be 'never()', 'onFailure()', 'always()', 'evicted()', or 'default()' - if empty will default to deleting the pod after `activeDeadlineSeconds` has passed.
 * **activeDeadlineSeconds** If `podRetention` is set to `never()` or `onFailure()`, the pod is deleted after this deadline is passed.
 * **idleMinutes** Allows the pod to remain active for reuse until the configured number of minutes has passed since the last step was executed on it.
 * **showRawYaml** Enable or disable the output of the raw pod manifest. Defaults to `true`

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/retention/Evicted.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/retention/Evicted.java
@@ -1,0 +1,73 @@
+package org.csanchez.jenkins.plugins.kubernetes.pod.retention;
+
+import hudson.Extension;
+import io.fabric8.kubernetes.api.model.Pod;
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.Locale;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class Evicted extends PodRetention implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 6424267627207206819L;
+
+    private static final Logger LOGGER = Logger.getLogger(Evicted.class.getName());
+
+    @DataBoundConstructor
+    public Evicted() {}
+
+    @Override
+    public boolean shouldDeletePod(KubernetesCloud cloud, Supplier<Pod> podS) {
+        Pod pod = null;
+        try {
+            pod = podS.get();
+        } catch (RuntimeException x) {
+            LOGGER.log(Level.WARNING, null, x);
+        }
+        boolean isEvicted = pod != null
+                && pod.getStatus() != null
+                && pod.getStatus().getReason() != null
+                && pod.getStatus().getReason().toLowerCase(Locale.getDefault()).equals("evicted");
+        return !isEvicted;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (obj instanceof Evicted) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return this.toString().hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return Messages.evicted();
+    }
+
+    @Extension
+    @Symbol("evicted")
+    public static class DescriptorImpl extends PodRetentionDescriptor {
+
+        @Override
+        public String getDisplayName() {
+            return Messages.evicted();
+        }
+    }
+}

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/help-podRetention.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/help-podRetention.html
@@ -6,6 +6,7 @@
     <ol>
         <li>Never - always delete the agent pod.</li>
         <li>On Failure - keep the agent pod if it fails during the build.</li>
+        <li>Evicted - keep the agent pod only if it was evicted during the build (For example a Node-pressure).</li>
         <li>Always - always keep the agent pod.</li>
     </ol>
     <p>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/help-podRetention.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/help-podRetention.html
@@ -8,6 +8,7 @@
         <li>Always - always keep the agent pod.</li>
         <li>Default - use the Pod Retention setting for the plugin.</li>
         <li>Never - always delete the agent pod.</li>
+        <li>Evicted - keep the agent pod only if it was evicted during the build (For example a Node-pressure).</li>
         <li>On Failure - keep the agent pod if it fails during the build.</li>
     </ol>
     <p>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pod/retention/Messages.properties
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pod/retention/Messages.properties
@@ -24,6 +24,7 @@ always=Always
 _default=Default
 never=Never
 on_Failure=On Failure
+evicted=Evicted
 PodOfflineCause.PodDeleted=Pod deleted
 PodOfflineCause.PodFailed=Pod failed (Reason: {0}, Message: {1})
 PodOfflineCause.ImagePullBackoff=Pod failed to start due to image pull failure (Reason: {0}, Image: {1})

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlaveTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlaveTest.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.csanchez.jenkins.plugins.kubernetes.pod.retention.Always;
 import org.csanchez.jenkins.plugins.kubernetes.pod.retention.Default;
+import org.csanchez.jenkins.plugins.kubernetes.pod.retention.Evicted;
 import org.csanchez.jenkins.plugins.kubernetes.pod.retention.Never;
 import org.csanchez.jenkins.plugins.kubernetes.pod.retention.OnFailure;
 import org.csanchez.jenkins.plugins.kubernetes.pod.retention.PodRetention;
@@ -178,7 +179,11 @@ public class KubernetesSlaveTest {
                     createPodRetentionTestCase(new Always(), new Default(), new Default()),
                     createPodRetentionTestCase(new Always(), new Always(), new Always()),
                     createPodRetentionTestCase(new Always(), new OnFailure(), new OnFailure()),
-                    createPodRetentionTestCase(new Always(), new Never(), new Never()));
+                    createPodRetentionTestCase(new Always(), new Never(), new Never()),
+                    createPodRetentionTestCase(new Evicted(), new Default(), new Default()),
+                    createPodRetentionTestCase(new Evicted(), new Always(), new Always()),
+                    createPodRetentionTestCase(new Evicted(), new OnFailure(), new OnFailure()),
+                    createPodRetentionTestCase(new Evicted(), new Never(), new Never()));
             KubernetesCloud cloud = new KubernetesCloud("test");
             r.jenkins.clouds.add(cloud);
             for (KubernetesSlaveTestCase<PodRetention> testCase : cases) {

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pod/retention/PodRetentionTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pod/retention/PodRetentionTest.java
@@ -60,7 +60,20 @@ public class PodRetentionTest {
         assertTrue(subject.shouldDeletePod(cloud, podS));
     }
 
+    @Test
+    public void testOnEvictedPodRetention() {
+        PodRetention subject = new Evicted();
+        pod.setStatus(buildStatus("Failed", "Evicted"));
+        assertFalse(subject.shouldDeletePod(cloud, podS));
+        pod.setStatus(buildStatus("Failed", "OOMKilled"));
+        assertTrue(subject.shouldDeletePod(cloud, podS));
+    }
+
     private PodStatus buildStatus(String phase) {
         return new PodStatusBuilder().withPhase(phase).build();
+    }
+
+    private PodStatus buildStatus(String phase, String reason) {
+        return new PodStatusBuilder().withPhase(phase).withReason(reason).build();
     }
 }


### PR DESCRIPTION
Add retention strategy on pod eviction

I'm interested by keeping only agent pods that were evicted by kubelet (to monitor their ephemeral storage).

### Testing done

mvn clean install and implemented some tests.

Evicted pod have a reason set to 'Evicted' such as

```yaml
status:
  ....
  message: 'The node was low on resource: ephemeral-storage. Threshold quantity: 19245089737,
    available: 16938436Ki. Container **** was using 2719916Ki, request is
    0, has larger consumption of ephemeral-storage. '
  phase: Failed
  podIP: ****
  podIPs:
  - ip: ****
  qosClass: Burstable
  reason: Evicted
  startTime: "2025-06-26T09:16:33Z"
....
```

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
