### PR TITLE
 Fix: watcher certificate expiry causing 401 Unauthorized errors #2706

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/retention/Reaper.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/retention/Reaper.java
@@ -232,16 +232,25 @@ public class Reaper extends ComputerListener {
                     String clientCertData = client.getConfiguration().getClientCertData();
                     if (clientCertData != null) {
                         byte[] certBytes = java.util.Base64.getDecoder().decode(clientCertData);
-                        java.security.cert.CertificateFactory certFactory = java.security.cert.CertificateFactory.getInstance("X.509");
-                        java.security.cert.X509Certificate cert = (java.security.cert.X509Certificate) certFactory.generateCertificate(new java.io.ByteArrayInputStream(certBytes));
+                        java.security.cert.CertificateFactory certFactory =
+                                java.security.cert.CertificateFactory.getInstance("X.509");
+                        java.security.cert.X509Certificate cert = (java.security.cert.X509Certificate)
+                                certFactory.generateCertificate(new java.io.ByteArrayInputStream(certBytes));
                         java.time.Instant notAfter = cert.getNotAfter().toInstant();
                         java.time.Instant now = java.time.Instant.now();
 
-                        long delayMillis = java.time.temporal.ChronoUnit.MILLIS.between(now, notAfter) - java.util.concurrent.TimeUnit.SECONDS.toMillis(30); // Stop 30s before expiry
+                        long delayMillis = java.time.temporal.ChronoUnit.MILLIS.between(now, notAfter)
+                                - java.util.concurrent.TimeUnit.SECONDS.toMillis(30); // Stop 30s before expiry
 
                         if (delayMillis > 0) {
-                            LOGGER.info(String.format("Scheduling proactive Reaper watcher restart for cloud %s in %d ms (Certificate expires at %s)", kc.getDisplayName(), delayMillis, notAfter));
-                            jenkins.util.Timer.get().schedule(() -> restartWatcher(kc, watcher), delayMillis, java.util.concurrent.TimeUnit.MILLISECONDS);
+                            LOGGER.info(String.format(
+                                    "Scheduling proactive Reaper watcher restart for cloud %s in %d ms (Certificate expires at %s)",
+                                    kc.getDisplayName(), delayMillis, notAfter));
+                            jenkins.util.Timer.get()
+                                    .schedule(
+                                            () -> restartWatcher(kc, watcher),
+                                            delayMillis,
+                                            java.util.concurrent.TimeUnit.MILLISECONDS);
                         }
                     }
                 } catch (Exception e) {
@@ -255,43 +264,59 @@ public class Reaper extends ComputerListener {
     }
 
     void restartWatcher(KubernetesCloud kc, CloudPodWatcher watcher) {
-        Jenkins jenkins = Jenkins.getInstanceOrNull();
-        if (jenkins == null) return;
-        Cloud cloud = jenkins.getCloud(kc.name);
+        try {
+            Jenkins jenkins = Jenkins.getInstanceOrNull();
+            if (jenkins == null) return;
+            Cloud cloud = jenkins.getCloud(kc.name);
 
-        // Handle instance replacement (e.g. config save)
-        if (cloud instanceof KubernetesCloud && cloud != kc) {
-            LOGGER.info(String.format("Cloud instance %s updated, migrating proactive Reaper watcher restart to new instance", kc.name));
-            // If there is still an active watcher, this will replace it.
-            // If is already replaced, this might restart the new one (due to invalidate), which is acceptable to ensure cert freshness.
-            KubernetesClientProvider.invalidate(cloud.getDisplayName());
-            watchCloud((KubernetesCloud) cloud);
+            // Handle instance replacement (e.g. config save)
+            if (cloud instanceof KubernetesCloud && cloud != kc) {
+                LOGGER.info(String.format(
+                        "Cloud instance %s updated, migrating proactive Reaper watcher restart to new instance",
+                        kc.name));
+                // If there is still an active watcher, this will replace it.
+                // If is already replaced, this might restart the new one (due to invalidate), which is acceptable to
+                // ensure cert freshness.
+                KubernetesClientProvider.invalidate(cloud.getDisplayName());
+                watchCloud((KubernetesCloud) cloud);
+                watcher.stop();
+                return;
+            }
+
+            // Handle removal or type change
+            if (cloud != kc) {
+                LOGGER.info(String.format(
+                        "Cloud instance %s is no longer active, skipping proactive Reaper watcher restart", kc.name));
+                watcher.stop();
+                return;
+            }
+
+            LOGGER.info(String.format(
+                    "Proactively restarting Reaper watcher for cloud %s due to impending certificate expiry",
+                    kc.getDisplayName()));
+            KubernetesClientProvider.invalidate(kc.getDisplayName());
+
+            // Stop the old watcher to ensure watchCloud doesn't skip update due to identical config validity
             watcher.stop();
-            return;
-        }
+            watchers.remove(kc.name, watcher);
 
-        // Handle removal or type change
-        if (cloud != kc) {
-             LOGGER.info(String.format("Cloud instance %s is no longer active, skipping proactive Reaper watcher restart", kc.name));
-             watcher.stop();
-             return;
-        }
+            // Restart the watcher immediately
+            watchCloud(kc);
 
-        LOGGER.info(String.format("Proactively restarting Reaper watcher for cloud %s due to impending certificate expiry", kc.getDisplayName()));
-        KubernetesClientProvider.invalidate(kc.getDisplayName());
-
-        // Stop the old watcher to ensure watchCloud doesn't skip update due to identical config validity
-        watcher.stop();
-        watchers.remove(kc.name, watcher);
-
-        // Restart the watcher immediately
-        watchCloud(kc);
-
-        // Verify if restart succeeded (watcher should be replaced in the map)
-        CloudPodWatcher newWatcher = watchers.get(kc.name);
-        if (newWatcher == null || newWatcher == watcher) {
-             LOGGER.warning(String.format("Failed to restart Reaper watcher for cloud %s, retrying in 10s", kc.getDisplayName()));
-             Timer.get().schedule(() -> restartWatcher(kc, watcher), 10, java.util.concurrent.TimeUnit.SECONDS);
+            // Verify if restart succeeded (watcher should be replaced in the map)
+            CloudPodWatcher newWatcher = watchers.get(kc.name);
+            if (newWatcher == null || newWatcher == watcher) {
+                LOGGER.warning(String.format(
+                        "Failed to restart Reaper watcher for cloud %s, retrying in 10s", kc.getDisplayName()));
+                Timer.get().schedule(() -> restartWatcher(kc, watcher), 10, java.util.concurrent.TimeUnit.SECONDS);
+            }
+        } catch (RuntimeException e) {
+            LOGGER.log(
+                    Level.WARNING,
+                    String.format(
+                            "Failed to restart Reaper watcher for cloud %s, retrying in 10s", kc.getDisplayName()),
+                    e);
+            Timer.get().schedule(() -> restartWatcher(kc, watcher), 10, java.util.concurrent.TimeUnit.SECONDS);
         }
     }
 


### PR DESCRIPTION
Implements proactive certificate renewal for Kubernetes watchers to prevent authentication failures when OIDC provider certificates expire. The watchers (SharedIndexInformer in KubernetesCloud and cloudPodWatcher in Reaper) now detect certificate expiry times and automatically restart with fresh credentials 30 seconds before expiry.

I've tried the alternatives but couldn't make them work due to some limitations.
- **Credential refresh on existing connections**: Not possible due to WebSocket/TLS limitations
- **Reactive reconnection on 401 errors**: Results in event loss and reconnection failures

Key changes:
- Added certificate expiry detection in KubernetesCloud.createInformer()
- Added certificate expiry detection in Reaper.watchCloud()
- Implemented restartInformer() with cloud instance migration support
- Implemented restartWatcher() with retry logic on failure
- Added comprehensive test coverage for all renewal scenarios

This fix prevents intermittent "401 Unauthorized" errors that occur when long-running Jenkins instances use short-lived OIDC certificates, particularly with Pinniped or similar OIDC providers.

Fixes: jenkinsci/kubernetes-plugin#2706
Related: fabric8io/kubernetes-client#2112, fabric8io/kubernetes-client#7164

### Testing done

- `org.csanchez.jenkins.plugins.kubernetes.KubernetesCloudRestartTest`
  - Tests informer restart scheduling on certificate expiry
  - Tests Reaper watcher restart scheduling
  - Tests long-lived certificate handling
  - Tests expired certificate warning
  - Tests restart execution and failure retry
  - Tests cloud instance migration
  
All tests pass:
 - Normal certificate renewal (5-minute expiry)
 - Long-lived certificates (10-year expiry)
 - Already-expired certificates
 - Cloud instance replacement scenarios
 - Failure and retry logic

Console logs:

```
2025-12-12 00:22:32.000+0000 [id=270]   INFO    o.c.j.p.k.KubernetesCloud#restartInformer: Proactively stopping informer for namespace test100 due to impending certificate expiry
2025-12-12 00:22:32.001+0000 [id=270]   INFO    o.c.j.p.k.KubernetesCloud#restartInformer: Creating fresh informer for namespace test100 with new credentials
2025-12-12 00:22:33.362+0000 [id=270]   INFO    o.c.j.p.k.KubernetesCloud#createInformer: Registered informer to watch pod events on namespace [test100], with labels [{jenkins=REDACTED, kubernetes.jenkins.io/controller=https___jenkins-test100_REDACTEDx}] on cloud [REDACTED]
2025-12-12 00:22:33.363+0000 [id=270]   INFO    o.c.j.p.k.KubernetesCloud#createInformer: Scheduling proactive informer restart for namespace test100 in 269637 ms (Certificate expires at 2025-12-12T00:27:33Z)
2025-12-12 00:22:42.000+0000 [id=128]   INFO    o.c.j.p.k.pod.retention.Reaper#restartWatcher: Proactively restarting Reaper watcher for cloud REDACTED due to impending certificate expiry
2025-12-12 00:22:42.000+0000 [id=128]   INFO    o.c.j.p.k.p.r.Reaper$CloudPodWatcher#stop: Stopping watch for kubernetes cloud REDACTED
2025-12-12 00:22:43.208+0000 [id=128]   INFO    o.c.j.p.k.pod.retention.Reaper#watchCloud: set up watcher on REDACTED
2025-12-12 00:22:43.208+0000 [id=128]   INFO    o.c.j.p.k.pod.retention.Reaper#watchCloud: Scheduling proactive Reaper watcher restart for cloud REDACTED in 269792 ms (Certificate expires at 2025-12-12T00:27:43Z)
```
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
