### PR TITLE
[JENKINS-76095] Schedule cleanup of expired clients

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesClientProvider.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesClientProvider.java
@@ -7,8 +7,11 @@ import hudson.Extension;
 import hudson.XmlFile;
 import hudson.model.Saveable;
 import hudson.model.listeners.SaveableListener;
+import hudson.util.DaemonThreadFactory;
+import hudson.util.NamingThreadFactory;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import java.io.IOException;
+import java.lang.ref.Cleaner;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -94,12 +97,20 @@ public class KubernetesClientProvider {
     }
 
     private static class Client {
+
+        private static final Cleaner cleaner = Cleaner.create(new NamingThreadFactory(
+                new DaemonThreadFactory(), KubernetesClientProvider.class.getName() + ".Cleaner"));
+        // Use Java Cleaner to ensure the client is closed eventually
         private final KubernetesClient client;
         private final int validity;
 
         public Client(int validity, KubernetesClient client) {
             this.client = client;
             this.validity = validity;
+            cleaner.register(this, () -> {
+                LOGGER.log(Level.FINE, "Closing expired client " + client);
+                client.close();
+            });
         }
 
         public KubernetesClient getClient() {


### PR DESCRIPTION
[JENKINS-76095](https://issues.jenkins.io/browse/JENKINS-76095)

Cleanup resources linked to expired clients.

Expired clients may leak threads overtime under certain conditions (simplest reproducible is when a client credentials are not working anymore and the client is used over and over). Proposing to use a `java.lang.ref.Cleaner` to "schedule" the closure of the client when the references are GCed.

Hopefully this is good enough. A more aggressive way would be to schedule for closure based on number of active connections I guess. I recall that we were doing that in the past..

### Testing done

* Start Jenkins with `org.csanchez.jenkins.plugins.kubernetes.clients.cacheExpiration=1` to stress this out
* Spin Up Jenkins
* Configure a Kubernetes Cloud with a fake credentials ( credentials that doe snot work and will make the kubernetes client fail)
* Create one template in that Kubernetes Cloud
* Create a Pipeline that request that Pod template
* Build the pipeline
* See the increasing the number of `-XXXXXXXX-pool-XX-thread-XX`
* See that eventually (when GC kicks off, no strong, soft or weak reference remain) the clients are closed and thread pool shutdown

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
