### PR TITLE
Fixing `jenkins.host.address` instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1018,7 +1018,7 @@ then
 ```bash
 kubectl krew install tunnel # as needed; install Krew first
 kubectl tunnel expose jenkins 8000:8000 8001:8001 &
-mvn test -Djenkins.host.address=jenkins.default -Dport=8000 -DslaveAgentPort=8001 -Dtest=KubernetesPipelineTest#runInPod
+mvn test -Djenkins.host.address=jenkins.default.svc.cluster.local -Dport=8000 -DslaveAgentPort=8001 -Dtest=KubernetesPipelineTest#runInPod
 ```
 
 Alternately, you can run everything like in CI:


### PR DESCRIPTION
Adjusting #1593 instructions to actually work for Windows-based tests, since Windows K8s DNS does not allow partial suffixes. Needed for #1724 / #1726.