### PR TITLE
Do not inline the agent connection secret in the pod spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -818,6 +818,7 @@ Please read [Features controlled by system properties](https://www.jenkins.io/do
 * `jenkins.host.address` : (for unit tests) controls the host agents should use to contact Jenkins
 * `org.csanchez.jenkins.plugins.kubernetes.KubernetesLauncher.templateResolutionTimeout` : How long to wait for a dynamic pod template to be re-registered after a restart before giving up (defaults to `60sec`)
 * `org.csanchez.jenkins.plugins.kubernetes.PodTemplate.connectionTimeout` : The time in seconds to wait before considering the pod scheduling has failed (defaults to `1000`)
+* `org.csanchez.jenkins.plugins.kubernetes.PodTemplateBuilder.secretViaSecretKeyRef` : Whether the agent connection secret is passed to the agent container through a `secretKeyRef` pointing at a per-agent `Secret` rather than being inlined in clear text in the pod spec (defaults to `true`). This requires the controller service account to be allowed to `create`, `update` and `delete` secrets in the agent namespace; set it to `false` if that permission cannot be granted.
 * `org.csanchez.jenkins.plugins.kubernetes.pipeline.ContainerExecDecorator.stdinBufferSize` : stdin buffer size in bytes for commands sent to Kubernetes exec api. A low value will cause slowness in commands executed. A higher value will consume more memory (defaults to `16*1024`)
 * `org.csanchez.jenkins.plugins.kubernetes.pipeline.ContainerExecDecorator.websocketConnectionTimeout` : Time to wait for the websocket used by `container` step to connect (defaults to `30`)
 

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncher.java
@@ -40,14 +40,20 @@ import hudson.slaves.JNLPLauncher;
 import hudson.slaves.SlaveComputer;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.OwnerReference;
+import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -166,10 +172,14 @@ public class KubernetesLauncher extends JNLPLauncher {
             Pod existingPod =
                     client.pods().inNamespace(namespace).withName(podName).get();
             if (existingPod == null) {
+                // The agent connection secret is passed to the agent container through a secretKeyRef, so the secret
+                // holding it must exist before the pod is created, otherwise the kubelet fails to start the container.
+                createAgentSecret(client, namespace, podName, computer.getJnlpMac());
                 LOGGER.log(FINE, () -> "Creating Pod: " + cloudName + " " + namespace + "/" + podName);
                 try {
                     pod = client.pods().inNamespace(namespace).create(pod);
                 } catch (KubernetesClientException e) {
+                    deleteAgentSecret(client, namespace, podName);
                     Metrics.metricRegistry()
                             .counter(MetricNames.CREATION_FAILED)
                             .inc();
@@ -217,6 +227,9 @@ public class KubernetesLauncher extends JNLPLauncher {
                     }
                     throw e;
                 }
+                // Now that the pod exists, make it own the secret so that the secret is garbage collected along with
+                // it.
+                adoptAgentSecret(client, namespace, pod);
                 LOGGER.log(INFO, () -> "Created Pod: " + cloudName + " " + namespace + "/" + podName);
                 listener.getLogger().printf("Created Pod: %s %s/%s%n", cloudName, namespace, podName);
                 Metrics.metricRegistry().counter(MetricNames.PODS_CREATED).inc();
@@ -363,6 +376,99 @@ public class KubernetesLauncher extends JNLPLauncher {
             }
         }
         return node.getTemplate();
+    }
+
+    /**
+     * Creates the {@link Secret} holding the agent connection secret referenced by the {@code JENKINS_SECRET}
+     * environment variable of the agent container, so that the secret is not inlined in clear text in the pod spec.
+     *
+     * <p>The secret has to exist before the pod is created, otherwise the kubelet refuses to start the agent container.
+     * It is adopted by the pod right after the pod is created (see {@link #adoptAgentSecret}) so that it is garbage
+     * collected along with it.
+     *
+     * <p>Does nothing if {@link PodTemplateBuilder#SECRET_VIA_SECRET_KEY_REF} has been disabled, in which case the
+     * value is inlined in the pod spec as before.
+     */
+    static void createAgentSecret(KubernetesClient client, String namespace, String podName, String jnlpMac) {
+        if (!PodTemplateBuilder.SECRET_VIA_SECRET_KEY_REF) {
+            return;
+        }
+        String secretName = PodTemplateBuilder.agentSecretName(podName);
+        Secret secret = new SecretBuilder()
+                .withNewMetadata()
+                .withName(secretName)
+                .withNamespace(namespace)
+                .endMetadata()
+                .withType("Opaque")
+                .withData(Map.of(
+                        PodTemplateBuilder.JENKINS_SECRET_KEY,
+                        Base64.getEncoder().encodeToString(jnlpMac.getBytes(StandardCharsets.UTF_8))))
+                .build();
+        LOGGER.log(FINE, () -> "Creating Secret: " + namespace + "/" + secretName);
+        try {
+            client.secrets().inNamespace(namespace).resource(secret).create();
+        } catch (KubernetesClientException e) {
+            if (e.getCode() == 409) {
+                // Left over from a previous launch attempt of the same agent; the connection secret of a given
+                // computer is stable, but replace it anyway so that a stale value cannot linger.
+                LOGGER.log(FINE, () -> "Secret already exists, replacing: " + namespace + "/" + secretName);
+                client.secrets().inNamespace(namespace).resource(secret).update();
+            } else {
+                throw e;
+            }
+        }
+    }
+
+    /**
+     * Adds an owner reference from the agent secret to the agent pod, so that deleting the pod also deletes the secret.
+     * Best effort: a leftover secret is reaped by {@link Reaper} along with the pod, so failing here must not fail the
+     * launch.
+     */
+    static void adoptAgentSecret(KubernetesClient client, String namespace, Pod pod) {
+        if (!PodTemplateBuilder.SECRET_VIA_SECRET_KEY_REF) {
+            return;
+        }
+        String secretName = PodTemplateBuilder.agentSecretName(pod.getMetadata().getName());
+        OwnerReference ownerReference = new OwnerReferenceBuilder()
+                .withApiVersion("v1")
+                .withKind("Pod")
+                .withName(pod.getMetadata().getName())
+                .withUid(pod.getMetadata().getUid())
+                .withController(true)
+                .withBlockOwnerDeletion(false)
+                .build();
+        try {
+            client.secrets()
+                    .inNamespace(namespace)
+                    .withName(secretName)
+                    .edit(s -> new SecretBuilder(s)
+                            .editMetadata()
+                            .addToOwnerReferences(ownerReference)
+                            .endMetadata()
+                            .build());
+        } catch (KubernetesClientException e) {
+            LOGGER.log(
+                    WARNING,
+                    e,
+                    () -> "Failed to set owner reference on secret " + namespace + "/" + secretName
+                            + "; it will have to be deleted along with the pod");
+        }
+    }
+
+    /**
+     * Deletes the agent secret created by {@link #createAgentSecret}. Only needed when the pod could not be created,
+     * since otherwise the secret is garbage collected through its owner reference. Best effort.
+     */
+    static void deleteAgentSecret(KubernetesClient client, String namespace, String podName) {
+        if (!PodTemplateBuilder.SECRET_VIA_SECRET_KEY_REF) {
+            return;
+        }
+        String secretName = PodTemplateBuilder.agentSecretName(podName);
+        try {
+            client.secrets().inNamespace(namespace).withName(secretName).delete();
+        } catch (KubernetesClientException e) {
+            LOGGER.log(WARNING, e, () -> "Failed to delete secret " + namespace + "/" + secretName);
+        }
     }
 
     private static void terminateOrLog(KubernetesSlave node) {

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -39,6 +39,7 @@ import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import io.fabric8.kubernetes.api.model.EnvVarSourceBuilder;
 import io.fabric8.kubernetes.api.model.ExecAction;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.Pod;
@@ -48,6 +49,7 @@ import io.fabric8.kubernetes.api.model.ProbeBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
+import io.fabric8.kubernetes.api.model.SecretKeySelectorBuilder;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeBuilder;
 import io.fabric8.kubernetes.api.model.VolumeMount;
@@ -100,6 +102,31 @@ public class PodTemplateBuilder {
             SystemProperties.getString(PodTemplateBuilder.class.getName() + ".noReconnectAfter", "1d");
     private static final String JENKINS_AGENT_FILE_ENVVAR = "JENKINS_AGENT_FILE";
     private static final String JENKINS_AGENT = "/jenkins-agent";
+
+    static final String JENKINS_SECRET_ENVVAR = "JENKINS_SECRET";
+
+    /**
+     * Key under which the agent connection secret is stored in the per-agent {@link io.fabric8.kubernetes.api.model.Secret}.
+     */
+    @Restricted(NoExternalUse.class)
+    public static final String JENKINS_SECRET_KEY = "jenkins-secret";
+
+    /**
+     * Whether the agent connection secret is passed to the agent container through a {@code secretKeyRef} pointing at a
+     * per-agent {@link io.fabric8.kubernetes.api.model.Secret} (the default) rather than being inlined in clear text in
+     * the pod spec.
+     *
+     * <p>Inlining the secret makes it readable by anyone able to {@code get}/{@code list} pods in the agent namespace,
+     * and leaks it into anything that records pod specs (audit logs, admission webhooks, GitOps diffs, {@code kubectl
+     * describe} output). Referencing a Secret instead keeps the value out of the pod spec.
+     *
+     * <p>This requires the controller's service account to be allowed to {@code create} (and {@code delete}) secrets in
+     * the agent namespace. Set this system property to {@code false} to restore the previous behaviour if that
+     * permission cannot be granted.
+     */
+    @Restricted(NoExternalUse.class)
+    public static boolean SECRET_VIA_SECRET_KEY_REF =
+            SystemProperties.getBoolean(PodTemplateBuilder.class.getName() + ".secretViaSecretKeyRef", true);
 
     @Restricted(NoExternalUse.class)
     static String DEFAULT_JNLP_DOCKER_REGISTRY_PREFIX =
@@ -465,12 +492,13 @@ public class PodTemplateBuilder {
         }
         // Last-write wins map of environment variable names to values
         HashMap<String, String> env = new HashMap<>();
+        Map<String, EnvVar> envVarsMap = new HashMap<>();
 
         if (agent != null) {
             SlaveComputer computer = agent.getComputer();
             if (computer != null) {
                 // Add some default env vars for Jenkins
-                env.put("JENKINS_SECRET", computer.getJnlpMac());
+                envVarsMap.put(JENKINS_SECRET_ENVVAR, agentSecretEnvVar(computer));
                 // JENKINS_AGENT_NAME is default in jnlp-slave
                 // JENKINS_NAME only here for backwords compatability
                 env.put("JENKINS_NAME", computer.getName());
@@ -503,10 +531,45 @@ public class PodTemplateBuilder {
             }
             env.put("REMOTING_OPTS", "-noReconnectAfter " + NO_RECONNECT_AFTER_TIMEOUT);
         }
-        Map<String, EnvVar> envVarsMap = new HashMap<>();
 
         env.entrySet().forEach(item -> envVarsMap.put(item.getKey(), new EnvVar(item.getKey(), item.getValue(), null)));
         return envVarsMap;
+    }
+
+    /**
+     * Builds the {@code JENKINS_SECRET} environment variable for the agent container.
+     *
+     * <p>Unless {@link #SECRET_VIA_SECRET_KEY_REF} has been disabled, this is a {@code secretKeyRef} pointing at the
+     * per-agent secret created by {@code KubernetesLauncher}, so that the agent connection secret never appears in
+     * clear text in the pod spec.
+     *
+     * @see #agentSecretName(String)
+     */
+    @NonNull
+    private EnvVar agentSecretEnvVar(@NonNull SlaveComputer computer) {
+        if (SECRET_VIA_SECRET_KEY_REF && agent != null) {
+            return new EnvVarBuilder()
+                    .withName(JENKINS_SECRET_ENVVAR)
+                    .withValueFrom(new EnvVarSourceBuilder()
+                            .withSecretKeyRef(new SecretKeySelectorBuilder()
+                                    .withName(agentSecretName(agent.getPodName()))
+                                    .withKey(JENKINS_SECRET_KEY)
+                                    .withOptional(false)
+                                    .build())
+                            .build())
+                    .build();
+        }
+        return new EnvVar(JENKINS_SECRET_ENVVAR, computer.getJnlpMac(), null);
+    }
+
+    /**
+     * Name of the {@link io.fabric8.kubernetes.api.model.Secret} holding the connection secret of the agent running in
+     * the given pod. Pod names are already unique and are valid secret names, so they are reused as is.
+     */
+    @NonNull
+    @Restricted(NoExternalUse.class)
+    public static String agentSecretName(@NonNull String podName) {
+        return podName;
     }
 
     private Container createContainer(

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilder.java
@@ -125,7 +125,7 @@ public class PodTemplateBuilder {
      * permission cannot be granted.
      */
     @Restricted(NoExternalUse.class)
-    public static boolean SECRET_VIA_SECRET_KEY_REF =
+    static boolean SECRET_VIA_SECRET_KEY_REF =
             SystemProperties.getBoolean(PodTemplateBuilder.class.getName() + ".secretViaSecretKeyRef", true);
 
     @Restricted(NoExternalUse.class)
@@ -498,7 +498,7 @@ public class PodTemplateBuilder {
             SlaveComputer computer = agent.getComputer();
             if (computer != null) {
                 // Add some default env vars for Jenkins
-                envVarsMap.put(JENKINS_SECRET_ENVVAR, agentSecretEnvVar(computer));
+                envVarsMap.put(JENKINS_SECRET_ENVVAR, agentSecretEnvVar(computer, agent.getPodName()));
                 // JENKINS_AGENT_NAME is default in jnlp-slave
                 // JENKINS_NAME only here for backwords compatability
                 env.put("JENKINS_NAME", computer.getName());
@@ -546,13 +546,13 @@ public class PodTemplateBuilder {
      * @see #agentSecretName(String)
      */
     @NonNull
-    private EnvVar agentSecretEnvVar(@NonNull SlaveComputer computer) {
-        if (SECRET_VIA_SECRET_KEY_REF && agent != null) {
+    private static EnvVar agentSecretEnvVar(@NonNull SlaveComputer computer, @NonNull String podName) {
+        if (SECRET_VIA_SECRET_KEY_REF) {
             return new EnvVarBuilder()
                     .withName(JENKINS_SECRET_ENVVAR)
                     .withValueFrom(new EnvVarSourceBuilder()
                             .withSecretKeyRef(new SecretKeySelectorBuilder()
-                                    .withName(agentSecretName(agent.getPodName()))
+                                    .withName(agentSecretName(podName))
                                     .withKey(JENKINS_SECRET_KEY)
                                     .withOptional(false)
                                     .build())

--- a/src/main/kubernetes/service-account.yml
+++ b/src/main/kubernetes/service-account.yml
@@ -27,7 +27,9 @@ rules:
   verbs: ["watch"]
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["get"]
+  # "create"/"update"/"delete" are needed for the per-agent secret holding the agent connection secret, which is
+  # referenced by the agent container through a secretKeyRef so that it is not stored in clear text in the pod spec.
+  verbs: ["create","delete","get","update"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncherTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesLauncherTest.java
@@ -1,8 +1,25 @@
 package org.csanchez.jenkins.plugins.kubernetes;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.fabric8.kubernetes.api.model.OwnerReference;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class KubernetesLauncherTest {
@@ -38,5 +55,101 @@ class KubernetesLauncherTest {
     @Test
     void isResourceQuotaUpdateConflict_unrelated409() {
         assertThat(KubernetesLauncher.isResourceQuotaUpdateConflict(409, "pods \"my-pod\" already exists"), is(false));
+    }
+
+    /**
+     * Lifecycle of the per-agent secret holding the agent connection secret, which the agent container reads through a
+     * {@code secretKeyRef} instead of having it inlined in clear text in the pod spec.
+     */
+    @Nested
+    @EnableKubernetesMockClient(crud = true)
+    class AgentSecret {
+
+        private static final String NAMESPACE = "jenkins";
+        private static final String POD_NAME = "test-agent-abc12";
+        private static final String JNLP_MAC = "d1e2a3d4b5e6e7f8";
+
+        KubernetesClient client;
+
+        private Secret secret() {
+            return client.secrets()
+                    .inNamespace(NAMESPACE)
+                    .withName(PodTemplateBuilder.agentSecretName(POD_NAME))
+                    .get();
+        }
+
+        private String decode(Secret secret) {
+            return new String(
+                    Base64.getDecoder().decode(secret.getData().get(PodTemplateBuilder.JENKINS_SECRET_KEY)),
+                    StandardCharsets.UTF_8);
+        }
+
+        @Test
+        void createdWithTheConnectionSecret() {
+            KubernetesLauncher.createAgentSecret(client, NAMESPACE, POD_NAME, JNLP_MAC);
+
+            Secret secret = secret();
+            assertNotNull(secret, "secret should have been created");
+            assertEquals("Opaque", secret.getType());
+            assertEquals(JNLP_MAC, decode(secret));
+        }
+
+        @Test
+        void createIsIdempotentAcrossLaunchAttempts() {
+            KubernetesLauncher.createAgentSecret(client, NAMESPACE, POD_NAME, "stale");
+            // e.g. the controller was interrupted between creating the secret and creating the pod
+            KubernetesLauncher.createAgentSecret(client, NAMESPACE, POD_NAME, JNLP_MAC);
+
+            assertEquals(JNLP_MAC, decode(secret()));
+        }
+
+        @Test
+        void ownedByThePodOnceItExists() {
+            KubernetesLauncher.createAgentSecret(client, NAMESPACE, POD_NAME, JNLP_MAC);
+            assertThat(secret().getMetadata().getOwnerReferences(), is(empty()));
+
+            Pod pod = client.pods()
+                    .inNamespace(NAMESPACE)
+                    .resource(new PodBuilder()
+                            .withNewMetadata()
+                            .withName(POD_NAME)
+                            .withNamespace(NAMESPACE)
+                            .withUid("2c9d8c0e-0e0e-4a4a-8b8b-1f1f1f1f1f1f")
+                            .endMetadata()
+                            .build())
+                    .create();
+
+            KubernetesLauncher.adoptAgentSecret(client, NAMESPACE, pod);
+
+            List<OwnerReference> ownerReferences = secret().getMetadata().getOwnerReferences();
+            assertThat(ownerReferences.stream().map(OwnerReference::getName).toList(), contains(POD_NAME));
+            OwnerReference ownerReference = ownerReferences.get(0);
+            assertEquals("Pod", ownerReference.getKind());
+            assertEquals("v1", ownerReference.getApiVersion());
+            assertEquals(pod.getMetadata().getUid(), ownerReference.getUid());
+            assertTrue(ownerReference.getController());
+        }
+
+        @Test
+        void deletedWhenThePodCouldNotBeCreated() {
+            KubernetesLauncher.createAgentSecret(client, NAMESPACE, POD_NAME, JNLP_MAC);
+            assertNotNull(secret());
+
+            KubernetesLauncher.deleteAgentSecret(client, NAMESPACE, POD_NAME);
+
+            assertThat(secret(), is(nullValue()));
+        }
+
+        @Test
+        void notCreatedWhenTheFeatureIsDisabled() {
+            boolean orig = PodTemplateBuilder.SECRET_VIA_SECRET_KEY_REF;
+            PodTemplateBuilder.SECRET_VIA_SECRET_KEY_REF = false;
+            try {
+                KubernetesLauncher.createAgentSecret(client, NAMESPACE, POD_NAME, JNLP_MAC);
+                assertNull(secret());
+            } finally {
+                PodTemplateBuilder.SECRET_VIA_SECRET_KEY_REF = orig;
+            }
+        }
     }
 }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodTemplateBuilderTest.java
@@ -9,13 +9,17 @@ import static org.mockito.Mockito.*;
 
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import io.fabric8.kubernetes.api.model.EnvVarSourceBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodSecurityContext;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.SecretKeySelectorBuilder;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
+import io.fabric8.kubernetes.client.utils.Serialization;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -63,6 +67,7 @@ class PodTemplateBuilderTest {
 
     private static final String AGENT_NAME = "jenkins-agent";
     private static final String AGENT_SECRET = "xxx";
+    private static final String POD_NAME = "jenkins-agent-pod";
     private static final String JENKINS_URL = "http://jenkins.example.com";
     private static final String JENKINS_PROTOCOLS = "JNLP4-connect";
 
@@ -365,6 +370,7 @@ class PodTemplateBuilderTest {
         when(computer.getJnlpMac()).thenReturn(AGENT_SECRET);
         when(slave.getComputer()).thenReturn(computer);
         when(slave.getKubernetesCloud()).thenReturn(cloud);
+        when(slave.getPodName()).thenReturn(POD_NAME);
     }
 
     private void validatePod(Pod pod, boolean directConnection) {
@@ -469,7 +475,7 @@ class PodTemplateBuilderTest {
             } else {
                 envVars.add(new EnvVar("JENKINS_URL", JENKINS_URL, null));
             }
-            envVars.add(new EnvVar("JENKINS_SECRET", AGENT_SECRET, null));
+            envVars.add(expectedJenkinsSecretEnvVar());
             envVars.add(new EnvVar("JENKINS_NAME", AGENT_NAME, null));
             envVars.add(new EnvVar("JENKINS_AGENT_NAME", AGENT_NAME, null));
             envVars.add(new EnvVar("JENKINS_AGENT_WORKDIR", ContainerTemplate.DEFAULT_WORKING_DIR, null));
@@ -478,6 +484,65 @@ class PodTemplateBuilderTest {
             assertThat(jnlp.getArgs(), empty());
         }
         assertThat(jnlp.getEnv(), containsInAnyOrder(envVars.toArray(new EnvVar[0])));
+    }
+
+    /**
+     * The agent connection secret must never be inlined in the pod spec: it is read from the per-agent secret created
+     * by {@link KubernetesLauncher}.
+     */
+    private static EnvVar expectedJenkinsSecretEnvVar() {
+        if (!PodTemplateBuilder.SECRET_VIA_SECRET_KEY_REF) {
+            return new EnvVar("JENKINS_SECRET", AGENT_SECRET, null);
+        }
+        return new EnvVarBuilder()
+                .withName("JENKINS_SECRET")
+                .withValueFrom(new EnvVarSourceBuilder()
+                        .withSecretKeyRef(new SecretKeySelectorBuilder()
+                                .withName(PodTemplateBuilder.agentSecretName(POD_NAME))
+                                .withKey(PodTemplateBuilder.JENKINS_SECRET_KEY)
+                                .withOptional(false)
+                                .build())
+                        .build())
+                .build();
+    }
+
+    @Test
+    void agentSecretIsNotInlinedInPodSpec() {
+        setupStubs();
+        Pod pod = new PodTemplateBuilder(new PodTemplate(), slave).build();
+        EnvVar secretEnvVar = pod.getSpec().getContainers().stream()
+                .filter(c -> KubernetesCloud.JNLP_NAME.equals(c.getName()))
+                .flatMap(c -> c.getEnv().stream())
+                .filter(e -> "JENKINS_SECRET".equals(e.getName()))
+                .findFirst()
+                .orElseThrow();
+        assertNull(secretEnvVar.getValue(), "the connection secret must not appear in clear text in the pod spec");
+        var secretKeyRef = secretEnvVar.getValueFrom().getSecretKeyRef();
+        assertEquals(PodTemplateBuilder.agentSecretName(POD_NAME), secretKeyRef.getName());
+        assertEquals(PodTemplateBuilder.JENKINS_SECRET_KEY, secretKeyRef.getKey());
+        assertFalse(secretKeyRef.getOptional());
+        // and nothing else in the whole pod spec leaks it either
+        assertThat(Serialization.asYaml(pod), not(containsString(AGENT_SECRET)));
+    }
+
+    @Test
+    void agentSecretCanStillBeInlinedForBackwardsCompatibility() {
+        boolean orig = PodTemplateBuilder.SECRET_VIA_SECRET_KEY_REF;
+        PodTemplateBuilder.SECRET_VIA_SECRET_KEY_REF = false;
+        try {
+            setupStubs();
+            Pod pod = new PodTemplateBuilder(new PodTemplate(), slave).build();
+            EnvVar secretEnvVar = pod.getSpec().getContainers().stream()
+                    .filter(c -> KubernetesCloud.JNLP_NAME.equals(c.getName()))
+                    .flatMap(c -> c.getEnv().stream())
+                    .filter(e -> "JENKINS_SECRET".equals(e.getName()))
+                    .findFirst()
+                    .orElseThrow();
+            assertEquals(AGENT_SECRET, secretEnvVar.getValue());
+            assertNull(secretEnvVar.getValueFrom());
+        } finally {
+            PodTemplateBuilder.SECRET_VIA_SECRET_KEY_REF = orig;
+        }
     }
 
     @Test


### PR DESCRIPTION
## Problem

`PodTemplateBuilder.agentEnvVars` sets `JENKINS_SECRET` to the literal value of `SlaveComputer.getJnlpMac()`:

```java
env.put("JENKINS_SECRET", computer.getJnlpMac());
```

so every agent pod carries its connection secret in clear text in `spec.containers[].env[].value`:

```yaml
env:
- name: JENKINS_SECRET
  value: 6f2a1c...   # the agent's connection secret
```

A pod spec is not a confidential object. This means the secret is readable by:

- anyone with `get`/`list` on pods in the agent namespace (a much broader set than `get secrets`, and commonly granted to developers and to other workloads via the API);
- API server audit logs, which record the full object on create;
- any mutating/validating admission webhook in the path;
- `kubectl describe pod` / `kubectl get pod -o yaml`, support bundles, and any tooling that snapshots or diffs cluster state.

The value is sufficient to connect to the controller as that agent.

## Change

Pass it through a `secretKeyRef` instead, which is what this field is for:

```yaml
env:
- name: JENKINS_SECRET
  valueFrom:
    secretKeyRef:
      name: <pod name>
      key: jenkins-secret
      optional: false
```

Lifecycle, in `KubernetesLauncher.launch`:

1. the `Secret` (named after the pod, so no extra uniqueness scheme is needed) is created **before** the pod — the kubelet refuses to start a container whose `secretKeyRef` does not resolve;
2. immediately after the pod is created, an owner reference to the pod is added to the secret, so the secret is garbage collected along with the pod — including under `podRetention` policies that keep the pod around, and on controller restart;
3. if pod creation fails, the secret is deleted again so nothing is orphaned.

Steps 2 and 3 are best effort and log at `WARNING` rather than failing the launch.

## Compatibility

This requires `create`, `update` and `delete` on secrets in the agent namespace; the role in `src/main/kubernetes/service-account.yml` previously only had `get`, and is updated. **Existing installations that pin their own RBAC will need to grant these verbs**, otherwise agent provisioning fails.

For setups where that permission cannot be granted, the previous behaviour is available via a system property, documented in the README:

```
-Dorg.csanchez.jenkins.plugins.kubernetes.PodTemplateBuilder.secretViaSecretKeyRef=false
```

Defaulting it to `true` is deliberate — the secure behaviour should be what people get without knowing to ask for it — but I'm happy to flip the default, or gate it on a `KubernetesCloud` option instead of a system property, if maintainers prefer a softer rollout.

