### PR TITLE
Remove obsolete `jenkins-test-harness.version` override

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,6 @@
     <spotless.check.skip>false</spotless.check.skip>
     <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
     <banObsoleteDependencyOverrides.skip>false</banObsoleteDependencyOverrides.skip>
-    <jenkins-test-harness.version>2573.vd91b_8a_43e019</jenkins-test-harness.version>
     <ban-commons-lang-2.skip>false</ban-commons-lang-2.skip>
   </properties>
 


### PR DESCRIPTION
Regression in #2837, specifically 3df9fbb75f34d0d9fbb7a2d77921cf16cf152f04. Easily reproducible locally. I have not yet figured out why CI is not flagging it, including in dd5315be0d0da63c49ca73305d1fbc5e42d55c8c.