### PR TITLE
Update Windows tests from LTSC 2019 to LTSC 2022

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecorator.java
@@ -623,8 +623,8 @@ public class ContainerExecDecorator extends LauncherDecorator implements Seriali
                     if (!launcher.isUnix() && toggleOutputForCaller != null) {
                         // Windows welcome message should not be sent to the caller as it is a side-effect of calling
                         // the wrapping cmd.exe
-                        // Microsoft Windows [Version 10.0.17763.2686]
-                        // (c) 2018 Microsoft Corporation. All rights reserved.
+                        // Microsoft Windows [Version 10.0.20348.4893]
+                        // (c) Microsoft Corporation. All rights reserved.
                         //
                         // C:\>
                         stream.flush();

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/help-directConnection.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/help-directConnection.html
@@ -12,7 +12,7 @@
 
   <p>
     <b>Note:</b> In <i>Direct Connection</i> mode agents will not be able to reconnect to a restarted controller if a <i>Random</i> 'TCP port for inbound agents' is configured!<br/>
-    <b>Note:</b> <i>Direct Connection</i> does not work with the currently available <code>jenkins/inbound-agent:windowsservercore-1809</code> image.
+    <b>Note:</b> <i>Direct Connection</i> does not work with the currently available <code>jenkins/inbound-agent:windowsservercore-ltsc2022</code> image.
   </p>
 
 </div>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/samples/windows.groovy
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/samples/windows.groovy
@@ -8,9 +8,9 @@ kind: Pod
 spec:
   containers:
   - name: jnlp
-    image: jenkins/inbound-agent:windowsservercore-1809
+    image: jenkins/inbound-agent:windowsservercore-ltsc2022
   - name: shell
-    image: mcr.microsoft.com/powershell:preview-windowsservercore-1809
+    image: mcr.microsoft.com/powershell:preview-windowsservercore-ltsc2022
     command:
     - powershell
     args:
@@ -18,6 +18,7 @@ spec:
     - 999999
   nodeSelector:
     kubernetes.io/os: windows
+    node.kubernetes.io/windows-build: 10.0.20348
 ''') {
     retry(count: 2, conditions: [kubernetesAgent(), nonresumable()]) {
         node(POD_LABEL) {

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesTestUtil.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesTestUtil.java
@@ -31,7 +31,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeNoException;
 import static org.junit.Assume.assumeTrue;
 
-import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.Util;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.fabric8.kubernetes.api.model.Node;
@@ -81,7 +80,7 @@ public class KubernetesTestUtil {
     public static final String CONTAINER_ENV_VAR_FROM_SECRET_VALUE = "container-pa55w0rd";
     public static final String POD_ENV_VAR_FROM_SECRET_VALUE = "pod-pa55w0rd";
 
-    public static final String WINDOWS_1809_BUILD = "10.0.17763";
+    public static final String WINDOWS_LTSC_2022_BUILD = "10.0.20348";
 
     public static KubernetesCloud setupCloud(Object test, TestName name) throws KubernetesAuthException, IOException {
         KubernetesCloud cloud = new KubernetesCloud("kubernetes");
@@ -159,7 +158,7 @@ public class KubernetesTestUtil {
         assumeTrue("Cluster seems to contain no Windows nodes with build " + buildNumber, isWindows(buildNumber));
     }
 
-    public static boolean isWindows(@CheckForNull String buildNumber) {
+    public static boolean isWindows(String buildNumber) {
         try (KubernetesClient client = new KubernetesClientBuilder().build()) {
             for (Node n : client.nodes().list().getItems()) {
                 Map<String, String> labels = n.getMetadata().getLabels();
@@ -167,10 +166,8 @@ public class KubernetesTestUtil {
                 String windowsBuild = labels.get("node.kubernetes.io/windows-build");
                 LOGGER.info(() -> "Found node " + n.getMetadata().getName() + " running OS " + os
                         + " with Windows build " + windowsBuild);
-                if ("windows".equals(os)) {
-                    if (buildNumber == null || buildNumber.equals(windowsBuild)) {
-                        return true;
-                    }
+                if ("windows".equals(os) && buildNumber.equals(windowsBuild)) {
+                    return true;
                 }
             }
         }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorWindowsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorWindowsTest.java
@@ -24,7 +24,7 @@
 
 package org.csanchez.jenkins.plugins.kubernetes.pipeline;
 
-import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.WINDOWS_1809_BUILD;
+import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.WINDOWS_LTSC_2022_BUILD;
 import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.assumeKubernetes;
 import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.assumeWindows;
 import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.deletePods;
@@ -99,7 +99,7 @@ public class ContainerExecDecoratorWindowsTest {
     @BeforeClass
     public static void setUpClass() throws Exception {
         assumeKubernetes();
-        assumeWindows(WINDOWS_1809_BUILD);
+        assumeWindows(WINDOWS_LTSC_2022_BUILD);
     }
 
     @Before
@@ -108,7 +108,7 @@ public class ContainerExecDecoratorWindowsTest {
         client = cloud.connect();
         deletePods(client, getLabels(this, name), false);
 
-        String image = "mcr.microsoft.com/windows:" + WINDOWS_1809_BUILD + ".2686";
+        String image = "mcr.microsoft.com/powershell:preview-windowsservercore-ltsc2022";
         String containerName = "container";
         String podName = "test-command-execution-" + RandomStringUtils.random(5, "bcdfghjklmnpqrstvwxz0123456789");
         pod = client.pods()
@@ -125,7 +125,7 @@ public class ContainerExecDecoratorWindowsTest {
                                 .withArgs("Start-Sleep", "2147483")
                                 .build())
                         .addToNodeSelector("kubernetes.io/os", "windows")
-                        .addToNodeSelector("node.kubernetes.io/windows-build", WINDOWS_1809_BUILD)
+                        .addToNodeSelector("node.kubernetes.io/windows-build", WINDOWS_LTSC_2022_BUILD)
                         .withTerminationGracePeriodSeconds(0L)
                         .endSpec()
                         .build());

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesPipelineTest.java
@@ -28,7 +28,7 @@ import static jenkins.test.RunMatchers.logContains;
 import static org.awaitility.Awaitility.await;
 import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.CONTAINER_ENV_VAR_FROM_SECRET_VALUE;
 import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.POD_ENV_VAR_FROM_SECRET_VALUE;
-import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.WINDOWS_1809_BUILD;
+import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.WINDOWS_LTSC_2022_BUILD;
 import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.assumeWindows;
 import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.deletePods;
 import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.getLabels;
@@ -109,6 +109,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.LoggerRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import org.jvnet.hudson.test.TestExtension;
+import org.jvnet.hudson.test.recipes.WithTimeout;
 
 public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
 
@@ -729,8 +730,9 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
 
     @Issue("JENKINS-57256")
     @Test
+    @WithTimeout(value = 900) // in case we need to pull windows docker image
     public void basicWindows() throws Exception {
-        assumeWindows(WINDOWS_1809_BUILD);
+        assumeWindows(WINDOWS_LTSC_2022_BUILD);
         cloud.setDirectConnection(false); // not yet supported by
         // https://github.com/jenkinsci/docker-inbound-agent/blob/517ccd68fd1ce420e7526ca6a40320c9a47a2c18/jenkins-agent.ps1
         r.assertBuildStatusSuccess(r.waitForCompletion(b));
@@ -740,8 +742,9 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
 
     @Issue("JENKINS-53500")
     @Test
+    @WithTimeout(value = 900) // in case we need to pull windows docker image
     public void windowsContainer() throws Exception {
-        assumeWindows(WINDOWS_1809_BUILD);
+        assumeWindows(WINDOWS_LTSC_2022_BUILD);
         cloud.setDirectConnection(false);
         r.assertBuildStatusSuccess(r.waitForCompletion(b));
         r.assertLogContains("Directory of C:\\home\\jenkins\\agent\\workspace\\windows Container\\subdir", b);
@@ -752,7 +755,7 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
     @Test
     @Ignore("Does not appear fixable: https://github.com/jenkinsci/kubernetes-plugin/pull/1724#discussion_r2287512410")
     public void interruptedPodWindows() throws Exception {
-        assumeWindows(WINDOWS_1809_BUILD);
+        assumeWindows(WINDOWS_LTSC_2022_BUILD);
         cloud.setDirectConnection(false);
         r.waitForMessage("starting to sleep", b);
         b.getExecutor().interrupt();
@@ -762,20 +765,22 @@ public class KubernetesPipelineTest extends AbstractKubernetesPipelineTest {
 
     @Test
     @Issue("JENKINS-75563")
+    @WithTimeout(value = 900) // in case we need to pull windows docker image
     // Before PR#1724 this would fail as windows processes were not killed
     // and hence files blocked. The test is a bit unrealistic as I want it
     // to be fast and deterministic, but imagine that instead of the ping we execute
     // a big checkout that locks some files and prevents next steps to execute
     public void killsProcessesWindows() throws Exception {
-        assumeWindows(WINDOWS_1809_BUILD);
+        assumeWindows(WINDOWS_LTSC_2022_BUILD);
         cloud.setDirectConnection(false);
         r.assertBuildStatus(Result.ABORTED, r.waitForCompletion(b));
         r.assertLogContains("\"It worked!\"", b);
     }
 
     @Test
+    @WithTimeout(value = 900) // in case we need to pull windows docker image
     public void secretMaskingWindows() throws Exception {
-        assumeWindows(WINDOWS_1809_BUILD);
+        assumeWindows(WINDOWS_LTSC_2022_BUILD);
         cloud.setDirectConnection(false);
         r.assertBuildStatusSuccess(r.waitForCompletion(b));
         r.assertLogContains(

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesSamplesTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesSamplesTest.java
@@ -45,7 +45,7 @@ public class KubernetesSamplesTest extends AbstractKubernetesPipelineTest {
     @Test
     public void smokes() throws Exception {
         for (GroovySample gs : ExtensionList.lookup(GroovySample.class)) {
-            if (gs.name().equals("kubernetes-windows") && !isWindows(null)) {
+            if (gs.name().equals("kubernetes-windows") && !isWindows(WINDOWS_LTSC_2022_BUILD)) {
                 System.err.println("==== Skipping " + gs.title() + " ====");
                 continue;
             }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/RestartPipelineTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/RestartPipelineTest.java
@@ -64,6 +64,7 @@ import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsSessionRule;
 import org.jvnet.hudson.test.LoggerRule;
+import org.jvnet.hudson.test.recipes.WithTimeout;
 
 public class RestartPipelineTest {
     protected static final String CONTAINER_ENV_VAR_VALUE = "container-env-var-value";
@@ -221,8 +222,9 @@ public class RestartPipelineTest {
     }
 
     @Test
+    @WithTimeout(value = 900) // in case we need to pull windows docker image
     public void windowsRestart() throws Throwable {
-        assumeWindows(WINDOWS_1809_BUILD);
+        assumeWindows(WINDOWS_LTSC_2022_BUILD);
         AtomicReference<String> projectName = new AtomicReference<>();
         story.then(r -> {
             configureAgentListener();

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/basicWindows.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/basicWindows.groovy
@@ -4,10 +4,10 @@ kind: Pod
 spec:
   containers:
   - name: jnlp
-    image: jenkins/inbound-agent:windowsservercore-1809
+    image: jenkins/inbound-agent:windowsservercore-ltsc2022
   nodeSelector:
     kubernetes.io/os: windows
-    node.kubernetes.io/windows-build: 10.0.17763
+    node.kubernetes.io/windows-build: 10.0.20348
 '''
 ) {
     node(POD_LABEL) {

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/interruptedPodWindows.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/interruptedPodWindows.groovy
@@ -4,9 +4,9 @@ kind: Pod
 spec:
   containers:
   - name: jnlp
-    image: jenkins/inbound-agent:windowsservercore-1809
+    image: jenkins/inbound-agent:windowsservercore-ltsc2022
   - name: shell
-    image: mcr.microsoft.com/powershell:preview-windowsservercore-1809
+    image: mcr.microsoft.com/powershell:preview-windowsservercore-ltsc2022
     command:
     - powershell
     args:
@@ -14,7 +14,7 @@ spec:
     - 999999
   nodeSelector:
     kubernetes.io/os: windows
-    node.kubernetes.io/windows-build: 10.0.17763
+    node.kubernetes.io/windows-build: 10.0.20348
 ''') {
     node(POD_LABEL) {
         container('shell') {

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/killsProcessesWindows.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/killsProcessesWindows.groovy
@@ -7,7 +7,7 @@ kind: Pod
 spec:
   containers:
   - name: jnlp
-    image: "jenkins/inbound-agent:windowsservercore-1809"
+    image: "jenkins/inbound-agent:windowsservercore-ltsc2022"
     imagePullPolicy: IfNotPresent
     resources:
       cpu:
@@ -16,6 +16,7 @@ spec:
         request: 2Gi
   nodeSelector:
     kubernetes.io/os: windows
+    node.kubernetes.io/windows-build: 10.0.20348
 """
         }
     }

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/secretMaskingWindows.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/secretMaskingWindows.groovy
@@ -4,7 +4,7 @@ kind: Pod
 spec:
   containers:
   - name: jnlp
-    image: jenkins/inbound-agent:windowsservercore-1809
+    image: jenkins/inbound-agent:windowsservercore-ltsc2022
     env:
     - name: POD_ENV_VAR_FROM_SECRET
       valueFrom:
@@ -12,7 +12,7 @@ spec:
           key: password
           name: pod-secret
   - name: shell
-    image: mcr.microsoft.com/powershell:preview-windowsservercore-1809
+    image: mcr.microsoft.com/powershell:preview-windowsservercore-ltsc2022
     command:
     - powershell
     args:
@@ -26,7 +26,7 @@ spec:
           name: container-secret
   nodeSelector:
     kubernetes.io/os: windows
-    node.kubernetes.io/windows-build: 10.0.17763
+    node.kubernetes.io/windows-build: 10.0.20348
 ''') {
     node(POD_LABEL) {
         powershell 'echo "INSIDE_POD_ENV_VAR_FROM_SECRET = $Env:POD_ENV_VAR_FROM_SECRET or $($Env:POD_ENV_VAR_FROM_SECRET.ToUpper())"'

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/windowsContainer.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/windowsContainer.groovy
@@ -4,9 +4,9 @@ kind: Pod
 spec:
   containers:
   - name: jnlp
-    image: jenkins/inbound-agent:windowsservercore-1809
+    image: jenkins/inbound-agent:windowsservercore-ltsc2022
   - name: shell
-    image: mcr.microsoft.com/powershell:preview-windowsservercore-1809
+    image: mcr.microsoft.com/powershell:preview-windowsservercore-ltsc2022
     command:
     - powershell
     args:
@@ -14,7 +14,7 @@ spec:
     - 999999
   nodeSelector:
     kubernetes.io/os: windows
-    node.kubernetes.io/windows-build: 10.0.17763
+    node.kubernetes.io/windows-build: 10.0.20348
 '''
 ) {
     node(POD_LABEL) {

--- a/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/windowsRestart.groovy
+++ b/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/pipeline/windowsRestart.groovy
@@ -4,9 +4,9 @@ kind: Pod
 spec:
   containers:
   - name: jnlp
-    image: jenkins/inbound-agent:windowsservercore-1809
+    image: jenkins/inbound-agent:windowsservercore-ltsc2022
   - name: shell
-    image: mcr.microsoft.com/powershell:preview-windowsservercore-1809
+    image: mcr.microsoft.com/powershell:preview-windowsservercore-ltsc2022
     command:
     - powershell
     args:
@@ -14,7 +14,7 @@ spec:
     - 999999
   nodeSelector:
     kubernetes.io/os: windows
-    node.kubernetes.io/windows-build: 10.0.17763
+    node.kubernetes.io/windows-build: 10.0.20348
 ''') {
     node(POD_LABEL) {
         container('shell') {


### PR DESCRIPTION
Follow-up to #1149.

## Summary

- Update all Windows pipeline Groovy scripts to use `windowsservercore-ltsc2022` images and `node.kubernetes.io/windows-build: 10.0.20348` node selector
- Add `@WithTimeout(value = 900)` to Windows test methods (image pulls on a fresh node can be very slow)
- Switch `ContainerExecDecoratorWindowsTest` from the non-existent `mcr.microsoft.com/windows:10.0.20348.2686` tag to `mcr.microsoft.com/powershell:preview-windowsservercore-ltsc2022`, consistent with other Windows tests
- Update the `windows` sample pipeline (shown in the Jenkins UI and exercised by `KubernetesSamplesTest`) to ltsc2022 images, and add `node.kubernetes.io/windows-build: 10.0.20348` so it is not accidentally scheduled on a 2019 node in a mixed-version cluster
- Make `KubernetesTestUtil.isWindows` require a non-null build number (there is no valid reason to check for any Windows node regardless of version); update `KubernetesSamplesTest` to pass `WINDOWS_LTSC_2022_BUILD`
- Update help text and illustrative comment in `ContainerExecDecorator` to reference 2022 version numbers

All modified Windows tests verified against a GKE cluster with an LTSC 2022 node pool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)