### PR TITLE
Set the HostPathVolume name to the normalized host path instead of volume-x

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -184,7 +184,7 @@ public class PodTemplateBuilder {
         int i = 0;
         for (final PodVolume volume : template.getVolumes()) {
             final String volumeName = (volume instanceof HostPathVolume hp)
-                    ? normalizePath(hp.getHostPath()).replaceFirst("^/", "").replace("/", "-")
+                    ? normalizePath(hp.getHostPath()).replaceFirst("^/", "").replaceAll("[^a-zA-Z0-9-]", "-")
                     : "volume-" + i;
             final String mountPath = normalizePath(volume.getMountPath());
             if (!volumeMounts.containsKey(mountPath)) {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -183,7 +183,9 @@ public class PodTemplateBuilder {
         String podName = agent.getPodName();
         int i = 0;
         for (final PodVolume volume : template.getVolumes()) {
-            final String volumeName = "volume-" + i;
+            final String volumeName = (volume instanceof HostPathVolume hp)
+                    ? normalizePath(hp.getHostPath()).replaceFirst("^/", "").replace("/", "-")
+                    : "volume-" + i;
             final String mountPath = normalizePath(volume.getMountPath());
             if (!volumeMounts.containsKey(mountPath)) {
                 VolumeMountBuilder volumeMountBuilder = new VolumeMountBuilder() //

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
@@ -398,7 +398,7 @@ public class PodTemplateBuilderTest {
             assertNotNull(volumes.get("empty-volume"));
             assertNotNull(volumes.get("host-volume"));
         } else {
-            assertNotNull(volumes.get("volume-0"));
+            assertNotNull(volumes.get("host-data"));
             assertNotNull(volumes.get("volume-1"));
         }
 
@@ -427,7 +427,7 @@ public class PodTemplateBuilderTest {
                     equalTo(
                             new VolumeMountBuilder() //
                                     .withMountPath("/container/data")
-                                    .withName("volume-0")
+                                    .withName("host-data")
                                     .withReadOnly(false)
                                     .build()),
                     equalTo(


### PR DESCRIPTION
This ensures the name of a `HostPathVolume` is known a priori and static. Previously the name was `volume-x` with x as a non static number, which might change when adding or removing volumes of a pod.

The name of the `HostPathVolume` is the specified normalized host path and its `/` being replaced by `-`. A host path like `/mnt/my/path/on-a_host` will generate the `HostPathVolume` name as `mnt-my-path-on-a_host`

### Testing done

The plugin has been build and deployed to my Jenkins instance. The plugin config output has been validated by printing the raw YAML to the console.

All unit tests have been successfully executed on my machine.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] <s>Ensure that the pull request title represents the desired changelog entry</s>
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
