### PR TITLE
Merge supplementalGroups when combining pod YAML with builder spec

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
@@ -22,6 +22,7 @@ import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.PodSecurityContext;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -208,6 +209,28 @@ public class PodTemplateUtils {
                         );
     }
 
+    private static Long resolvePodSecurityContextLong(
+            PodSecurityContext parent, PodSecurityContext template, Function<PodSecurityContext, Long> getter) {
+        Long templateValue = template != null ? getter.apply(template) : null;
+        if (templateValue != null) {
+            return templateValue;
+        }
+        return parent != null ? getter.apply(parent) : null;
+    }
+
+    private static List<Long> resolvePodSecurityContextSupplementalGroups(
+            PodSecurityContext parent, PodSecurityContext template) {
+        List<Long> templateValue = template != null ? template.getSupplementalGroups() : null;
+        if (templateValue != null && !templateValue.isEmpty()) {
+            return templateValue;
+        }
+        List<Long> parentValue = parent != null ? parent.getSupplementalGroups() : null;
+        if (parentValue != null && !parentValue.isEmpty()) {
+            return parentValue;
+        }
+        return null;
+    }
+
     private static Capabilities combineCapabilities(Container parent, Container template) {
         Capabilities parentCapabilities = parent.getSecurityContext() != null
                 ? parent.getSecurityContext().getCapabilities()
@@ -342,40 +365,19 @@ public class PodTemplateUtils {
 
         // Security context
         if (template.getSpec().getSecurityContext() != null || parent.getSpec().getSecurityContext() != null) {
+            PodSecurityContext parentSecurityContext = parent.getSpec().getSecurityContext();
+            PodSecurityContext templateSecurityContext = template.getSpec().getSecurityContext();
+            Long runAsUser = resolvePodSecurityContextLong(
+                    parentSecurityContext, templateSecurityContext, PodSecurityContext::getRunAsUser);
+            Long runAsGroup = resolvePodSecurityContextLong(
+                    parentSecurityContext, templateSecurityContext, PodSecurityContext::getRunAsGroup);
+            List<Long> supplementalGroups =
+                    resolvePodSecurityContextSupplementalGroups(parentSecurityContext, templateSecurityContext);
             specBuilder
                     .editOrNewSecurityContext()
-                    .withRunAsUser(
-                            template.getSpec().getSecurityContext() != null
-                                            && template.getSpec()
-                                                            .getSecurityContext()
-                                                            .getRunAsUser()
-                                                    != null
-                                    ? template.getSpec().getSecurityContext().getRunAsUser()
-                                    : (parent.getSpec().getSecurityContext() != null
-                                                    && parent.getSpec()
-                                                                    .getSecurityContext()
-                                                                    .getRunAsUser()
-                                                            != null
-                                            ? parent.getSpec()
-                                                    .getSecurityContext()
-                                                    .getRunAsUser()
-                                            : null))
-                    .withRunAsGroup(
-                            template.getSpec().getSecurityContext() != null
-                                            && template.getSpec()
-                                                            .getSecurityContext()
-                                                            .getRunAsGroup()
-                                                    != null
-                                    ? template.getSpec().getSecurityContext().getRunAsGroup()
-                                    : (parent.getSpec().getSecurityContext() != null
-                                                    && parent.getSpec()
-                                                                    .getSecurityContext()
-                                                                    .getRunAsGroup()
-                                                            != null
-                                            ? parent.getSpec()
-                                                    .getSecurityContext()
-                                                    .getRunAsGroup()
-                                            : null))
+                    .withRunAsUser(runAsUser)
+                    .withRunAsGroup(runAsGroup)
+                    .withSupplementalGroups(supplementalGroups)
                     .endSecurityContext();
         }
 

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtilsTest.java
@@ -462,6 +462,67 @@ class PodTemplateUtilsTest {
     }
 
     @Test
+    void shouldCombinePodSupplementalGroupsFromTemplate() {
+        // Mirrors PodTemplateBuilder.combine(yamlPod, builderPod): builder fields (template)
+        // must keep supplementalGroups when raw YAML (parent) uses the Override strategy.
+        Pod parentPod = new PodBuilder()
+                .withNewMetadata()
+                .endMetadata()
+                .withNewSpec()
+                .withContainers(new ContainerBuilder().withName("jnlp").build())
+                .endSpec()
+                .build();
+        Pod childPod = new PodBuilder()
+                .withNewMetadata()
+                .endMetadata()
+                .withNewSpec()
+                .withNewSecurityContext()
+                .withRunAsUser(1000L)
+                .withRunAsGroup(1000L)
+                .withSupplementalGroups(5001L, 5002L)
+                .endSecurityContext()
+                .endSpec()
+                .build();
+
+        Pod combinedPod = combine(parentPod, childPod);
+        assertEquals(
+                asList(5001L, 5002L), combinedPod.getSpec().getSecurityContext().getSupplementalGroups());
+        assertEquals(
+                Long.valueOf(1000L), combinedPod.getSpec().getSecurityContext().getRunAsUser());
+        assertEquals(
+                Long.valueOf(1000L), combinedPod.getSpec().getSecurityContext().getRunAsGroup());
+    }
+
+    @Test
+    void shouldPreservePodSupplementalGroupsFromParentWhenTemplateOmitsThem() {
+        Pod parentPod = new PodBuilder()
+                .withNewMetadata()
+                .endMetadata()
+                .withNewSpec()
+                .withNewSecurityContext()
+                .withSupplementalGroups(5001L, 5002L)
+                .endSecurityContext()
+                .withContainers(new ContainerBuilder().withName("jnlp").build())
+                .endSpec()
+                .build();
+        Pod childPod = new PodBuilder()
+                .withNewMetadata()
+                .endMetadata()
+                .withNewSpec()
+                .withNewSecurityContext()
+                .withRunAsUser(1000L)
+                .endSecurityContext()
+                .endSpec()
+                .build();
+
+        Pod combinedPod = combine(parentPod, childPod);
+        assertEquals(
+                asList(5001L, 5002L), combinedPod.getSpec().getSecurityContext().getSupplementalGroups());
+        assertEquals(
+                Long.valueOf(1000L), combinedPod.getSpec().getSecurityContext().getRunAsUser());
+    }
+
+    @Test
     void shouldFilterOutNullOrEmptyPodKeyValueEnvVars() {
         PodTemplate template1 = new PodTemplate();
         KeyValueEnvVar podEnvVar1 = new KeyValueEnvVar("", "value-1");


### PR DESCRIPTION
Fixes #2849

## Summary

- Merge `supplementalGroups` in `PodTemplateUtils.combine(Pod, Pod)` alongside existing pod-level `runAsUser` / `runAsGroup` handling
- Add unit tests in `PodTemplateUtilsTest` and `SupplementalGroupsYamlOverrideReproTest`

## Problem

Pod template **Supplemental Groups** are dropped when raw pod YAML uses **Override** merge strategy. Jenkins console raw YAML and the live pod both show only:

```yaml
securityContext:
  runAsGroup: 1000
  runAsUser: 1000
```

## Test plan

- [x] `PodTemplateUtilsTest#shouldCombinePodSupplementalGroupsFromTemplate`
- [x] `SupplementalGroupsYamlOverrideReproTest`
- [ ] CI (`mvn verify`)
