### PR TITLE
Test with Java 25

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,7 +56,7 @@ stage('Tests') {
             node('maven-25') {
                 timeout(60) {
                     checkout scm
-                    sh 'mvn --show-version -B -ntp -Dset.changelist -Dmaven.test.failure.ignore clean install'
+                    sh 'mvn -B -ntp -Dset.changelist -Dmaven.test.failure.ignore clean install'
                     infra.prepareToPublishIncrementals()
                     junit 'target/surefire-reports/*.xml'
                 }

--- a/kind.sh
+++ b/kind.sh
@@ -52,7 +52,6 @@ ktunnel expose jenkins 8000:8000 8001:8001 &
 ktunnel_pid=$!
 
 mvn \
-    --show-version \
     -B \
     -ntp \
     -Djenkins.host.address=jenkins.default \


### PR DESCRIPTION
## Test with Java 25

Java 25 released Sep 16, 2025.  The Jenkins project wants to support Java 25 soon.  Assuring that plugins pass tests on Java 25 is part of the effort to support Java 25.

Replaces Java 17 with Java 21 as the Java version for `kind` tests.  The parent pom configures the Java 21 compiler to generate Java 17 byte code.  We've not found any issues where byte code generated by the Java 21 compiler resulted in bugs that were not also visible when the code was compiled with Java 17.  Rather than spend the money to run tests with Java 17, let's just run the tests with Java 21 and Java 25.

Replaces Java 21 with Java 25 for the tests that are run outside `kind`.

### Testing done

* Confirmed that tests pass locally with Java 25
* Confirmed that the expected Java versions are used in all tests
* Confirmed that `kind` tests pass on ci.jenkins.io
* Confirmed that the test coverage report shows only a 0.2% reduction in instruction coverage and a 0.3% reduction in branch coverage

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
- ~Link to relevant issues in GitHub or Jira~
- ~Link to relevant pull requests, esp. upstream and downstream changes~
