### PR TITLE
Remove commons-lang2 usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
     <spotless.check.skip>false</spotless.check.skip>
     <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
     <banObsoleteDependencyOverrides.skip>false</banObsoleteDependencyOverrides.skip>
+    <ban-commons-lang-2.skip>false</ban-commons-lang-2.skip>
   </properties>
 
   <dependencyManagement>

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/ContainerTemplate.java
@@ -16,7 +16,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.TreeMap;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
 import org.csanchez.jenkins.plugins.kubernetes.model.TemplateEnvVar;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
@@ -307,7 +306,7 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
 
         argMap.put("name", name);
 
-        if (!StringUtils.isEmpty(shell)) {
+        if (shell != null && !shell.isEmpty()) {
             argMap.put("shell", shell);
         }
 
@@ -342,7 +341,7 @@ public class ContainerTemplate extends AbstractDescribableImpl<ContainerTemplate
         }
 
         public FormValidation doCheckImage(@QueryParameter String value) {
-            if (StringUtils.isEmpty(value)) {
+            if (value == null || value.isEmpty()) {
                 return FormValidation.ok("Image is mandatory");
             } else if (PodTemplateUtils.validateImage(value)) {
                 return FormValidation.ok();

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -1,7 +1,6 @@
 package org.csanchez.jenkins.plugins.kubernetes;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.commons.lang.StringUtils.isEmpty;
 import static org.csanchez.jenkins.plugins.kubernetes.PodTemplateUtils.sanitizeLabel;
 
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
@@ -76,7 +75,6 @@ import jenkins.security.FIPS140;
 import jenkins.util.SystemProperties;
 import jenkins.websocket.WebSockets;
 import net.sf.json.JSONObject;
-import org.apache.commons.lang.StringUtils;
 import org.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateMap;
 import org.csanchez.jenkins.plugins.kubernetes.pod.retention.Default;
 import org.csanchez.jenkins.plugins.kubernetes.pod.retention.PodRetention;
@@ -755,7 +753,7 @@ public class KubernetesCloud extends Cloud implements PodTemplateGroup {
      * @param url Kubernetes server URL
      */
     private static void ensureKubernetesUrlInFipsMode(String url) {
-        if (!FIPS140.useCompliantAlgorithms() || StringUtils.isBlank(url)) {
+        if (!FIPS140.useCompliantAlgorithms() || url == null || url.isBlank()) {
             return;
         }
         if (!url.startsWith("https:")) {
@@ -790,7 +788,7 @@ public class KubernetesCloud extends Cloud implements PodTemplateGroup {
         if (!FIPS140.useCompliantAlgorithms()) {
             return;
         }
-        if (StringUtils.isBlank(serverCertificate)) {
+        if (serverCertificate == null || serverCertificate.isBlank()) {
             return; // JENKINS-73789, no certificate is accepted
         }
         try {
@@ -1057,7 +1055,7 @@ public class KubernetesCloud extends Cloud implements PodTemplateGroup {
 
             checkPermission(_context);
 
-            if (StringUtils.isBlank(name)) return FormValidation.error("name is required");
+            if (name == null || name.isBlank()) return FormValidation.error("name is required");
 
             try (KubernetesClient client = new KubernetesFactoryAdapter(
                             serverUrl,
@@ -1202,21 +1200,24 @@ public class KubernetesCloud extends Cloud implements PodTemplateGroup {
                 }
             }
 
+            boolean isJenkinsUrlConfigured = jenkinsUrl != null && !jenkinsUrl.isEmpty();
             if (value) {
                 if (webSocket) {
                     return FormValidation.error("Direct connection and WebSocket mode are mutually exclusive");
                 }
-                if (!isEmpty(jenkinsUrl))
+                if (isJenkinsUrlConfigured)
                     return FormValidation.warning("No need to configure Jenkins URL when direct connection is enabled");
 
                 if (Jenkins.get().getSlaveAgentPort() == 0)
                     return FormValidation.warning(
                             "A random 'TCP port for inbound agents' is configured in Global Security settings. In 'direct connection' mode agents will not be able to reconnect to a restarted controller with random port!");
             } else {
-                if (isEmpty(jenkinsUrl)) {
-                    String url = StringUtils.defaultIfBlank(
-                            System.getProperty("KUBERNETES_JENKINS_URL", System.getenv("KUBERNETES_JENKINS_URL")),
-                            JenkinsLocationConfiguration.get().getUrl());
+                if (!isJenkinsUrlConfigured) {
+                    String rawUrl =
+                            System.getProperty("KUBERNETES_JENKINS_URL", System.getenv("KUBERNETES_JENKINS_URL"));
+                    String url = (rawUrl != null && !rawUrl.isBlank())
+                            ? rawUrl
+                            : JenkinsLocationConfiguration.get().getUrl();
                     if (url != null) {
                         return FormValidation.ok("Will connect using " + url);
                     } else {
@@ -1263,7 +1264,7 @@ public class KubernetesCloud extends Cloud implements PodTemplateGroup {
         public FormValidation doCheckJenkinsUrl(@QueryParameter String value, @QueryParameter boolean directConnection)
                 throws IOException, ServletException {
             try {
-                if (!isEmpty(value)) new URL(value);
+                if (value != null && !value.isEmpty()) new URL(value);
             } catch (MalformedURLException e) {
                 return FormValidation.error(e, "Invalid Jenkins URL");
             }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesComputer.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesComputer.java
@@ -29,7 +29,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import org.acegisecurity.Authentication;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.kubernetes.auth.KubernetesAuthException;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest2;
@@ -89,7 +88,8 @@ public class KubernetesComputer extends AbstractCloudComputer<KubernetesSlave> {
         KubernetesCloud cloud = slave.getKubernetesCloud();
         KubernetesClient client = cloud.connect();
 
-        String namespace = StringUtils.defaultIfBlank(slave.getNamespace(), client.getNamespace());
+        String slaveNs = slave.getNamespace();
+        String namespace = (slaveNs != null && !slaveNs.isBlank()) ? slaveNs : client.getNamespace();
         Pod pod = client.pods().inNamespace(namespace).withName(getName()).get();
 
         if (pod == null) {
@@ -111,7 +111,8 @@ public class KubernetesComputer extends AbstractCloudComputer<KubernetesSlave> {
             KubernetesCloud cloud = slave.getKubernetesCloud();
             KubernetesClient client = cloud.connect();
 
-            String namespace = StringUtils.defaultIfBlank(slave.getNamespace(), client.getNamespace());
+            String slaveNs = slave.getNamespace();
+            String namespace = (slaveNs != null && !slaveNs.isBlank()) ? slaveNs : client.getNamespace();
 
             Pod pod = client.pods().inNamespace(namespace).withName(getName()).get();
             if (pod != null) {
@@ -146,7 +147,8 @@ public class KubernetesComputer extends AbstractCloudComputer<KubernetesSlave> {
         KubernetesSlave slave = getNode();
         if (slave != null) {
             KubernetesCloud cloud = slave.getKubernetesCloud();
-            String namespace = StringUtils.defaultIfBlank(slave.getNamespace(), cloud.getNamespace());
+            String slaveNs = slave.getNamespace();
+            String namespace = (slaveNs != null && !slaveNs.isBlank()) ? slaveNs : cloud.getNamespace();
             PodResource resource = cloud.getPodResource(namespace, containerId);
 
             // check if pod exists

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFactoryAdapter.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesFactoryAdapter.java
@@ -24,7 +24,6 @@ import java.util.Set;
 import java.util.logging.Logger;
 import jenkins.authentication.tokens.api.AuthenticationTokens;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.kubernetes.auth.KubernetesAuth;
 import org.jenkinsci.plugins.kubernetes.auth.KubernetesAuthConfig;
 import org.jenkinsci.plugins.kubernetes.auth.KubernetesAuthException;
@@ -171,7 +170,7 @@ public class KubernetesFactoryAdapter {
 
         ConfigBuilder builder;
 
-        if (StringUtils.isBlank(serviceAddress)) {
+        if (serviceAddress == null || serviceAddress.isBlank()) {
             LOGGER.log(FINE, "Autoconfiguring Kubernetes client");
             builder = new ConfigBuilder(Config.autoConfigure(null));
         } else {
@@ -200,9 +199,10 @@ public class KubernetesFactoryAdapter {
         builder.withMaxConcurrentRequestsPerHost(maxRequestsPerHost);
         builder.withMaxConcurrentRequests(maxRequestsPerHost);
 
-        if (!StringUtils.isBlank(namespace)) {
+        String builderNamespace = builder.getNamespace();
+        if (namespace != null && !namespace.isBlank()) {
             builder.withNamespace(namespace);
-        } else if (StringUtils.isBlank(builder.getNamespace())) {
+        } else if (builderNamespace == null || builderNamespace.isBlank()) {
             builder.withNamespace("default");
         }
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
@@ -58,7 +58,6 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import jenkins.metrics.api.Metrics;
 import jenkins.util.SystemProperties;
-import org.apache.commons.lang.StringUtils;
 import org.csanchez.jenkins.plugins.kubernetes.pod.decorator.PodDecoratorException;
 import org.csanchez.jenkins.plugins.kubernetes.pod.retention.Reaper;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -152,7 +151,7 @@ public class KubernetesLauncher extends JNLPLauncher {
             String namespace = Arrays.asList( //
                             pod.getMetadata().getNamespace(), template.getNamespace(), client.getNamespace()) //
                     .stream()
-                    .filter(s -> StringUtils.isNotBlank(s))
+                    .filter(s -> s != null && !s.isBlank())
                     .findFirst()
                     .orElse(null);
             node.setNamespace(namespace);
@@ -411,7 +410,7 @@ public class KubernetesLauncher extends JNLPLauncher {
                         .inContainer(containerStatus.getName())
                         .tailingLines(30)
                         .getLog();
-                if (!StringUtils.isBlank(log)) {
+                if (log != null && !log.isBlank()) {
                     String msg =
                             errors != null ? String.format(" exited with error %s", errors.get(containerName)) : "";
                     LOGGER.log(

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesSlave.java
@@ -46,8 +46,6 @@ import java.util.logging.Logger;
 import jenkins.metrics.api.Metrics;
 import jenkins.model.Jenkins;
 import jenkins.security.MasterToSlaveCallable;
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.Validate;
 import org.csanchez.jenkins.plugins.kubernetes.pod.retention.PodRetention;
 import org.jenkinsci.plugins.durabletask.executors.OnceRetentionStrategy;
 import org.jenkinsci.plugins.kubernetes.auth.KubernetesAuthException;
@@ -243,8 +241,10 @@ public class KubernetesSlave extends AbstractCloudSlave {
                         .filter(c -> JNLP_NAME.equals(c.getName()))
                         .findFirst();
                 if (optionalJnlp.isPresent()) {
-                    remoteFS = StringUtils.defaultIfBlank(
-                            optionalJnlp.get().getWorkingDir(), ContainerTemplate.DEFAULT_WORKING_DIR);
+                    String jnlpWorkingDir = optionalJnlp.get().getWorkingDir();
+                    remoteFS = (jnlpWorkingDir != null && !jnlpWorkingDir.isBlank())
+                            ? jnlpWorkingDir
+                            : ContainerTemplate.DEFAULT_WORKING_DIR;
                 }
             }
         }
@@ -260,7 +260,7 @@ public class KubernetesSlave extends AbstractCloudSlave {
             // if computer is null then channel is null and thus we were going to return null anyway
             return null;
         } else {
-            return createPath(StringUtils.defaultString(computer.getAbsoluteRemoteFs(), getRemoteFS()));
+            return createPath(Objects.toString(computer.getAbsoluteRemoteFs(), getRemoteFS()));
         }
     }
 
@@ -330,7 +330,7 @@ public class KubernetesSlave extends AbstractCloudSlave {
 
     static String getSlaveName(PodTemplate template) {
         String name = template.getName();
-        if (StringUtils.isEmpty(name)) {
+        if (name == null || name.isEmpty()) {
             name = DEFAULT_AGENT_PREFIX;
         }
 
@@ -687,8 +687,8 @@ public class KubernetesSlave extends AbstractCloudSlave {
                 value = "UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR",
                 justification = "False positive. https://github.com/spotbugs/spotbugs/issues/567")
         public KubernetesSlave build() throws IOException, Descriptor.FormException {
-            Validate.notNull(podTemplate);
-            Validate.notNull(cloud);
+            Objects.requireNonNull(podTemplate);
+            Objects.requireNonNull(cloud);
             return new KubernetesSlave(
                     name == null ? getSlaveName(podTemplate) : name,
                     podTemplate,

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodContainerSource.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodContainerSource.java
@@ -12,7 +12,6 @@ import io.fabric8.kubernetes.api.model.PodStatus;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import org.apache.commons.lang.StringUtils;
 
 /**
  * Pod container sources are responsible to locating details about Pod containers.
@@ -98,7 +97,7 @@ public abstract class PodContainerSource implements ExtensionPoint {
             }
 
             return podStatus.getContainerStatuses().stream()
-                    .filter(cs -> StringUtils.equals(cs.getName(), containerName))
+                    .filter(cs -> Objects.equals(cs.getName(), containerName))
                     .findFirst();
         }
     }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodLabel.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodLabel.java
@@ -13,7 +13,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import org.apache.commons.lang.Validate;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -76,7 +75,9 @@ public class PodLabel extends AbstractDescribableImpl<PodLabel> implements Seria
     }
 
     static List<PodLabel> listOf(String... keyValue) {
-        Validate.isTrue(keyValue.length % 2 == 0, "Expecting an even number of arguments");
+        if (keyValue.length % 2 != 0) {
+            throw new IllegalArgumentException("Expecting an even number of arguments");
+        }
         List<PodLabel> labels = new ArrayList<>();
         for (int i = 0; i < keyValue.length / 2; i++) {
             labels.add(new PodLabel(keyValue[2 * i], keyValue[2 * i + 1]));

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplate.java
@@ -39,7 +39,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
-import org.apache.commons.lang.StringUtils;
 import org.csanchez.jenkins.plugins.kubernetes.model.TemplateEnvVar;
 import org.csanchez.jenkins.plugins.kubernetes.pod.retention.PodRetention;
 import org.csanchez.jenkins.plugins.kubernetes.pod.yaml.YamlMergeStrategy;
@@ -395,7 +394,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
 
     @DataBoundSetter
     public void setInstanceCapStr(String instanceCapStr) {
-        if (StringUtils.isBlank(instanceCapStr)) {
+        if (instanceCapStr == null || instanceCapStr.isBlank()) {
             setInstanceCap(Integer.MAX_VALUE);
         } else {
             setInstanceCap(Integer.parseInt(instanceCapStr));
@@ -412,7 +411,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
 
     @DataBoundSetter
     public void setSlaveConnectTimeoutStr(String slaveConnectTimeoutStr) {
-        if (StringUtils.isBlank(slaveConnectTimeoutStr)) {
+        if (slaveConnectTimeoutStr == null || slaveConnectTimeoutStr.isBlank()) {
             setSlaveConnectTimeout(DEFAULT_SLAVE_JENKINS_CONNECTION_TIMEOUT);
         } else {
             setSlaveConnectTimeout(Integer.parseInt(slaveConnectTimeoutStr));
@@ -443,7 +442,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
 
     @DataBoundSetter
     public void setIdleMinutesStr(String idleMinutes) {
-        if (StringUtils.isBlank(idleMinutes)) {
+        if (idleMinutes == null || idleMinutes.isBlank()) {
             setIdleMinutes(0);
         } else {
             setIdleMinutes(Integer.parseInt(idleMinutes));
@@ -460,7 +459,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
 
     @DataBoundSetter
     public void setActiveDeadlineSecondsStr(String activeDeadlineSeconds) {
-        if (StringUtils.isBlank(activeDeadlineSeconds)) {
+        if (activeDeadlineSeconds == null || activeDeadlineSeconds.isBlank()) {
             setActiveDeadlineSeconds(0);
         } else {
             setActiveDeadlineSeconds(Integer.parseInt(activeDeadlineSeconds));
@@ -1069,7 +1068,7 @@ public class PodTemplate extends AbstractDescribableImpl<PodTemplate> implements
     }
 
     private void optionalField(StringBuilder builder, String label, String value) {
-        if (StringUtils.isNotBlank(value)) {
+        if (value != null && !value.isBlank()) {
             if (builder.length() > 0) {
                 builder.append(", ");
             }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -63,6 +63,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -71,7 +72,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import jenkins.model.Jenkins;
 import jenkins.util.SystemProperties;
-import org.apache.commons.lang.StringUtils;
 import org.csanchez.jenkins.plugins.kubernetes.model.TemplateEnvVar;
 import org.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution;
 import org.csanchez.jenkins.plugins.kubernetes.pod.decorator.PodDecorator;
@@ -308,7 +308,7 @@ public class PodTemplateBuilder {
         }
 
         // default agent container
-        String agentContainerName = StringUtils.defaultString(template.getAgentContainer(), JNLP_NAME);
+        String agentContainerName = Objects.toString(template.getAgentContainer(), JNLP_NAME);
         Optional<Container> agentOpt = pod.getSpec().getContainers().stream()
                 .filter(c -> agentContainerName.equals(c.getName()))
                 .findFirst();
@@ -324,12 +324,14 @@ public class PodTemplateBuilder {
                 .filter(c -> c.getWorkingDir() == null)
                 .forEach(c -> c.setWorkingDir(workingDir));
         String agentImage = DEFAULT_AGENT_IMAGE;
-        if (cloud != null && StringUtils.isNotEmpty(cloud.getJnlpregistry())) {
-            agentImage = Util.ensureEndsWith(cloud.getJnlpregistry(), "/") + agentImage;
-        } else if (StringUtils.isNotEmpty(DEFAULT_JNLP_DOCKER_REGISTRY_PREFIX)) {
+        String jnlpRegistry = cloud != null ? cloud.getJnlpregistry() : null;
+        if (jnlpRegistry != null && !jnlpRegistry.isEmpty()) {
+            agentImage = Util.ensureEndsWith(jnlpRegistry, "/") + agentImage;
+        } else if (DEFAULT_JNLP_DOCKER_REGISTRY_PREFIX != null && !DEFAULT_JNLP_DOCKER_REGISTRY_PREFIX.isEmpty()) {
             agentImage = Util.ensureEndsWith(DEFAULT_JNLP_DOCKER_REGISTRY_PREFIX, "/") + agentImage;
         }
-        if (StringUtils.isBlank(agentContainer.getImage())) {
+        String existingImage = agentContainer.getImage();
+        if (existingImage == null || existingImage.isBlank()) {
             agentContainer.setImage(agentImage);
         }
         Map<String, EnvVar> envVars = new HashMap<>();
@@ -438,11 +440,11 @@ public class PodTemplateBuilder {
                 // the processing of globalEnvVars below will override;
                 // see org.jenkinsci.remoting.engine.JnlpAgentEndpointResolver
                 String noProxy = System.getenv("no_proxy");
-                if (!StringUtils.isBlank(noProxy)) {
+                if (noProxy != null && !noProxy.isBlank()) {
                     env.put("no_proxy", noProxy);
                 }
                 String httpProxy = System.getenv("http_proxy");
-                if (!StringUtils.isBlank(httpProxy)) {
+                if (httpProxy != null && !httpProxy.isBlank()) {
                     env.put("http_proxy", httpProxy);
                 }
             }
@@ -481,7 +483,8 @@ public class PodTemplateBuilder {
 
             KubernetesCloud cloud = agent.getKubernetesCloud();
 
-            if (!StringUtils.isBlank(cloud.getJenkinsTunnel())) {
+            String jenkinsTunnel = cloud.getJenkinsTunnel();
+            if (jenkinsTunnel != null && !jenkinsTunnel.isBlank()) {
                 env.put("JENKINS_TUNNEL", cloud.getJenkinsTunnel());
             }
 
@@ -615,15 +618,15 @@ public class PodTemplateBuilder {
         String actualMemory = substituteEnv(memory);
         String actualCpu = substituteEnv(cpu);
         String actualEphemeralStorage = substituteEnv(ephemeralStorage);
-        if (StringUtils.isNotBlank(actualMemory)) {
+        if (actualMemory != null && !actualMemory.isBlank()) {
             Quantity memoryQuantity = new Quantity(actualMemory);
             builder.put("memory", memoryQuantity);
         }
-        if (StringUtils.isNotBlank(actualCpu)) {
+        if (actualCpu != null && !actualCpu.isBlank()) {
             Quantity cpuQuantity = new Quantity(actualCpu);
             builder.put("cpu", cpuQuantity);
         }
-        if (StringUtils.isNotBlank(actualEphemeralStorage)) {
+        if (actualEphemeralStorage != null && !actualEphemeralStorage.isBlank()) {
             Quantity ephemeralStorageQuantity = new Quantity(actualEphemeralStorage);
             builder.put("ephemeral-storage", ephemeralStorageQuantity);
         }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateUtils.java
@@ -53,7 +53,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.commons.lang.StringUtils;
 import org.apache.tools.ant.types.Commandline;
 import org.csanchez.jenkins.plugins.kubernetes.model.TemplateEnvVar;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.PodVolume;
@@ -673,7 +672,7 @@ public class PodTemplateUtils {
     public static Pod parseFromYaml(String yaml) {
         String s = yaml;
         // JENKINS-57116
-        if (StringUtils.isBlank(s)) {
+        if (s == null || s.isBlank()) {
             LOGGER.log(Level.WARNING, "[JENKINS-57116] Trying to parse invalid yaml: \"{0}\"", yaml);
             s = "{}";
         }
@@ -704,7 +703,7 @@ public class PodTemplateUtils {
     }
 
     public static Collection<String> validateYamlContainerNames(String yaml) {
-        if (StringUtils.isBlank(yaml)) {
+        if (yaml == null || yaml.isBlank()) {
             return Collections.emptyList();
         }
         Collection<String> errors = new ArrayList<>();
@@ -733,7 +732,7 @@ public class PodTemplateUtils {
      * Pulled from https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
      */
     public static boolean validateLabel(String label) {
-        return StringUtils.isBlank(label)
+        return (label == null || label.isBlank())
                 ? true
                 : label.length() <= 63 && LABEL_VALIDATION.matcher(label).matches();
     }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodUtils.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodUtils.java
@@ -26,6 +26,7 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodStatus;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
+import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -38,14 +39,15 @@ import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.RandomStringUtils;
-import org.apache.commons.lang.StringUtils;
 import org.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution;
 
 public final class PodUtils {
     private PodUtils() {}
 
     private static final Logger LOGGER = Logger.getLogger(PodUtils.class.getName());
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+    private static final String RANDOM_CHARS = "bcdfghjklmnpqrstvwxz0123456789";
 
     private static final Pattern NAME_PATTERN =
             Pattern.compile("[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*");
@@ -142,7 +144,7 @@ public final class PodUtils {
                             LOGGER.log(
                                     Level.FINE,
                                     () -> "Cancelling queue item: \"" + item.task.getDisplayName() + "\"\n"
-                                            + (!StringUtils.isBlank(reason) ? "due to " + reason : ""));
+                                            + (reason != null && !reason.isBlank() ? "due to " + reason : ""));
                             queue.cancel(item);
                         },
                         () -> {
@@ -208,7 +210,11 @@ public final class PodUtils {
      */
     @NonNull
     public static String generateRandomSuffix() {
-        return RandomStringUtils.random(5, "bcdfghjklmnpqrstvwxz0123456789");
+        StringBuilder sb = new StringBuilder(5);
+        for (int i = 0; i < 5; i++) {
+            sb.append(RANDOM_CHARS.charAt(RANDOM.nextInt(RANDOM_CHARS.length())));
+        }
+        return sb.toString();
     }
 
     /**

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgent.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgent.java
@@ -17,7 +17,6 @@ import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
-import org.apache.commons.lang.StringUtils;
 import org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate;
 import org.csanchez.jenkins.plugins.kubernetes.PodTemplate;
 import org.csanchez.jenkins.plugins.kubernetes.pod.retention.PodRetention;
@@ -399,7 +398,7 @@ public class KubernetesDeclarativeAgent extends RetryableDeclarativeAgent<Kubern
             argMap.put("containers", containerTemplates);
         }
 
-        if (!StringUtils.isEmpty(yaml)) {
+        if (yaml != null && !yaml.isEmpty()) {
             argMap.put("yaml", yaml);
         }
         if (showRawYaml != null) {
@@ -414,7 +413,7 @@ public class KubernetesDeclarativeAgent extends RetryableDeclarativeAgent<Kubern
         if (workspaceVolume != null) {
             argMap.put("workspaceVolume", workspaceVolume);
         }
-        if (!StringUtils.isEmpty(cloud)) {
+        if (cloud != null && !cloud.isEmpty()) {
             argMap.put("cloud", cloud);
         }
         if (idleMinutes != 0) {
@@ -423,16 +422,16 @@ public class KubernetesDeclarativeAgent extends RetryableDeclarativeAgent<Kubern
         if (inheritFrom != null) {
             argMap.put("inheritFrom", inheritFrom);
         }
-        if (!StringUtils.isEmpty(serviceAccount)) {
+        if (serviceAccount != null && !serviceAccount.isEmpty()) {
             argMap.put("serviceAccount", serviceAccount);
         }
-        if (!StringUtils.isEmpty(nodeSelector)) {
+        if (nodeSelector != null && !nodeSelector.isEmpty()) {
             argMap.put("nodeSelector", nodeSelector);
         }
-        if (!StringUtils.isEmpty(namespace)) {
+        if (namespace != null && !namespace.isEmpty()) {
             argMap.put("namespace", namespace);
         }
-        if (!StringUtils.isEmpty(workingDir)) {
+        if (workingDir != null && !workingDir.isEmpty()) {
             argMap.put("workingDir", workingDir);
         }
         if (activeDeadlineSeconds != 0) {
@@ -447,10 +446,10 @@ public class KubernetesDeclarativeAgent extends RetryableDeclarativeAgent<Kubern
         if (instanceCap > 0 && instanceCap < Integer.MAX_VALUE) {
             argMap.put("instanceCap", instanceCap);
         }
-        if (!StringUtils.isEmpty(supplementalGroups)) {
+        if (supplementalGroups != null && !supplementalGroups.isEmpty()) {
             argMap.put("supplementalGroups", supplementalGroups);
         }
-        if (!StringUtils.isEmpty(agentContainer)) {
+        if (agentContainer != null && !agentContainer.isEmpty()) {
             argMap.put("agentContainer", agentContainer);
         }
         if (agentInjection) {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStep.java
@@ -18,7 +18,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
 import org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate;
 import org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud;
 import org.csanchez.jenkins.plugins.kubernetes.PodAnnotation;
@@ -500,7 +499,8 @@ public class PodTemplateStep extends Step implements Serializable {
             if (cloud instanceof KubernetesCloud) {
                 List<PodTemplate> templates = ((KubernetesCloud) cloud).getTemplates();
                 result.addAll(templates.stream()
-                        .filter(template -> StringUtils.isNotEmpty(template.getName()))
+                        .filter(template -> template.getName() != null
+                                && !template.getName().isEmpty())
                         .map(PodTemplate::getName)
                         .map(ListBoxModel.Option::new)
                         .collect(Collectors.toList()));

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/PodTemplateStepExecution.java
@@ -19,7 +19,6 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.RandomStringUtils;
 import org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate;
 import org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud;
 import org.csanchez.jenkins.plugins.kubernetes.KubernetesFolderProperty;
@@ -28,6 +27,7 @@ import org.csanchez.jenkins.plugins.kubernetes.PodAnnotation;
 import org.csanchez.jenkins.plugins.kubernetes.PodImagePullSecret;
 import org.csanchez.jenkins.plugins.kubernetes.PodTemplate;
 import org.csanchez.jenkins.plugins.kubernetes.PodTemplateUtils;
+import org.csanchez.jenkins.plugins.kubernetes.PodUtils;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
 import org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback;
 import org.jenkinsci.plugins.workflow.steps.BodyInvoker;
@@ -75,8 +75,8 @@ public class PodTemplateStepExecution extends AbstractStepExecutionImpl {
         String label;
         String podTemplateLabel = step.getLabel();
         if (podTemplateLabel == null) {
-            var sanitized = PodTemplateUtils.sanitizeLabel(run.getExternalizableId()) + "-"
-                    + RandomStringUtils.random(5, "bcdfghjklmnpqrstvwxz0123456789");
+            var sanitized =
+                    PodTemplateUtils.sanitizeLabel(run.getExternalizableId()) + "-" + PodUtils.generateRandomSuffix();
             assert PodTemplateUtils.validateLabel(sanitized) : sanitized;
             label = sanitized;
         } else {
@@ -85,7 +85,7 @@ public class PodTemplateStepExecution extends AbstractStepExecutionImpl {
 
         // Let's generate a random name based on the user specified to make sure that we don't have
         // issues with concurrent builds, or messing with pre-existing configuration
-        String randString = RandomStringUtils.random(5, "bcdfghjklmnpqrstvwxz0123456789");
+        String randString = PodUtils.generateRandomSuffix();
         String stepName = step.getName();
         if (stepName == null) {
             stepName = label;

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/decorator/DefaultRestartPolicy.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/decorator/DefaultRestartPolicy.java
@@ -3,7 +3,6 @@ package org.csanchez.jenkins.plugins.kubernetes.pod.decorator;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import io.fabric8.kubernetes.api.model.Pod;
-import org.apache.commons.lang.StringUtils;
 import org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud;
 
 /**
@@ -14,7 +13,8 @@ public class DefaultRestartPolicy implements PodDecorator {
     @NonNull
     @Override
     public Pod decorate(@NonNull KubernetesCloud kubernetesCloud, @NonNull Pod pod) {
-        if (StringUtils.isBlank(pod.getSpec().getRestartPolicy())) {
+        String restartPolicy = pod.getSpec().getRestartPolicy();
+        if (restartPolicy == null || restartPolicy.isBlank()) {
             pod.getSpec().setRestartPolicy("Never");
         }
         return pod;

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes/ProvisionedVolume.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes/ProvisionedVolume.java
@@ -3,7 +3,7 @@ package org.csanchez.jenkins.plugins.kubernetes.volumes;
 import io.fabric8.kubernetes.api.model.Quantity;
 import java.util.Collections;
 import java.util.Map;
-import org.apache.commons.lang.StringUtils;
+import java.util.Objects;
 
 public interface ProvisionedVolume {
     default String getStorageClassNameOrDefault() {
@@ -17,13 +17,13 @@ public interface ProvisionedVolume {
     }
 
     default String getRequestsSizeOrDefault() {
-        return StringUtils.defaultString(getRequestsSize(), "10Gi");
+        return Objects.toString(getRequestsSize(), "10Gi");
     }
 
     String getRequestsSize();
 
     default String getAccessModesOrDefault() {
-        return StringUtils.defaultString(getAccessModes(), "ReadWriteOnce");
+        return Objects.toString(getAccessModes(), "ReadWriteOnce");
     }
 
     String getAccessModes();

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes/SecretVolume.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes/SecretVolume.java
@@ -30,7 +30,6 @@ import hudson.model.Descriptor;
 import io.fabric8.kubernetes.api.model.SecretVolumeSource;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeBuilder;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -61,7 +60,7 @@ public class SecretVolume extends PodVolume {
         secretVolumeSource.setSecretName(getSecretName());
         secretVolumeSource.setOptional(getOptional());
 
-        if (StringUtils.isNotBlank(defaultMode)) {
+        if (defaultMode != null && !defaultMode.isBlank()) {
             secretVolumeSource.setDefaultMode(Integer.parseInt(getDefaultMode()));
         }
 

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesTestUtil.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesTestUtil.java
@@ -56,7 +56,6 @@ import java.util.stream.IntStream;
 import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -88,7 +87,7 @@ public class KubernetesTestUtil {
 
         // if there is a namespace specific for this branch (ie. kubernetes-plugin-test-master), use it
         String branch = System.getenv("BRANCH_NAME");
-        if (StringUtils.isNotBlank(branch)) {
+        if (branch != null && !branch.isBlank()) {
             String namespaceWithBranch = String.format("%s-%s", DEFAULT_TESTING_NAMESPACE, branch);
             LOGGER.log(FINE, "Trying to use namespace: {0}", testingNamespace);
             try {
@@ -122,7 +121,7 @@ public class KubernetesTestUtil {
         // Agents running in Kubernetes (minikube) need to connect to this server, so localhost does not work
         URL url = new URL(JenkinsLocationConfiguration.get().getUrl());
         String hostAddress = System.getProperty("jenkins.host.address");
-        if (org.apache.commons.lang3.StringUtils.isBlank(hostAddress)) {
+        if (hostAddress == null || hostAddress.isBlank()) {
             hostAddress = InetAddress.getLocalHost().getHostAddress();
         }
         System.err.println("Calling home to address: " + hostAddress);

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodUtilsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodUtilsTest.java
@@ -6,7 +6,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.IntStream;
-import org.apache.commons.lang.StringUtils;
 import org.junit.jupiter.api.Test;
 
 class PodUtilsTest {
@@ -38,9 +37,9 @@ class PodUtilsTest {
         assertTrue(name.startsWith("foo-bar-cat-"));
 
         // very long names
-        name = PodUtils.createNameWithRandomSuffix(StringUtils.repeat("a", 70));
+        name = PodUtils.createNameWithRandomSuffix("a".repeat(70));
         assertEquals(63, name.length());
-        assertTrue(name.startsWith(StringUtils.repeat("a", 57) + "-"));
+        assertTrue(name.startsWith("a".repeat(57) + "-"));
     }
 
     @Test

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/AbstractKubernetesPipelineRJRTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/AbstractKubernetesPipelineRJRTest.java
@@ -2,7 +2,6 @@ package org.csanchez.jenkins.plugins.kubernetes.pipeline;
 
 import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.assumeKubernetes;
 
-import org.apache.commons.lang.StringUtils;
 import org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil;
 import org.csanchez.jenkins.plugins.kubernetes.pipeline.steps.CreateWorkflowJobThenScheduleRun;
 import org.csanchez.jenkins.plugins.kubernetes.pipeline.steps.RunId;
@@ -20,7 +19,7 @@ abstract class AbstractKubernetesPipelineRJRTest {
 
     {
         String port = System.getProperty("port");
-        if (StringUtils.isNotBlank(port)) {
+        if (port != null && !port.isBlank()) {
             System.err.println("Overriding port using system property: " + port);
             rjr = rjr.withPort(Integer.parseInt(port));
         }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorTest.java
@@ -28,6 +28,7 @@ import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.assumeK
 import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.deletePods;
 import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.getLabels;
 import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.setupCloud;
+import static org.csanchez.jenkins.plugins.kubernetes.PodUtils.createNameWithRandomSuffix;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContaining;
@@ -63,8 +64,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import org.apache.commons.io.output.TeeOutputStream;
-import org.apache.commons.lang.RandomStringUtils;
-import org.apache.commons.lang.StringUtils;
 import org.csanchez.jenkins.plugins.kubernetes.KubernetesClientProvider;
 import org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud;
 import org.csanchez.jenkins.plugins.kubernetes.KubernetesSlave;
@@ -122,7 +121,7 @@ class ContainerExecDecoratorTest {
         deletePods(client, getLabels(this, name), false);
 
         String image = "busybox";
-        String podName = "test-command-execution-" + RandomStringUtils.random(5, "bcdfghjklmnpqrstvwxz0123456789");
+        String podName = createNameWithRandomSuffix("test-command-execution");
         pod = client.pods()
                 .create(new PodBuilder()
                         .withNewMetadata()
@@ -299,13 +298,15 @@ class ContainerExecDecoratorTest {
         // Check output with quiet=false
         ProcReturn r = execCommand(false, false, "sh", "-c", "echo " + testString);
         assertEquals(0, r.exitCode);
-        String output = StringUtils.substringAfter(r.output, "exit");
+        int exitIdx = r.output.indexOf("exit");
+        String output = exitIdx >= 0 ? r.output.substring(exitIdx + "exit".length()) : "";
         assertEquals(testString, output.trim());
 
         // Check output with quiet=false and outputForCaller same as launcher output
         r = execCommand(false, true, "sh", "-c", "echo " + testString);
         assertEquals(0, r.exitCode);
-        output = StringUtils.substringAfter(r.output, "exit");
+        exitIdx = r.output.indexOf("exit");
+        output = exitIdx >= 0 ? r.output.substring(exitIdx + "exit".length()) : "";
         assertEquals(testString, output.trim());
 
         // Check output with quiet=true

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorWindowsTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerExecDecoratorWindowsTest.java
@@ -30,6 +30,7 @@ import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.assumeW
 import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.deletePods;
 import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.getLabels;
 import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.setupCloud;
+import static org.csanchez.jenkins.plugins.kubernetes.PodUtils.createNameWithRandomSuffix;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.doReturn;
@@ -56,7 +57,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import org.apache.commons.io.output.TeeOutputStream;
-import org.apache.commons.lang.RandomStringUtils;
 import org.csanchez.jenkins.plugins.kubernetes.KubernetesClientProvider;
 import org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud;
 import org.csanchez.jenkins.plugins.kubernetes.KubernetesSlave;
@@ -108,7 +108,7 @@ class ContainerExecDecoratorWindowsTest {
 
         String image = "mcr.microsoft.com/powershell:preview-windowsservercore-ltsc2022";
         String containerName = "container";
-        String podName = "test-command-execution-" + RandomStringUtils.random(5, "bcdfghjklmnpqrstvwxz0123456789");
+        String podName = createNameWithRandomSuffix("test-command-execution");
         pod = client.pods()
                 .create(new PodBuilder()
                         .withNewMetadata()


### PR DESCRIPTION
Prepare for https://github.com/jenkinsci/jenkins/pull/26105 by removing the commons-lang2 usages. As the usages are simple migrating to the JDK equivalents.

**Testing done**

Manual verification, and AI code review - correctness verified.
Compiles cleanly with lang2 removed local jenkins - `mvn clean compile -Djenkins.version=2.574-SNAPSHOT`