### PR TITLE
[JENKINS-76157] Restore autoconfigure when auth is not null

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFactoryAdapter.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFactoryAdapter.java
@@ -176,7 +176,7 @@ public class KubernetesFactoryAdapter {
             builder = new ConfigBuilder(Config.autoConfigure(null));
         } else {
             // Using Config.empty() disables autoconfiguration when both serviceAddress and auth are set
-            builder = auth == null ? new ConfigBuilder() : new ConfigBuilder(Config.empty());
+            builder = auth == null ? new ConfigBuilder(Config.autoConfigure(null)) : new ConfigBuilder(Config.empty());
             builder = builder.withMasterUrl(serviceAddress);
         }
 

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFactoryAdapterTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFactoryAdapterTest.java
@@ -152,6 +152,36 @@ public class KubernetesFactoryAdapterTest {
     }
 
     @Test
+    public void autoConfigWithMasterUrlWithoutAuth() throws Exception {
+        System.setProperty(KUBERNETES_NAMESPACE_FILE, "src/test/resources/kubenamespace");
+        KubernetesFactoryAdapter factory = new KubernetesFactoryAdapter("http://example.com", null, null, false);
+        KubernetesClient client = factory.createClient();
+        assertEquals("test-namespace", client.getNamespace());
+        assertEquals(HTTP_PROXY, client.getConfiguration().getHttpProxy());
+        assertEquals(HTTPS_PROXY, client.getConfiguration().getHttpsProxy());
+        assertArrayEquals(new String[] {NO_PROXY}, client.getConfiguration().getNoProxy());
+        assertEquals(PROXY_USERNAME, client.getConfiguration().getProxyUsername());
+        assertEquals(PROXY_PASSWORD, client.getConfiguration().getProxyPassword());
+        assertTrue(client.getConfiguration().getAutoConfigure());
+        assertEquals("http://example.com/", client.getConfiguration().getMasterUrl());
+    }
+
+    @Test
+    public void autoConfigWithKubeconfig() throws Exception {
+        System.setProperty(KUBERNETES_KUBECONFIG_FILE, "src/test/resources/kubeconfig");
+        KubernetesFactoryAdapter factory = new KubernetesFactoryAdapter("http://example.com", null, null, false);
+        KubernetesClient client = factory.createClient();
+        assertEquals("test-namespace", client.getNamespace());
+        assertEquals(HTTP_PROXY, client.getConfiguration().getHttpProxy());
+        assertEquals(HTTPS_PROXY, client.getConfiguration().getHttpsProxy());
+        assertArrayEquals(new String[] {NO_PROXY}, client.getConfiguration().getNoProxy());
+        assertEquals(PROXY_USERNAME, client.getConfiguration().getProxyUsername());
+        assertEquals(PROXY_PASSWORD, client.getConfiguration().getProxyPassword());
+        assertTrue(client.getConfiguration().getAutoConfigure());
+        assertEquals("http://example.com/", client.getConfiguration().getMasterUrl());
+    }
+
+    @Test
     @Issue("JENKINS-70416")
     public void autoConfigWithAuth() throws Exception {
         System.setProperty(KUBERNETES_NAMESPACE_FILE, "src/test/resources/kubenamespace");

--- a/src/test/resources/kubeconfig
+++ b/src/test/resources/kubeconfig
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Config
+clusters:
+  - name: test-cluster
+    cluster:
+      server: http://example.com
+      insecure-skip-tls-verify: true
+contexts:
+  - name: test-context
+    context:
+      cluster: test-cluster
+      user: test-user
+      namespace: test-namespace
+current-context: test-context
+users:
+  - name: test-user
+    user:
+      token: dummy-token


### PR DESCRIPTION
[JENKINS-76157](https://issues.jenkins.io/browse/JENKINS-76157)

Since https://github.com/fabric8io/kubernetes-client/pull/6153, the behavior described to not use autoconfigure ONLY IF there is no auth provided is not respected anymore. If one specifies the Kubernetes URL `https://kubernetes.default.svc.cluster.local/` the client is not autoconfigured and use to the `default` namespace.

* adding tests that would have passed with Kubernetes client api < 6.13.2
* set autoconfigure when auth is null

### Testing done

* Spin up Jenkins in Kubernetes in a namespace other than default
* Configure a Kubernetes Cloud and set the Kubernetes URL to https://kubernetes.default.svc.cluster.local/
* Try to provision a Kubernetes agent using the cloud

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
