### PR TITLE
Add retry metadata to replacement agent pods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ nb-configuration.xml
 *.bak
 /.vscode/
 **/.DS_Store
+/.codex-m2-repo/

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@ nb-configuration.xml
 *.bak
 /.vscode/
 **/.DS_Store
-/.codex-m2-repo/

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -929,6 +929,7 @@ public class KubernetesCloud extends Cloud implements PodTemplateGroup {
      */
     public void removeDynamicTemplate(PodTemplate t) {
         PodTemplateMap.get().removeTemplate(this, t);
+        KubernetesSlave.TEMPLATE_PROVISION_COUNTS.remove(t.getId());
     }
 
     @Override

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
@@ -37,10 +37,12 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.metrics.api.Metrics;
@@ -73,6 +75,20 @@ public class KubernetesSlave extends AbstractCloudSlave {
      */
     private static final ResourceBundleHolder HOLDER = ResourceBundleHolder.get(Messages.class);
 
+    /**
+     * Tracks the number of times each dynamic pod template (identified by its ID) has been used
+     * to provision a new agent. This allows detection of retry attempts when a pod fails and
+     * Jenkins requests a replacement agent for the same template.
+     *
+     * <p>Dynamic pod template IDs are UUID-based and unique per {@code podTemplate()} step
+     * invocation, so entries from different builds or clouds cannot collide.
+     *
+     * <p>Entries are removed when the corresponding dynamic template is removed from the cloud
+     * (i.e., when the {@code podTemplate} step block exits). See
+     * {@link KubernetesCloud#removeDynamicTemplate(PodTemplate)}.
+     */
+    static final ConcurrentHashMap<String, AtomicInteger> TEMPLATE_PROVISION_COUNTS = new ConcurrentHashMap<>();
+
     private final String cloudName;
     private String namespace;
 
@@ -84,6 +100,14 @@ public class KubernetesSlave extends AbstractCloudSlave {
 
     @CheckForNull
     private transient Pod pod;
+
+    /**
+     * Attempt index for this pod, starting at {@code 0} for the very first provisioning.
+     * A value of {@code 1} means one prior attempt failed and this pod is the first retry;
+     * {@code 2} means two prior attempts failed, etc.
+     * This is a transient field set at construction time and never persisted.
+     */
+    private transient int retryAttempt;
 
     @NonNull
     public PodTemplate getTemplate() throws IllegalStateException {
@@ -106,6 +130,17 @@ public class KubernetesSlave extends AbstractCloudSlave {
             template = getKubernetesCloud().getTemplateById(podTemplateId);
         }
         return template;
+    }
+
+    /**
+     * Returns the attempt index for this pod.
+     * {@code 0} means the first provisioning (not a retry); {@code 1} means the first retry
+     * (one prior attempt failed); {@code 2} means the second retry, etc.
+     *
+     * @return the attempt index (0 = first attempt, &gt;0 = retry)
+     */
+    public int getRetryAttempt() {
+        return retryAttempt;
     }
 
     /**
@@ -689,7 +724,7 @@ public class KubernetesSlave extends AbstractCloudSlave {
         public KubernetesSlave build() throws IOException, Descriptor.FormException {
             Validate.notNull(podTemplate);
             Validate.notNull(cloud);
-            return new KubernetesSlave(
+            KubernetesSlave slave = new KubernetesSlave(
                     name == null ? getSlaveName(podTemplate) : name,
                     podTemplate,
                     nodeDescription == null ? podTemplate.getName() : nodeDescription,
@@ -701,6 +736,11 @@ public class KubernetesSlave extends AbstractCloudSlave {
                                     ? new KubernetesLauncher(cloud.getJenkinsTunnel(), null)
                                     : computerLauncher),
                     retentionStrategy == null ? determineRetentionStrategy(cloud, podTemplate) : retentionStrategy);
+            int provisionCount = TEMPLATE_PROVISION_COUNTS
+                    .computeIfAbsent(podTemplate.getId(), k -> new AtomicInteger(0))
+                    .incrementAndGet();
+            slave.retryAttempt = provisionCount - 1;
+            return slave;
         }
 
         private ComputerLauncher decorateLauncher(@NonNull KubernetesCloud cloud, @NonNull ComputerLauncher launcher) {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -104,6 +104,7 @@ public class PodTemplateBuilder {
      * Absent on the first provisioning attempt.
      */
     public static final String ANNOTATION_KUBERNETES_RETRY_ATTEMPT = "kubernetes.jenkins.io/retry-attempt";
+
     static final String NO_RECONNECT_AFTER_TIMEOUT =
             SystemProperties.getString(PodTemplateBuilder.class.getName() + ".noReconnectAfter", "1d");
     private static final String JENKINS_AGENT_FILE_ENVVAR = "JENKINS_AGENT_FILE";

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -96,6 +96,14 @@ public class PodTemplateBuilder {
     public static final Pattern FROM_DIRECTIVE = Pattern.compile("^FROM (.*)$");
 
     public static final String LABEL_KUBERNETES_CONTROLLER = "kubernetes.jenkins.io/controller";
+    /** Label added to retry pods: {@code kubernetes.jenkins.io/retry=true}. */
+    public static final String LABEL_KUBERNETES_RETRY = "kubernetes.jenkins.io/retry";
+    /**
+     * Annotation added to retry pods. The value equals {@link KubernetesSlave#getRetryAttempt()}:
+     * {@code "1"} for the first retry, {@code "2"} for the second retry, etc.
+     * Absent on the first provisioning attempt.
+     */
+    public static final String ANNOTATION_KUBERNETES_RETRY_ATTEMPT = "kubernetes.jenkins.io/retry-attempt";
     static final String NO_RECONNECT_AFTER_TIMEOUT =
             SystemProperties.getString(PodTemplateBuilder.class.getName() + ".noReconnectAfter", "1d");
     private static final String JENKINS_AGENT_FILE_ENVVAR = "JENKINS_AGENT_FILE";
@@ -239,6 +247,11 @@ public class PodTemplateBuilder {
         Map<String, String> annotations = getAnnotationsMap(template.getAnnotations());
         if (!annotations.isEmpty()) {
             metadataBuilder.withAnnotations(annotations);
+        }
+        if (agent != null && agent.getRetryAttempt() > 0) {
+            metadataBuilder.addToLabels(LABEL_KUBERNETES_RETRY, "true");
+            metadataBuilder.addToAnnotations(
+                    ANNOTATION_KUBERNETES_RETRY_ATTEMPT, String.valueOf(agent.getRetryAttempt()));
         }
 
         var builder = metadataBuilder.endMetadata().withNewSpec();

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlaveTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlaveTest.java
@@ -173,16 +173,22 @@ public class KubernetesSlaveTest {
         podTemplate.setName("retry-test");
         podTemplate.setLabel("retry-test");
 
-        KubernetesSlave first =
-                new KubernetesSlave.Builder().podTemplate(podTemplate).cloud(cloud).build();
+        KubernetesSlave first = new KubernetesSlave.Builder()
+                .podTemplate(podTemplate)
+                .cloud(cloud)
+                .build();
         assertEquals("First provisioning should not be a retry", 0, first.getRetryAttempt());
 
-        KubernetesSlave second =
-                new KubernetesSlave.Builder().podTemplate(podTemplate).cloud(cloud).build();
+        KubernetesSlave second = new KubernetesSlave.Builder()
+                .podTemplate(podTemplate)
+                .cloud(cloud)
+                .build();
         assertEquals("Second provisioning should be retry #1", 1, second.getRetryAttempt());
 
-        KubernetesSlave third =
-                new KubernetesSlave.Builder().podTemplate(podTemplate).cloud(cloud).build();
+        KubernetesSlave third = new KubernetesSlave.Builder()
+                .podTemplate(podTemplate)
+                .cloud(cloud)
+                .build();
         assertEquals("Third provisioning should be retry #2", 2, third.getRetryAttempt());
 
         cloud.addDynamicTemplate(podTemplate);
@@ -191,10 +197,11 @@ public class KubernetesSlaveTest {
                 "Provision count must be cleared after template removal",
                 KubernetesSlave.TEMPLATE_PROVISION_COUNTS.containsKey(podTemplate.getId()));
 
-        KubernetesSlave afterReset =
-                new KubernetesSlave.Builder().podTemplate(podTemplate).cloud(cloud).build();
-        assertEquals(
-                "After counter reset, first provisioning should not be a retry", 0, afterReset.getRetryAttempt());
+        KubernetesSlave afterReset = new KubernetesSlave.Builder()
+                .podTemplate(podTemplate)
+                .cloud(cloud)
+                .build();
+        assertEquals("After counter reset, first provisioning should not be a retry", 0, afterReset.getRetryAttempt());
     }
 
     @Test

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlaveTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlaveTest.java
@@ -165,6 +165,39 @@ public class KubernetesSlaveTest {
     }
 
     @Test
+    public void testRetryAttemptTracking() throws Exception {
+        KubernetesCloud cloud = new KubernetesCloud("kube");
+        r.jenkins.clouds.add(cloud);
+
+        PodTemplate podTemplate = new PodTemplate();
+        podTemplate.setName("retry-test");
+        podTemplate.setLabel("retry-test");
+
+        KubernetesSlave first =
+                new KubernetesSlave.Builder().podTemplate(podTemplate).cloud(cloud).build();
+        assertEquals("First provisioning should not be a retry", 0, first.getRetryAttempt());
+
+        KubernetesSlave second =
+                new KubernetesSlave.Builder().podTemplate(podTemplate).cloud(cloud).build();
+        assertEquals("Second provisioning should be retry #1", 1, second.getRetryAttempt());
+
+        KubernetesSlave third =
+                new KubernetesSlave.Builder().podTemplate(podTemplate).cloud(cloud).build();
+        assertEquals("Third provisioning should be retry #2", 2, third.getRetryAttempt());
+
+        cloud.addDynamicTemplate(podTemplate);
+        cloud.removeDynamicTemplate(podTemplate);
+        assertFalse(
+                "Provision count must be cleared after template removal",
+                KubernetesSlave.TEMPLATE_PROVISION_COUNTS.containsKey(podTemplate.getId()));
+
+        KubernetesSlave afterReset =
+                new KubernetesSlave.Builder().podTemplate(podTemplate).cloud(cloud).build();
+        assertEquals(
+                "After counter reset, first provisioning should not be a retry", 0, afterReset.getRetryAttempt());
+    }
+
+    @Test
     public void testGetPodRetention() {
         try {
             List<KubernetesSlaveTestCase<PodRetention>> cases = Arrays.asList(

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
@@ -998,8 +998,9 @@ public class PodTemplateBuilderTest {
         assertThat(
                 "retry annotation must be absent on first attempt",
                 pod.getMetadata().getAnnotations() == null
-                        || !pod.getMetadata().getAnnotations().containsKey(
-                                PodTemplateBuilder.ANNOTATION_KUBERNETES_RETRY_ATTEMPT),
+                        || !pod.getMetadata()
+                                .getAnnotations()
+                                .containsKey(PodTemplateBuilder.ANNOTATION_KUBERNETES_RETRY_ATTEMPT),
                 is(true));
     }
 

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
@@ -984,6 +984,42 @@ public class PodTemplateBuilderTest {
         assertThat(pod.getSpec().getNodeSelector(), anEmptyMap());
     }
 
+    @Test
+    public void testNoRetryLabelOnFirstAttempt() throws Exception {
+        when(slave.getRetryAttempt()).thenReturn(0);
+        setupStubs();
+        PodTemplate template = new PodTemplate();
+        template.setYaml(loadYamlFile("pod-busybox.yaml"));
+        Pod pod = new PodTemplateBuilder(template, slave).build();
+        assertThat(
+                "retry label must be absent on first attempt",
+                pod.getMetadata().getLabels(),
+                not(hasKey(PodTemplateBuilder.LABEL_KUBERNETES_RETRY)));
+        assertThat(
+                "retry annotation must be absent on first attempt",
+                pod.getMetadata().getAnnotations() == null
+                        || !pod.getMetadata().getAnnotations().containsKey(
+                                PodTemplateBuilder.ANNOTATION_KUBERNETES_RETRY_ATTEMPT),
+                is(true));
+    }
+
+    @Test
+    public void testRetryLabelAndAnnotationOnRetryAttempt() throws Exception {
+        when(slave.getRetryAttempt()).thenReturn(1);
+        setupStubs();
+        PodTemplate template = new PodTemplate();
+        template.setYaml(loadYamlFile("pod-busybox.yaml"));
+        Pod pod = new PodTemplateBuilder(template, slave).build();
+        assertThat(
+                "retry label must be present on retry attempt",
+                pod.getMetadata().getLabels(),
+                hasEntry(PodTemplateBuilder.LABEL_KUBERNETES_RETRY, "true"));
+        assertThat(
+                "retry-attempt annotation must equal the attempt number",
+                pod.getMetadata().getAnnotations(),
+                hasEntry(PodTemplateBuilder.ANNOTATION_KUBERNETES_RETRY_ATTEMPT, "1"));
+    }
+
     private Map<String, Container> toContainerMap(Pod pod) {
         return pod.getSpec().getContainers().stream()
                 .collect(Collectors.toMap(Container::getName, Function.identity()));


### PR DESCRIPTION
### Testing done

- Added unit coverage in `KubernetesSlaveTest#testRetryAttemptTracking` for retry-attempt tracking and counter cleanup.
- Added unit coverage in `PodTemplateBuilderTest#testNoRetryLabelOnFirstAttempt` and `PodTemplateBuilderTest#testRetryLabelAndAnnotationOnRetryAttempt` for retry pod metadata.
- Ran `docker run --rm -v /Users/zuowuhui/apps/github.com/wuhuizuo/jenkins-kubernetes-plugin:/workspace -w /workspace maven:3.9.9-eclipse-temurin-17 mvn -Dmaven.repo.local=/workspace/.codex-m2-repo -Dtest=KubernetesSlaveTest,PodTemplateBuilderTest test`.
- Result: `Tests run: 41, Failures: 0, Errors: 0, Skipped: 0`, `BUILD SUCCESS`.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
  - Track repeated provisioning for the same dynamic pod template.
  - Add `kubernetes.jenkins.io/retry=true` to retry pods.
  - Add `kubernetes.jenkins.io/retry-attempt` with the retry index.
  - Clear the retry counter when the dynamic template is removed.
- [x] Link to relevant issues in GitHub or Jira
  - No existing GitHub issue or Jira ticket was linked for this change.
- [x] Link to relevant pull requests, esp. upstream and downstream changes
  - Downstream staging update: https://github.com/PingCAP-QE/ee-ops/pull/2014
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed