### PR TITLE
Broaden the 409 handling for OpenShift ClusterResourceQuota

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
@@ -177,9 +177,9 @@ public class KubernetesLauncher extends JNLPLauncher {
                                             namespace,
                                             pod.getMetadata().getName(),
                                             e.getMessage());
-                        } else if (httpCode == 409
-                                && e.getMessage().contains("Operation cannot be fulfilled on resourcequotas")) {
+                        } else if (isResourceQuotaUpdateConflict(httpCode, e.getMessage())) {
                             // See: https://github.com/kubernetes/kubernetes/issues/67761 ; A retry usually works.
+                            // OpenShift ClusterResourceQuota conflicts use clusterresourcequotas.quota.openshift.io.
                             node.getRunListener()
                                     .getLogger()
                                     .printf(
@@ -389,6 +389,19 @@ public class KubernetesLauncher extends JNLPLauncher {
                 }
             }
         }
+    }
+
+    /**
+     * Detects transient quota update conflicts during pod creation.
+     * These occur when concurrent pod creations race to update ResourceQuota or OpenShift ClusterResourceQuota.
+     *
+     * @see <a href="https://github.com/kubernetes/kubernetes/issues/67761">kubernetes#67761</a>
+     */
+    static boolean isResourceQuotaUpdateConflict(int httpCode, @CheckForNull String message) {
+        return httpCode == 409
+                && message != null
+                && message.contains("Operation cannot be fulfilled on")
+                && message.contains("resourcequotas");
     }
 
     /**

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncherTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncherTest.java
@@ -1,0 +1,47 @@
+package org.csanchez.jenkins.plugins.kubernetes;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.jvnet.hudson.test.WithoutJenkins;
+
+public class KubernetesLauncherTest {
+
+    private static final String K8S_RESOURCE_QUOTA_CONFLICT =
+            "Operation cannot be fulfilled on resourcequotas \"compute-resources\": the object has been modified; please apply your changes to the latest version and try again";
+
+    private static final String OPENSHIFT_CLUSTER_RESOURCE_QUOTA_CONFLICT =
+            "Operation cannot be fulfilled on clusterresourcequotas.quota.openshift.io \"dno--notterminating\": the object has been modified; please apply your changes to the latest version and try again";
+
+    @WithoutJenkins
+    @Test
+    public void isResourceQuotaUpdateConflict_kubernetesResourceQuota() {
+        assertTrue(KubernetesLauncher.isResourceQuotaUpdateConflict(409, K8S_RESOURCE_QUOTA_CONFLICT));
+    }
+
+    @WithoutJenkins
+    @Test
+    public void isResourceQuotaUpdateConflict_openshiftClusterResourceQuota() {
+        assertTrue(KubernetesLauncher.isResourceQuotaUpdateConflict(409, OPENSHIFT_CLUSTER_RESOURCE_QUOTA_CONFLICT));
+    }
+
+    @WithoutJenkins
+    @Test
+    public void isResourceQuotaUpdateConflict_not409() {
+        assertFalse(KubernetesLauncher.isResourceQuotaUpdateConflict(403, K8S_RESOURCE_QUOTA_CONFLICT));
+    }
+
+    @WithoutJenkins
+    @Test
+    public void isResourceQuotaUpdateConflict_nullMessage() {
+        assertFalse(KubernetesLauncher.isResourceQuotaUpdateConflict(409, null));
+    }
+
+    @WithoutJenkins
+    @Test
+    public void isResourceQuotaUpdateConflict_unrelated409() {
+        assertFalse(
+                KubernetesLauncher.isResourceQuotaUpdateConflict(409, "pods \"my-pod\" already exists"));
+    }
+}

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncherTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncherTest.java
@@ -41,7 +41,6 @@ public class KubernetesLauncherTest {
     @WithoutJenkins
     @Test
     public void isResourceQuotaUpdateConflict_unrelated409() {
-        assertFalse(
-                KubernetesLauncher.isResourceQuotaUpdateConflict(409, "pods \"my-pod\" already exists"));
+        assertFalse(KubernetesLauncher.isResourceQuotaUpdateConflict(409, "pods \"my-pod\" already exists"));
     }
 }


### PR DESCRIPTION
Currently, `409` responses are handled (retried) only for this string - `Operation cannot be fulfilled on resourcequotas`
In Openshift (Distribution of kubernetes), the unique `ClusterResourceQuota` is also used similarly (but on the cluster level).
That increases this resource's chance of being updated, as it's doing so for **any** namespace.

This change will include both `Operation cannot be fulfilled on resourcequotas` (_kubernetes_) and `Operation cannot be fulfilled on clusterresourcequotas` (_openshift_)

This issue is mentioned in https://github.com/jenkinsci/kubernetes-plugin/issues/2843

AI usage: Co-authored with Cursor

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
