### PR TITLE
Fix #2809: default activeDeadlineSeconds for multi-container agent pods

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -98,6 +98,16 @@ public class PodTemplateBuilder {
     public static final String LABEL_KUBERNETES_CONTROLLER = "kubernetes.jenkins.io/controller";
     static final String NO_RECONNECT_AFTER_TIMEOUT =
             SystemProperties.getString(PodTemplateBuilder.class.getName() + ".noReconnectAfter", "1d");
+
+    /**
+     * Default {@code activeDeadlineSeconds} for multi-container agent pods when the template does not set one.
+     * Caps zombie pods when the agent exits after {@code -noReconnectAfter} but sidecars keep the pod alive
+     * (jenkinsci/kubernetes-plugin#2809). Defaults to one day, aligned with {@link #NO_RECONNECT_AFTER_TIMEOUT}.
+     * Set to {@code 0} to disable.
+     */
+    static final int MULTI_CONTAINER_ACTIVE_DEADLINE_SECONDS = SystemProperties.getInteger(
+            PodTemplateBuilder.class.getName() + ".multiContainerActiveDeadlineSeconds", 86_400);
+
     private static final String JENKINS_AGENT_FILE_ENVVAR = "JENKINS_AGENT_FILE";
     private static final String JENKINS_AGENT = "/jenkins-agent";
 
@@ -416,12 +426,31 @@ public class PodTemplateBuilder {
 
             agentContainer.setResources(reqs);
         }
+        applyMultiContainerActiveDeadline(pod);
         if (cloud != null) {
             pod = PodDecorator.decorateAll(cloud, pod);
         }
         Pod finalPod = pod;
         LOGGER.finest(() -> "Pod built: " + Serialization.asYaml(finalPod));
         return pod;
+    }
+
+    /**
+     * Multi-container pods without an explicit deadline get a default {@code activeDeadlineSeconds} so Kubernetes
+     * eventually terminates zombie pods when the agent exits after {@code -noReconnectAfter} (#2809).
+     */
+    private void applyMultiContainerActiveDeadline(@NonNull Pod pod) {
+        if (MULTI_CONTAINER_ACTIVE_DEADLINE_SECONDS <= 0) {
+            return;
+        }
+        List<Container> containers = pod.getSpec().getContainers();
+        if (containers == null || containers.size() <= 1) {
+            return;
+        }
+        if (template.getActiveDeadlineSeconds() > 0 || pod.getSpec().getActiveDeadlineSeconds() != null) {
+            return;
+        }
+        pod.getSpec().setActiveDeadlineSeconds((long) MULTI_CONTAINER_ACTIVE_DEADLINE_SECONDS);
     }
 
     private String normalizePath(String np) {

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
@@ -1021,6 +1021,80 @@ class PodTemplateBuilderTest {
         assertThat(pod.getSpec().getNodeSelector(), anEmptyMap());
     }
 
+    @Issue("2809")
+    @Test
+    void multiContainerPodGetsDefaultActiveDeadlineSeconds() {
+        PodTemplate template = new PodTemplate();
+        ContainerTemplate sidecar = new ContainerTemplate("busybox", "busybox");
+        sidecar.setCommand("sleep");
+        sidecar.setArgs("infinity");
+        template.getContainers().add(sidecar);
+        setupStubs();
+        Pod pod = new PodTemplateBuilder(template, slave).build();
+
+        assertEquals(
+                Long.valueOf(MULTI_CONTAINER_ACTIVE_DEADLINE_SECONDS),
+                pod.getSpec().getActiveDeadlineSeconds());
+    }
+
+    @Issue("2809")
+    @Test
+    void singleContainerPodDoesNotGetDefaultActiveDeadlineSeconds() {
+        setupStubs();
+        Pod pod = new PodTemplateBuilder(new PodTemplate(), slave).build();
+
+        assertNull(pod.getSpec().getActiveDeadlineSeconds());
+    }
+
+    @Issue("2809")
+    @Test
+    void explicitTemplateActiveDeadlineSecondsIsNotOverridden() {
+        PodTemplate template = new PodTemplate();
+        template.setActiveDeadlineSeconds(120);
+        ContainerTemplate sidecar = new ContainerTemplate("busybox", "busybox");
+        sidecar.setCommand("sleep");
+        sidecar.setArgs("infinity");
+        template.getContainers().add(sidecar);
+        setupStubs();
+        Pod pod = new PodTemplateBuilder(template, slave).build();
+
+        assertEquals(Long.valueOf(120), pod.getSpec().getActiveDeadlineSeconds());
+    }
+
+    @Issue("2809")
+    @Test
+    void yamlActiveDeadlineSecondsIsNotOverridden() {
+        PodTemplate template = new PodTemplate();
+        template.setYaml("spec:\n  activeDeadlineSeconds: 300");
+        ContainerTemplate sidecar = new ContainerTemplate("busybox", "busybox");
+        sidecar.setCommand("sleep");
+        sidecar.setArgs("infinity");
+        template.getContainers().add(sidecar);
+        setupStubs();
+        Pod pod = new PodTemplateBuilder(template, slave).build();
+
+        assertEquals(Long.valueOf(300), pod.getSpec().getActiveDeadlineSeconds());
+    }
+
+    @Issue("2809")
+    @Test
+    void customAgentContainerStillGetsDefaultActiveDeadlineSeconds() {
+        PodTemplate template = new PodTemplate();
+        template.setAgentContainer("maven");
+        template.setAgentInjection(true);
+        template.getContainers().add(new ContainerTemplate("maven", "maven:3-eclipse-temurin-17"));
+        ContainerTemplate golang = new ContainerTemplate("golang", "golang:1.23");
+        golang.setCommand("sleep");
+        golang.setArgs("99d");
+        template.getContainers().add(golang);
+        setupStubs();
+        Pod pod = new PodTemplateBuilder(template, slave).build();
+
+        assertEquals(
+                Long.valueOf(MULTI_CONTAINER_ACTIVE_DEADLINE_SECONDS),
+                pod.getSpec().getActiveDeadlineSeconds());
+    }
+
     private Map<String, Container> toContainerMap(Pod pod) {
         return pod.getSpec().getContainers().stream()
                 .collect(Collectors.toMap(Container::getName, Function.identity()));


### PR DESCRIPTION
## Summary

Fixes #2809: when `-noReconnectAfter` stops the Jenkins agent in a multi-container pod, sidecars can keep the pod Running indefinitely without controller intervention.

Per [maintainer feedback](https://github.com/jenkinsci/kubernetes-plugin/pull/2835#pullrequestreview-...), this replaces the earlier liveness-probe / `shareProcessNamespace` approach with a simpler default:

- **`PodTemplateBuilder`**: for multi-container templates with no explicit deadline, set `activeDeadlineSeconds` to **86400** (1 day), aligned with the default `noReconnectAfter` timeout.
- Respects explicit `activeDeadlineSeconds` on the template or in raw YAML.
- Single-container pods unchanged.
- Configurable via system property `org.csanchez.jenkins.plugins.kubernetes.PodTemplateBuilder.multiContainerActiveDeadlineSeconds` (set `0` to disable).

## Test plan

- [x] `PodTemplateBuilderTest` — 5 new #2809 cases (default deadline, single-container skip, template override, YAML override, custom agent container)
- [x] `mvn verify` + spotless green locally (rebased on latest master)
- [ ] CI (Jenkins PR builder)

Fixes #2809