### PR TITLE
Remove timeout on `KubernetesSamplesTest`

### DIFF
--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesSamplesTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesSamplesTest.java
@@ -19,15 +19,12 @@ package org.csanchez.jenkins.plugins.kubernetes.pipeline;
 import static org.csanchez.jenkins.plugins.kubernetes.KubernetesTestUtil.*;
 
 import hudson.ExtensionList;
-import java.util.concurrent.TimeUnit;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.cps.GroovySample;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 
-@Timeout(value = 2, unit = TimeUnit.MINUTES)
 class KubernetesSamplesTest extends AbstractKubernetesPipelineTest {
 
     @BeforeEach


### PR DESCRIPTION
#1734 apparently mistranslated

```java
r.timeout *= 2;
```

to mean a 2m timeout. In fact the original was _doubling_ the 3m timeout from `JenkinsRule`, to 6m! So it could easily [time out pulling images](https://github.com/jenkinsci/kubernetes-plugin/pull/2837/checks?check_run_id=88972501844).

AFAICT `@WithJenkins` applies no default timeout; at least, this test edited to run a sleep loop ran for >5m. (This plugin has a 90m per-branch build timeout. Typical `buildPlugin` defaults to a 60m timeout.)