### PR TITLE
support agent jdk injection

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -192,6 +192,8 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
 
     private boolean agentInjection;
 
+    private boolean agentJdkInjection;
+
     /**
      * Persisted yaml fragment
      */
@@ -647,6 +649,15 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
     @DataBoundSetter
     public void setAgentInjection(boolean agentInjection) {
         this.agentInjection = agentInjection;
+    }
+
+    public boolean isAgentJdkInjection() {
+        return agentJdkInjection;
+    }
+
+    @DataBoundSetter
+    public void setAgentJdkInjection(boolean agentJdkInjection) {
+        this.agentJdkInjection = agentJdkInjection;
     }
 
     public List<TemplateEnvVar> getEnvVars() {
@@ -1199,6 +1210,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
                 + (!unwrapped ? "" : ", unwrapped=" + unwrapped)
                 + (agentContainer == null ? "" : ", agentContainer='" + agentContainer + '\'')
                 + (!agentInjection ? "" : ", agentInjection=" + agentInjection)
+                + (!agentJdkInjection ? "" : ", agentJdkInjection=" + agentJdkInjection)
                 + '}';
     }
 }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -342,14 +342,15 @@ public class PodTemplateBuilder {
             var agentVolumeMountBuilder =
                     new VolumeMountBuilder().withName("jenkins-agent").withMountPath("/jenkins-agent");
             var oldInitContainers = pod.getSpec().getInitContainers();
+            String initCommand = "cp $(command -v jenkins-agent) " + JENKINS_AGENT + "/jenkins-agent" + ";"
+                    + "cp -R /usr/share/jenkins/. " + JENKINS_AGENT;
+            if (template.isAgentJdkInjection()) {
+                initCommand += ";" + "cp -R /opt/java/openjdk " + JENKINS_AGENT + "/jdk";
+            }
             var jenkinsAgentInitContainer = new ContainerBuilder()
                     .withName("set-up-jenkins-agent")
                     .withImage(agentImage)
-                    .withCommand(
-                            "/bin/sh",
-                            "-c",
-                            "cp $(command -v jenkins-agent) " + JENKINS_AGENT + "/jenkins-agent" + ";"
-                                    + "cp -R /usr/share/jenkins/. " + JENKINS_AGENT)
+                    .withCommand("/bin/sh", "-c", initCommand)
                     .withVolumeMounts(agentVolumeMountBuilder.build())
                     .build();
             if (oldInitContainers != null) {
@@ -390,6 +391,14 @@ public class PodTemplateBuilder {
                             .withName(JENKINS_AGENT_FILE_ENVVAR)
                             .withValue(JENKINS_AGENT + "/agent.jar")
                             .build());
+            if (template.isAgentJdkInjection()) {
+                envVars.put(
+                        "JENKINS_JAVA_BIN",
+                        new EnvVarBuilder()
+                                .withName("JENKINS_JAVA_BIN")
+                                .withValue(JENKINS_AGENT + "/jdk/bin/java")
+                                .build());
+            }
         }
         agentContainer.setEnv(new ArrayList<>(envVars.values()));
         if (agentContainer.getResources() == null) {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
@@ -503,6 +503,7 @@ public class PodTemplateUtils {
         podTemplate.setSupplementalGroups(h.resolve(PodTemplate::getSupplementalGroups, Objects::isNull));
         podTemplate.setAgentContainer(h.resolve(PodTemplate::getAgentContainer, PodTemplateUtils::isNullOrEmpty));
         podTemplate.setAgentInjection(h.resolve(PodTemplate::isAgentInjection, v -> !v));
+        podTemplate.setAgentJdkInjection(h.resolve(PodTemplate::isAgentJdkInjection, v -> !v));
         if (template.isHostNetworkSet()) {
             podTemplate.setHostNetwork(template.isHostNetwork());
         } else if (parent.isHostNetworkSet()) {

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/config.jelly
@@ -53,6 +53,10 @@ THE SOFTWARE.
     <f:checkbox/>
   </f:entry>
 
+  <f:entry field="agentJdkInjection" title="${%Inject JDK from agent image}">
+    <f:checkbox/>
+  </f:entry>
+
   <f:entry field="containers" title="${%Containers}" description="${%List of container in the agent pod}">
       <f:repeatableHeteroProperty field="containers" hasHeader="true" addCaption="${%Add Container}"
                                     deleteCaption="${%Delete Container}" />

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/help-agentJdkInjection.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/PodTemplate/help-agentJdkInjection.html
@@ -1,0 +1,29 @@
+<p>
+Injects the JDK from the agent injection image into the agent container when <strong>Inject Jenkins agent in agent container</strong> is enabled.
+</p>
+
+<p>
+This is useful when your agent container is a minimal toolchain image (python, node, golang) that doesn't include Java,
+but the Jenkins agent needs Java to run.
+</p>
+
+<p>
+When enabled, the init container copies the JDK from <code>/opt/java/openjdk</code> to <code>/jenkins-agent/jdk</code>
+and sets <code>JENKINS_JAVA_BIN=/jenkins-agent/jdk/bin/java</code>.
+</p>
+
+<p><strong>Example use case:</strong></p>
+<pre>Agent container: python:3.11-slim (no Java)
+Agent injection image: jenkins/inbound-agent:alpine-jdk21 (has Java)
+Result: Agent runs with injected JDK</pre>
+
+<p><strong>Trade-offs:</strong></p>
+<ul>
+  <li>Adds 10-20 seconds to pod startup (copying ~100-200MB JDK)</li>
+  <li>Requires additional volume space (~200MB per pod)</li>
+</ul>
+
+<p>
+<strong>Note:</strong> Only applies when agent injection is enabled.
+If your agent container already has Java installed, leave this disabled.
+</p>

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
@@ -263,6 +263,58 @@ public class PodTemplateBuilderTest {
     }
 
     @Test
+    public void testAgentJdkInjection() throws Exception {
+        PodTemplate template = new PodTemplate();
+        template.setAgentInjection(true);
+        template.setAgentJdkInjection(true);
+        template.setYaml(loadYamlFile("pod-busybox.yaml"));
+        setupStubs();
+
+        Pod pod = new PodTemplateBuilder(template, slave).build();
+
+        // Verify init container command includes JDK copy
+        Container initContainer = pod.getSpec().getInitContainers().get(0);
+        String command = String.join(" ", initContainer.getCommand());
+        assertThat(command, containsString("cp -R /opt/java/openjdk /jenkins-agent/jdk"));
+
+        // Verify JENKINS_JAVA_BIN environment variable is set
+        Container jnlpContainer = pod.getSpec().getContainers().stream()
+                .filter(c -> "jnlp".equals(c.getName()))
+                .findFirst()
+                .orElseThrow();
+        EnvVar javaBindEnvVar = jnlpContainer.getEnv().stream()
+                .filter(env -> "JENKINS_JAVA_BIN".equals(env.getName()))
+                .findFirst()
+                .orElseThrow();
+        assertEquals("/jenkins-agent/jdk/bin/java", javaBindEnvVar.getValue());
+    }
+
+    @Test
+    public void testAgentJdkInjectionDisabled() throws Exception {
+        PodTemplate template = new PodTemplate();
+        template.setAgentInjection(true);
+        template.setAgentJdkInjection(false);
+        template.setYaml(loadYamlFile("pod-busybox.yaml"));
+        setupStubs();
+
+        Pod pod = new PodTemplateBuilder(template, slave).build();
+
+        // Verify init container command does NOT include JDK copy
+        Container initContainer = pod.getSpec().getInitContainers().get(0);
+        String command = String.join(" ", initContainer.getCommand());
+        assertThat(command, not(containsString("cp -R /opt/java/openjdk")));
+
+        // Verify JENKINS_JAVA_BIN is NOT set
+        Container jnlpContainer = pod.getSpec().getContainers().stream()
+                .filter(c -> "jnlp".equals(c.getName()))
+                .findFirst()
+                .orElseThrow();
+        boolean hasJavaBinEnv =
+                jnlpContainer.getEnv().stream().anyMatch(env -> "JENKINS_JAVA_BIN".equals(env.getName()));
+        assertFalse(hasJavaBinEnv);
+    }
+
+    @Test
     @Issue("JENKINS-50525")
     public void testBuildWithCustomWorkspaceVolume() throws Exception {
         PodTemplate template = new PodTemplate();


### PR DESCRIPTION
Fix #2824
<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

#### SOLUTION
  Add agentJdkInjection field that injects JDK from the agent image at runtime.
  Toolchain images no longer need Java - they stay pure build environments.

####  BENEFITS
  - Build images decoupled from Jenkins - no Java needed
  - Jenkins upgrades don't require rebuilding toolchain images
  - Update agent version once, all pods get new agent automatically
  - Cleaner separation: toolchains for builds, agent for Jenkins communication

####  USAGE
  Jenkins UI configuration:
  ☑ Inject Jenkins agent in agent container
  ☑ Inject JDK from agent image

####  Pod template:
  - Agent container: python:3.11-slim (pure Python, no Java)
  - Agent injection image: jenkins/inbound-agent:alpine-jdk21

  Result: JDK injected at pod startup, agent runs with injected Java

  BACKWARD COMPATIBILITY
  - Fully backward compatible - disabled by default
  - Existing pod templates work unchanged
  - No migration needed
  - Only applies when explicitly enabled

  TRADE-OFFS
  - Adds 10-20 seconds to pod startup (one-time JDK copy)
  - Requires ~200MB volume space per pod


Here is the template config
<img width="1274" height="529" alt="image" src="https://github.com/user-attachments/assets/c544e8b2-afe1-48bb-91b9-6e275e57ddf7" />


Here is the job output

```log
spec:
  containers:
  - command:
    - "/jenkins-agent/jenkins-agent"
    env:
    - name: "JENKINS_SECRET"
      value: "********"
    - name: "JENKINS_AGENT_NAME"
      value: "test-label-6vxt2"
    - name: "JENKINS_AGENT_FILE"
      value: "/jenkins-agent/agent.jar"
    - name: "JENKINS_WEB_SOCKET"
      value: "true"
    - name: "REMOTING_OPTS"
      value: "-noReconnectAfter 1d"
    - name: "JENKINS_NAME"
      value: "test-label-6vxt2"
    - name: "JENKINS_AGENT_WORKDIR"
      value: "/home/jenkins/agent"
    - name: "JENKINS_URL"
      value: "http://10.66.40.223:8080/"
    - name: "JENKINS_JAVA_BIN"
      value: "/jenkins-agent/jdk/bin/java"
    image: "cn-build-nexus.example.com/example-docker-preprod/python:3.13-slim"
    name: "jnlp"
    resources:
      requests:
        memory: "256Mi"
        cpu: "100m"
    tty: true
    volumeMounts:
    - mountPath: "/jenkins-agent"
      name: "jenkins-agent"
      readOnly: true
    - mountPath: "/home/jenkins/agent"
      name: "workspace-volume"
      readOnly: false
    workingDir: "/home/jenkins/agent"
  hostNetwork: false
  initContainers:
  - command:
    - "/bin/sh"
    - "-c"
    - "cp $(command -v jenkins-agent) /jenkins-agent/jenkins-agent;cp -R /usr/share/jenkins/.\
      \ /jenkins-agent;cp -R /opt/java/openjdk /jenkins-agent/jdk"
    image: "cn-build-nexus.example.com/example-docker-preprod/jenkins/inbound-agent:3355.v388858a_47b_33-3-jdk21"
    name: "set-up-jenkins-agent"
    volumeMounts:
    - mountPath: "/jenkins-agent"
      name: "jenkins-agent"
```


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
