### PR TITLE
Support Alpine-based containers with Agent Injection

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -192,6 +192,8 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
 
     private boolean agentInjection;
 
+    private String agentInjectionImage;
+
     /**
      * Persisted yaml fragment
      */
@@ -647,6 +649,16 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
     @DataBoundSetter
     public void setAgentInjection(boolean agentInjection) {
         this.agentInjection = agentInjection;
+    }
+
+    @CheckForNull
+    public String getAgentInjectionImage() {
+        return agentInjectionImage;
+    }
+
+    @DataBoundSetter
+    public void setAgentInjectionImage(@CheckForNull String agentInjectionImage) {
+        this.agentInjectionImage = Util.fixEmptyAndTrim(agentInjectionImage);
     }
 
     public List<TemplateEnvVar> getEnvVars() {
@@ -1199,6 +1211,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
                 + (!unwrapped ? "" : ", unwrapped=" + unwrapped)
                 + (agentContainer == null ? "" : ", agentContainer='" + agentContainer + '\'')
                 + (!agentInjection ? "" : ", agentInjection=" + agentInjection)
+                + (agentInjectionImage == null ? "" : ", agentInjectionImage='" + agentInjectionImage + '\'')
                 + '}';
     }
 }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -324,10 +324,18 @@ public class PodTemplateBuilder {
                 .filter(c -> c.getWorkingDir() == null)
                 .forEach(c -> c.setWorkingDir(workingDir));
         String agentImage = DEFAULT_AGENT_IMAGE;
-        if (cloud != null && StringUtils.isNotEmpty(cloud.getJnlpregistry())) {
-            agentImage = Util.ensureEndsWith(cloud.getJnlpregistry(), "/") + agentImage;
-        } else if (StringUtils.isNotEmpty(DEFAULT_JNLP_DOCKER_REGISTRY_PREFIX)) {
-            agentImage = Util.ensureEndsWith(DEFAULT_JNLP_DOCKER_REGISTRY_PREFIX, "/") + agentImage;
+
+        // Priority 1: Template-level custom image (most specific)
+        if (StringUtils.isNotEmpty(template.getAgentInjectionImage())) {
+            agentImage = template.getAgentInjectionImage();
+        } else {
+            // Priority 2: Cloud-level registry prefix
+            if (cloud != null && StringUtils.isNotEmpty(cloud.getJnlpregistry())) {
+                agentImage = Util.ensureEndsWith(cloud.getJnlpregistry(), "/") + agentImage;
+            } else if (StringUtils.isNotEmpty(DEFAULT_JNLP_DOCKER_REGISTRY_PREFIX)) {
+                // Priority 3: System property prefix
+                agentImage = Util.ensureEndsWith(DEFAULT_JNLP_DOCKER_REGISTRY_PREFIX, "/") + agentImage;
+            }
         }
         if (StringUtils.isBlank(agentContainer.getImage())) {
             agentContainer.setImage(agentImage);

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
@@ -503,6 +503,7 @@ public class PodTemplateUtils {
         podTemplate.setSupplementalGroups(h.resolve(PodTemplate::getSupplementalGroups, Objects::isNull));
         podTemplate.setAgentContainer(h.resolve(PodTemplate::getAgentContainer, PodTemplateUtils::isNullOrEmpty));
         podTemplate.setAgentInjection(h.resolve(PodTemplate::isAgentInjection, v -> !v));
+        podTemplate.setAgentInjectionImage(h.resolve(PodTemplate::getAgentInjectionImage, PodTemplateUtils::isNullOrEmpty));
         if (template.isHostNetworkSet()) {
             podTemplate.setHostNetwork(template.isHostNetwork());
         } else if (parent.isHostNetworkSet()) {

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
@@ -53,6 +53,10 @@ THE SOFTWARE.
     <f:checkbox/>
   </f:entry>
 
+  <f:entry field="agentInjectionImage" title="${%Agent injection image}">
+    <f:textbox/>
+  </f:entry>
+
   <f:entry field="containers" title="${%Containers}" description="${%List of container in the agent pod}">
       <f:repeatableHeteroProperty field="containers" hasHeader="true" addCaption="${%Add Container}"
                                     deleteCaption="${%Delete Container}" />

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/help-agentInjectionImage.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/help-agentInjectionImage.html
@@ -1,0 +1,29 @@
+<p>
+Specifies the container image to use for agent injection when <strong>Inject Jenkins agent in agent container</strong> is enabled.
+</p>
+
+<p>
+This is useful when your agent container is based on Alpine Linux (musl libc) and needs an Alpine-compatible agent image.
+</p>
+
+<p>
+If not specified, the plugin uses the default agent image (<code>jenkins/inbound-agent:3355.v388858a_47b_33-3-jdk21</code>)
+with any configured registry prefix.
+</p>
+
+<p><strong>Examples:</strong></p>
+<ul>
+  <li><code>jenkins/inbound-agent:3355.v388858a_47b_33-3-alpine-jdk21</code> - Use the official Alpine variant</li>
+  <li><code>my-registry.com/custom-agent:latest</code> - Use a custom registry and image</li>
+</ul>
+
+<p>
+<strong>Important:</strong> The <code>jenkins-agent</code> script requires <code>bash</code>.
+If your agent container is Alpine-based and doesn't include bash, add it to your container:
+</p>
+<pre>RUN apk add --no-cache bash</pre>
+
+<p>
+<strong>Note:</strong> This setting only applies when agent injection is enabled.
+It does not affect the agent container's base image.
+</p>

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
@@ -263,6 +263,57 @@ public class PodTemplateBuilderTest {
     }
 
     @Test
+    public void testAgentInjectionWithCustomImage() throws Exception {
+        PodTemplate template = new PodTemplate();
+        template.setAgentInjection(true);
+        template.setAgentInjectionImage("jenkins/inbound-agent:alpine-jdk21");
+        template.setYaml(loadYamlFile("pod-busybox.yaml"));
+        setupStubs();
+
+        Pod pod = new PodTemplateBuilder(template, slave).build();
+
+        assertNotNull(pod.getSpec().getInitContainers());
+        assertEquals(1, pod.getSpec().getInitContainers().size());
+        Container initContainer = pod.getSpec().getInitContainers().get(0);
+        assertEquals("set-up-jenkins-agent", initContainer.getName());
+        assertEquals("jenkins/inbound-agent:alpine-jdk21", initContainer.getImage());
+    }
+
+    @Test
+    public void testAgentInjectionImageOverridesRegistry() throws Exception {
+        cloud.setJnlpregistry("registry.example.com");
+
+        PodTemplate template = new PodTemplate();
+        template.setAgentInjection(true);
+        template.setAgentInjectionImage("custom-registry.io/my-agent:alpine");
+        template.setYaml(loadYamlFile("pod-busybox.yaml"));
+        setupStubs();
+
+        Pod pod = new PodTemplateBuilder(template, slave).build();
+
+        assertNotNull(pod.getSpec().getInitContainers());
+        Container initContainer = pod.getSpec().getInitContainers().get(0);
+        assertEquals("custom-registry.io/my-agent:alpine", initContainer.getImage());
+    }
+
+    @Test
+    public void testAgentInjectionWithoutCustomImageUsesDefault() throws Exception {
+        cloud.setJnlpregistry("registry.example.com");
+
+        PodTemplate template = new PodTemplate();
+        template.setAgentInjection(true);
+        // agentInjectionImage NOT set
+        template.setYaml(loadYamlFile("pod-busybox.yaml"));
+        setupStubs();
+
+        Pod pod = new PodTemplateBuilder(template, slave).build();
+
+        assertNotNull(pod.getSpec().getInitContainers());
+        Container initContainer = pod.getSpec().getInitContainers().get(0);
+        assertEquals("registry.example.com/" + DEFAULT_AGENT_IMAGE, initContainer.getImage());
+    }
+
+    @Test
     @Issue("JENKINS-50525")
     public void testBuildWithCustomWorkspaceVolume() throws Exception {
         PodTemplate template = new PodTemplate();


### PR DESCRIPTION
fix #2822
<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

Add agentInjectionImage configuration for Alpine support

  Adds an optional agentInjectionImage field to PodTemplate, allowing users to specify a custom agent injection image (e.g., Alpine variants) instead
   of always using the default glibc-based image.

  MOTIVATION
  Agent injection currently always uses jenkins/inbound-agent:3355.v388858a_47b_33-3-jdk21, which is incompatible with Alpine containers (musl libc
  vs glibc).

  CHANGES
  - PodTemplate.java: Added agentInjectionImage field with getter/setter
  - PodTemplateBuilder.java: Image resolution priority: custom image > registry prefix > system property > default
  - PodTemplateUtils.java: Added field to template inheritance
  - config.jelly: Added UI textbox field
  - help-agentInjectionImage.html: Added documentation

  TESTING
  Automated: Added 3 test cases in PodTemplateBuilderTest covering custom image usage, priority override, and backward compatibility. All 17 tests
  pass.

  Manual: Deployed plugin, configured PodTemplate with agentInjectionImage=jenkins/inbound-agent:3355.v388858a_47b_33-3-alpine-jdk21, verified init
  container uses specified image, confirmed agent connects with Alpine container.

  BACKWARD COMPATIBILITY
  Fully compatible - existing templates without the field use default behavior unchanged.

<img width="1262" height="553" alt="image" src="https://github.com/user-attachments/assets/13f94d3d-0861-4911-83fd-bc035d8af5cb" />

here is the generated template.

```log
  initContainers:
  - command:
    - "sh"
    - "-c"
    - "ls -al"
    image: "busybox:1.36"
    name: "volume-mount-permission"
    securityContext:
      runAsUser: 0
  - command:
    - "/bin/sh"
    - "-c"
    - "cp $(command -v jenkins-agent) /jenkins-agent/jenkins-agent;cp -R /usr/share/jenkins/.\
      \ /jenkins-agent"
    image: "jenkins/inbound-agent:3355.v388858a_47b_33-3-alpine3.23-jdk21"
    name: "set-up-jenkins-agent"
    volumeMounts:
    - mountPath: "/jenkins-agent"
      name: "jenkins-agent"
  nodeSelector:
    kubernetes.io/os: "linux"
  restartPolicy: "Never"
  volumes:
  - emptyDir:
      medium: ""
    name: "workspace-volume"
  - emptyDir: {}
    name: "jenkins-agent"
```


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
