### PR TITLE
Issue#2834: Agent Impersonation via JENKINS_SECRET

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
@@ -39,7 +39,10 @@ import hudson.slaves.JNLPLauncher;
 import hudson.slaves.SlaveComputer;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import java.io.IOException;
@@ -218,8 +221,11 @@ public class KubernetesLauncher extends JNLPLauncher {
             } else {
                 LOGGER.log(INFO, () -> "Pod already exists: " + cloudName + " " + namespace + "/" + podName);
                 listener.getLogger().printf("Pod already exists: %s %s/%s%n", cloudName, namespace, podName);
+                pod = existingPod;
             }
             kubernetesComputer.setLaunching(true);
+
+            createJnlpSecret(client, pod, kubernetesComputer.getJnlpMac());
 
             ObjectMeta podMetadata = pod.getMetadata();
             template.getWorkspaceVolume().createVolume(client, podMetadata);
@@ -331,6 +337,44 @@ public class KubernetesLauncher extends JNLPLauncher {
             LOGGER.log(Level.FINER, "Removing Jenkins node: {0}", node.getNodeName());
             terminateOrLog(node);
             throw new RuntimeException(ex);
+        }
+    }
+
+    /**
+     * Create a per-agent Kubernetes Secret holding the JNLP HMAC, owned by the Pod so it is
+     * garbage-collected with it. The Secret is referenced by the jnlp container via secretKeyRef,
+     * so the value never appears in the PodSpec.
+     */
+    private static void createJnlpSecret(KubernetesClient client, Pod pod, String jnlpMac) {
+        String namespace = pod.getMetadata().getNamespace();
+        String secretName = pod.getMetadata().getName() + PodTemplateBuilder.JNLP_SECRET_NAME_SUFFIX;
+        Secret secret = new SecretBuilder()
+                .withNewMetadata()
+                .withName(secretName)
+                .withNamespace(namespace)
+                .addToOwnerReferences(new OwnerReferenceBuilder()
+                        .withApiVersion("v1")
+                        .withKind("Pod")
+                        .withName(pod.getMetadata().getName())
+                        .withUid(pod.getMetadata().getUid())
+                        .withController(true)
+                        .withBlockOwnerDeletion(true)
+                        .build())
+                .endMetadata()
+                .withType("Opaque")
+                .addToStringData(PodTemplateBuilder.JNLP_SECRET_KEY, jnlpMac)
+                .build();
+        try {
+            client.secrets().inNamespace(namespace).create(secret);
+            LOGGER.log(FINE, () -> "Created JNLP Secret: " + namespace + "/" + secretName);
+        } catch (KubernetesClientException e) {
+            if (e.getCode() == 409) {
+                // Already exists from a previous launcher attempt; the JNLP mac is deterministic
+                // per agent identity, so the existing value is still valid.
+                LOGGER.log(FINE, () -> "JNLP Secret already exists, reusing: " + namespace + "/" + secretName);
+            } else {
+                throw e;
+            }
         }
     }
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -39,6 +39,7 @@ import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import io.fabric8.kubernetes.api.model.EnvVarSourceBuilder;
 import io.fabric8.kubernetes.api.model.ExecAction;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.Pod;
@@ -48,6 +49,7 @@ import io.fabric8.kubernetes.api.model.ProbeBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
+import io.fabric8.kubernetes.api.model.SecretKeySelectorBuilder;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeBuilder;
 import io.fabric8.kubernetes.api.model.VolumeMount;
@@ -96,6 +98,10 @@ public class PodTemplateBuilder {
     public static final Pattern FROM_DIRECTIVE = Pattern.compile("^FROM (.*)$");
 
     public static final String LABEL_KUBERNETES_CONTROLLER = "kubernetes.jenkins.io/controller";
+
+    public static final String JNLP_SECRET_NAME_SUFFIX = "-jnlp-secret";
+    public static final String JNLP_SECRET_KEY = "jenkins-secret";
+
     static final String NO_RECONNECT_AFTER_TIMEOUT =
             SystemProperties.getString(PodTemplateBuilder.class.getName() + ".noReconnectAfter", "1d");
     private static final String JENKINS_AGENT_FILE_ENVVAR = "JENKINS_AGENT_FILE";
@@ -467,8 +473,9 @@ public class PodTemplateBuilder {
         if (agent != null) {
             SlaveComputer computer = agent.getComputer();
             if (computer != null) {
-                // Add some default env vars for Jenkins
-                env.put("JENKINS_SECRET", computer.getJnlpMac());
+                // JENKINS_SECRET is injected via a per-agent Kubernetes Secret (see KubernetesLauncher)
+                // so the literal value never appears in the PodSpec, where anyone with
+                // `get pods` could read it.
                 // JENKINS_AGENT_NAME is default in jnlp-slave
                 // JENKINS_NAME only here for backwords compatability
                 env.put("JENKINS_NAME", computer.getName());
@@ -503,7 +510,24 @@ public class PodTemplateBuilder {
         Map<String, EnvVar> envVarsMap = new HashMap<>();
 
         env.entrySet().forEach(item -> envVarsMap.put(item.getKey(), new EnvVar(item.getKey(), item.getValue(), null)));
+
+        if (agent != null && agent.getComputer() != null) {
+            envVarsMap.put("JENKINS_SECRET", buildJnlpSecretEnvVar(agent.getComputer().getName()));
+        }
         return envVarsMap;
+    }
+
+    private static EnvVar buildJnlpSecretEnvVar(String agentName) {
+        return new EnvVarBuilder()
+                .withName("JENKINS_SECRET")
+                .withValueFrom(new EnvVarSourceBuilder()
+                        .withSecretKeyRef(new SecretKeySelectorBuilder()
+                                .withName(agentName + JNLP_SECRET_NAME_SUFFIX)
+                                .withKey(JNLP_SECRET_KEY)
+                                .withOptional(false)
+                                .build())
+                        .build())
+                .build();
     }
 
     private Container createContainer(

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
@@ -13,6 +13,9 @@ import static org.mockito.Mockito.*;
 
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import io.fabric8.kubernetes.api.model.EnvVarSourceBuilder;
+import io.fabric8.kubernetes.api.model.SecretKeySelectorBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodSecurityContext;
 import io.fabric8.kubernetes.api.model.Quantity;
@@ -476,7 +479,16 @@ public class PodTemplateBuilderTest {
             } else {
                 envVars.add(new EnvVar("JENKINS_URL", JENKINS_URL, null));
             }
-            envVars.add(new EnvVar("JENKINS_SECRET", AGENT_SECRET, null));
+            envVars.add(new EnvVarBuilder()
+                    .withName("JENKINS_SECRET")
+                    .withValueFrom(new EnvVarSourceBuilder()
+                            .withSecretKeyRef(new SecretKeySelectorBuilder()
+                                    .withName(AGENT_NAME + JNLP_SECRET_NAME_SUFFIX)
+                                    .withKey(JNLP_SECRET_KEY)
+                                    .withOptional(false)
+                                    .build())
+                            .build())
+                    .build());
             envVars.add(new EnvVar("JENKINS_NAME", AGENT_NAME, null));
             envVars.add(new EnvVar("JENKINS_AGENT_NAME", AGENT_NAME, null));
             envVars.add(new EnvVar("JENKINS_AGENT_WORKDIR", ContainerTemplate.DEFAULT_WORKING_DIR, null));


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

Closes https://github.com/jenkinsci/kubernetes-plugin/issues/2834

Replaced JENKINS_SECRET env var value from plain text to K8s secret in JNLP container. It is created after pod is created with pod as owner. Pod waits for secret removal before it is deleted.

Unit test provided.

Manul test showing part of the output of command `kubectl describe pod xxx` after the fix where jnlp container env vars are shown
```
Environment:
      JENKINS_SECRET:         <set to the key 'jenkins-secret' in secret 'job-5-45dsn-k1lb8-g3854-jnlp-secret'>  Optional: false
      REMOTING_OPTS:          -noReconnectAfter 1d
      JENKINS_AGENT_NAME:     job-5-45dsn-k1lb8-g3854
      JENKINS_NAME:           job-5-45dsn-k1lb8-g3854
      JENKINS_AGENT_WORKDIR:  /home/jenkins/agent
      JENKINS_URL:            http://host.docker.internal:8080/jenkins/
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
