### PR TITLE
Fix counter leak when Jenkins restarts with ephemeral templates

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesProvisioningLimits.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesProvisioningLimits.java
@@ -165,6 +165,44 @@ public final class KubernetesProvisioningLimits {
         return podTemplateCounts.getOrDefault(podTemplate, 0);
     }
 
+    /**
+     * Unregister executors using persistent field values (cloudName and templateId).
+     * This method works correctly even after Jenkins restart when transient template references are null.
+     *
+     * @param cloudName the kubernetes cloud name
+     * @param podTemplateId the pod template ID
+     * @param numExecutors the number of executors (pretty much always 1)
+     */
+    public void unregisterByIds(@NonNull String cloudName, @NonNull String podTemplateId, int numExecutors) {
+        if (initInstance()) {
+            synchronized (this) {
+                int newGlobalCount = getGlobalCount(cloudName) - numExecutors;
+                if (newGlobalCount < 0) {
+                    LOGGER.log(
+                            Level.WARNING,
+                            "Global count for " + cloudName
+                                    + " went below zero. There is likely a bug in kubernetes-plugin");
+                }
+                cloudCounts.put(cloudName, Math.max(0, newGlobalCount));
+                LOGGER.log(
+                        Level.FINEST,
+                        () -> cloudName + " global limit: " + Math.max(0, newGlobalCount));
+
+                int newPodTemplateCount = getPodTemplateCount(podTemplateId) - numExecutors;
+                if (newPodTemplateCount < 0) {
+                    LOGGER.log(
+                            Level.WARNING,
+                            "Pod template count for " + podTemplateId
+                                    + " went below zero. There is likely a bug in kubernetes-plugin");
+                }
+                podTemplateCounts.put(podTemplateId, Math.max(0, newPodTemplateCount));
+                LOGGER.log(
+                        Level.FINEST,
+                        () -> podTemplateId + " template limit: " + Math.max(0, newPodTemplateCount));
+            }
+        }
+    }
+
     @Extension
     public static class NodeListenerImpl extends NodeListener {
         @Override
@@ -172,10 +210,10 @@ public final class KubernetesProvisioningLimits {
             if (node instanceof KubernetesSlave) {
                 KubernetesProvisioningLimits instance = KubernetesProvisioningLimits.get();
                 KubernetesSlave kubernetesNode = (KubernetesSlave) node;
-                PodTemplate template = kubernetesNode.getTemplateOrNull();
-                if (template != null) {
-                    instance.unregister(kubernetesNode.getKubernetesCloud(), template, node.getNumExecutors());
-                }
+                // Use persistent fields (cloudName, templateId) instead of transient template object
+                // This works correctly even after Jenkins restart when template reference is null
+                instance.unregisterByIds(
+                        kubernetesNode.getCloudName(), kubernetesNode.getTemplateId(), node.getNumExecutors());
             }
         }
     }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesProvisioningLimits.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesProvisioningLimits.java
@@ -176,11 +176,9 @@ public final class KubernetesProvisioningLimits {
     public void unregisterByIds(@NonNull String cloudName, @NonNull String podTemplateId, int numExecutors) {
         if (initInstance()) {
             synchronized (this) {
-                // Only unregister if the counts exist (node was actually registered)
+                // Decrement each counter independently if it was registered
                 int currentGlobalCount = getGlobalCount(cloudName);
-                int currentPodTemplateCount = getPodTemplateCount(podTemplateId);
-
-                if (currentGlobalCount > 0 || currentPodTemplateCount > 0) {
+                if (currentGlobalCount > 0) {
                     int newGlobalCount = currentGlobalCount - numExecutors;
                     if (newGlobalCount < 0) {
                         LOGGER.log(
@@ -190,7 +188,10 @@ public final class KubernetesProvisioningLimits {
                     }
                     cloudCounts.put(cloudName, Math.max(0, newGlobalCount));
                     LOGGER.log(Level.FINEST, () -> cloudName + " global limit: " + Math.max(0, newGlobalCount));
+                }
 
+                int currentPodTemplateCount = getPodTemplateCount(podTemplateId);
+                if (currentPodTemplateCount > 0) {
                     int newPodTemplateCount = currentPodTemplateCount - numExecutors;
                     if (newPodTemplateCount < 0) {
                         LOGGER.log(

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesProvisioningLimits.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesProvisioningLimits.java
@@ -176,25 +176,32 @@ public final class KubernetesProvisioningLimits {
     public void unregisterByIds(@NonNull String cloudName, @NonNull String podTemplateId, int numExecutors) {
         if (initInstance()) {
             synchronized (this) {
-                int newGlobalCount = getGlobalCount(cloudName) - numExecutors;
-                if (newGlobalCount < 0) {
-                    LOGGER.log(
-                            Level.WARNING,
-                            "Global count for " + cloudName
-                                    + " went below zero. There is likely a bug in kubernetes-plugin");
-                }
-                cloudCounts.put(cloudName, Math.max(0, newGlobalCount));
-                LOGGER.log(Level.FINEST, () -> cloudName + " global limit: " + Math.max(0, newGlobalCount));
+                // Only unregister if the counts exist (node was actually registered)
+                int currentGlobalCount = getGlobalCount(cloudName);
+                int currentPodTemplateCount = getPodTemplateCount(podTemplateId);
 
-                int newPodTemplateCount = getPodTemplateCount(podTemplateId) - numExecutors;
-                if (newPodTemplateCount < 0) {
+                if (currentGlobalCount > 0 || currentPodTemplateCount > 0) {
+                    int newGlobalCount = currentGlobalCount - numExecutors;
+                    if (newGlobalCount < 0) {
+                        LOGGER.log(
+                                Level.WARNING,
+                                "Global count for " + cloudName
+                                        + " went below zero. There is likely a bug in kubernetes-plugin");
+                    }
+                    cloudCounts.put(cloudName, Math.max(0, newGlobalCount));
+                    LOGGER.log(Level.FINEST, () -> cloudName + " global limit: " + Math.max(0, newGlobalCount));
+
+                    int newPodTemplateCount = currentPodTemplateCount - numExecutors;
+                    if (newPodTemplateCount < 0) {
+                        LOGGER.log(
+                                Level.WARNING,
+                                "Pod template count for " + podTemplateId
+                                        + " went below zero. There is likely a bug in kubernetes-plugin");
+                    }
+                    podTemplateCounts.put(podTemplateId, Math.max(0, newPodTemplateCount));
                     LOGGER.log(
-                            Level.WARNING,
-                            "Pod template count for " + podTemplateId
-                                    + " went below zero. There is likely a bug in kubernetes-plugin");
+                            Level.FINEST, () -> podTemplateId + " template limit: " + Math.max(0, newPodTemplateCount));
                 }
-                podTemplateCounts.put(podTemplateId, Math.max(0, newPodTemplateCount));
-                LOGGER.log(Level.FINEST, () -> podTemplateId + " template limit: " + Math.max(0, newPodTemplateCount));
             }
         }
     }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesProvisioningLimits.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesProvisioningLimits.java
@@ -184,9 +184,7 @@ public final class KubernetesProvisioningLimits {
                                     + " went below zero. There is likely a bug in kubernetes-plugin");
                 }
                 cloudCounts.put(cloudName, Math.max(0, newGlobalCount));
-                LOGGER.log(
-                        Level.FINEST,
-                        () -> cloudName + " global limit: " + Math.max(0, newGlobalCount));
+                LOGGER.log(Level.FINEST, () -> cloudName + " global limit: " + Math.max(0, newGlobalCount));
 
                 int newPodTemplateCount = getPodTemplateCount(podTemplateId) - numExecutors;
                 if (newPodTemplateCount < 0) {
@@ -196,9 +194,7 @@ public final class KubernetesProvisioningLimits {
                                     + " went below zero. There is likely a bug in kubernetes-plugin");
                 }
                 podTemplateCounts.put(podTemplateId, Math.max(0, newPodTemplateCount));
-                LOGGER.log(
-                        Level.FINEST,
-                        () -> podTemplateId + " template limit: " + Math.max(0, newPodTemplateCount));
+                LOGGER.log(Level.FINEST, () -> podTemplateId + " template limit: " + Math.max(0, newPodTemplateCount));
             }
         }
     }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesProvisioningLimitsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesProvisioningLimitsTest.java
@@ -91,4 +91,58 @@ public class KubernetesProvisioningLimitsTest {
             }
         }
     }
+
+    @Test
+    public void testCounterDecrementAfterRestartWithEphemeralTemplate() throws Exception {
+        // Create a cloud with an ephemeral template
+        KubernetesCloud cloud = new KubernetesCloud("test-cloud");
+        cloud.setContainerCap(10);
+        j.jenkins.clouds.add(cloud);
+
+        // Create an ephemeral pod template (not saved to cloud config)
+        PodTemplate ephemeralTemplate = new PodTemplate();
+        ephemeralTemplate.setName("ephemeral-template");
+        ephemeralTemplate.setInstanceCap(5);
+
+        // Register the template (simulates agent creation)
+        KubernetesProvisioningLimits limits = KubernetesProvisioningLimits.get();
+        assertTrue("Should successfully register template", limits.register(cloud, ephemeralTemplate, 1));
+
+        // Get the template ID that was auto-generated
+        String templateId = ephemeralTemplate.getId();
+
+        // Verify counters were incremented after registration
+        assertEquals(
+                "Global count should be 1 after registration", 1, limits.getGlobalCount("test-cloud"));
+        assertEquals(
+                "Template count should be 1 after registration",
+                1,
+                limits.getPodTemplateCount(templateId));
+
+        // Create a KubernetesSlave using Builder pattern
+        KubernetesSlave slave = new KubernetesSlave.Builder()
+                .podTemplate(ephemeralTemplate)
+                .cloud(cloud)
+                .nodeDescription("Test agent for counter leak fix")
+                .build();
+
+        // Add the slave to Jenkins
+        j.jenkins.addNode(slave);
+
+        // Remove the node (simulates agent deletion)
+        // The fix ensures counters are decremented using cloudName and templateId,
+        // even when template reference is null (as happens with ephemeral templates after restart)
+        j.jenkins.removeNode(slave);
+
+        // After deletion, counters should be decremented back to 0
+        // This is the bug fix: should work even when template reference is null
+        assertEquals(
+                "Global count should be 0 after node deletion",
+                0,
+                limits.getGlobalCount("test-cloud"));
+        assertEquals(
+                "Template count should be 0 after node deletion",
+                0,
+                limits.getPodTemplateCount(templateId));
+    }
 }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesProvisioningLimitsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesProvisioningLimitsTest.java
@@ -112,12 +112,8 @@ public class KubernetesProvisioningLimitsTest {
         String templateId = ephemeralTemplate.getId();
 
         // Verify counters were incremented after registration
-        assertEquals(
-                "Global count should be 1 after registration", 1, limits.getGlobalCount("test-cloud"));
-        assertEquals(
-                "Template count should be 1 after registration",
-                1,
-                limits.getPodTemplateCount(templateId));
+        assertEquals("Global count should be 1 after registration", 1, limits.getGlobalCount("test-cloud"));
+        assertEquals("Template count should be 1 after registration", 1, limits.getPodTemplateCount(templateId));
 
         // Create a KubernetesSlave using Builder pattern
         KubernetesSlave slave = new KubernetesSlave.Builder()
@@ -136,13 +132,7 @@ public class KubernetesProvisioningLimitsTest {
 
         // After deletion, counters should be decremented back to 0
         // This is the bug fix: should work even when template reference is null
-        assertEquals(
-                "Global count should be 0 after node deletion",
-                0,
-                limits.getGlobalCount("test-cloud"));
-        assertEquals(
-                "Template count should be 0 after node deletion",
-                0,
-                limits.getPodTemplateCount(templateId));
+        assertEquals("Global count should be 0 after node deletion", 0, limits.getGlobalCount("test-cloud"));
+        assertEquals("Template count should be 0 after node deletion", 0, limits.getPodTemplateCount(templateId));
     }
 }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesProvisioningLimitsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesProvisioningLimitsTest.java
@@ -125,9 +125,12 @@ public class KubernetesProvisioningLimitsTest {
         // Add the slave to Jenkins
         j.jenkins.addNode(slave);
 
+        // Simulate ephemeral template removal (happens with idleMinutes config after build completion)
+        cloud.removeTemplate(ephemeralTemplate);
+
         // Remove the node (simulates agent deletion)
         // The fix ensures counters are decremented using cloudName and templateId,
-        // even when template reference is null (as happens with ephemeral templates after restart)
+        // even when template reference is null (as happens with ephemeral templates after removal/restart)
         j.jenkins.removeNode(slave);
 
         // After deletion, counters should be decremented back to 0


### PR DESCRIPTION
Fixes #2783  
Partially addresses #2737

## What's the bug?

When you create pod templates inside pipelines (ephemeral templates), Jenkins loses track of them after a restart. The cleanup code has this check:

PodTemplate template = kubernetesNode.getTemplateOrNull();
if (template != null) {
    instance.unregister(...);
}

Problem is, after restart the template is null (it's a transient field). So the cleanup never happens and the counter stays incremented forever. Eventually Jenkins thinks it's at capacity even when no pods are running.

## How I fixed it

Instead of relying on the template object, I'm now using cloudName and templateId which are always available (they're persistent fields). Added a new method `unregisterByIds()` that just needs these IDs instead of the whole template object.

The NodeListener now calls this new method without checking if template is null.

## What changed

- New method `unregisterByIds()` in KubernetesProvisioningLimits
- Updated NodeListener.onDeleted() to use it
- Added a test case (though it has some issues with the test harness I need help with)

## Testing

Ran `mvn clean compile` - everything builds fine. Checked the logic manually and it makes sense - cloudName and templateId are definitely persistent, so they'll survive restarts.

The test I added compiles but I'm not 100% sure it's set up right for the Jenkins test environment. Would appreciate a look at that.

## FYI

I'm also working on PR #2785 which fixes a different counter leak issue (ImagePullBackOff detection). Both are part of debugging issue #2737. Happy to wait for that one to merge first if you prefer - just wanted to get this out there since I had it working.

Thanks for taking a look!

cc @Vlatombe @jglick - would appreciate your review when you have time!

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed