### PR TITLE
Support container() step exec into native sidecar (restartPolicy: Always) init containers

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodContainerSource.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/PodContainerSource.java
@@ -12,6 +12,7 @@ import io.fabric8.kubernetes.api.model.PodStatus;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 /**
  * Pod container sources are responsible to locating details about Pod containers.
@@ -73,17 +74,36 @@ public abstract class PodContainerSource implements ExtensionPoint {
     }
 
     /**
-     * Default implementation of {@link PodContainerSource} that only searches the primary
-     * pod containers. Ephemeral or init containers are not included container lookups in
-     * this implementation.
+     * A container with {@code restartPolicy: Always} in {@code initContainers} is a
+     * <a href="https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/">native
+     * sidecar</a> (Kubernetes 1.29+): it keeps running for the lifetime of the pod, just like a
+     * regular container, so it is a valid target for the {@code container()} step. A plain
+     * (run-to-completion) init container is not, since it will already have terminated by the
+     * time any pipeline step runs.
+     */
+    private static final String NATIVE_SIDECAR_RESTART_POLICY = "Always";
+
+    /**
+     * Default implementation of {@link PodContainerSource} that searches the primary pod
+     * containers, plus any {@code initContainers} entry declared as a native sidecar
+     * ({@code restartPolicy: Always}). Plain (run-to-completion) init containers and ephemeral
+     * containers are not included in container lookups in this implementation.
      * @see PodSpec#getContainers()
+     * @see PodSpec#getInitContainers()
      */
     @Extension
     public static final class DefaultPodContainerSource extends PodContainerSource {
 
         @Override
         public Optional<String> getContainerWorkingDir(@NonNull Pod pod, @NonNull String containerName) {
-            return pod.getSpec().getContainers().stream()
+            Optional<String> workingDir = pod.getSpec().getContainers().stream()
+                    .filter(c -> Objects.equals(c.getName(), containerName))
+                    .findAny()
+                    .map(Container::getWorkingDir);
+            if (workingDir.isPresent()) {
+                return workingDir;
+            }
+            return nativeSidecars(pod)
                     .filter(c -> Objects.equals(c.getName(), containerName))
                     .findAny()
                     .map(Container::getWorkingDir);
@@ -96,9 +116,28 @@ public abstract class PodContainerSource implements ExtensionPoint {
                 return Optional.empty();
             }
 
-            return podStatus.getContainerStatuses().stream()
+            Optional<ContainerStatus> status = podStatus.getContainerStatuses().stream()
                     .filter(cs -> Objects.equals(cs.getName(), containerName))
                     .findFirst();
+            if (status.isPresent()) {
+                return status;
+            }
+            List<ContainerStatus> initContainerStatuses = podStatus.getInitContainerStatuses();
+            if (initContainerStatuses == null) {
+                return Optional.empty();
+            }
+            return initContainerStatuses.stream()
+                    .filter(cs -> Objects.equals(cs.getName(), containerName))
+                    .filter(cs -> nativeSidecars(pod).anyMatch(c -> Objects.equals(c.getName(), cs.getName())))
+                    .findFirst();
+        }
+
+        private static Stream<Container> nativeSidecars(@NonNull Pod pod) {
+            List<Container> initContainers = pod.getSpec().getInitContainers();
+            if (initContainers == null) {
+                return Stream.empty();
+            }
+            return initContainers.stream().filter(c -> NATIVE_SIDECAR_RESTART_POLICY.equals(c.getRestartPolicy()));
         }
     }
 }

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/decorator/DefaultWorkspaceVolume.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/decorator/DefaultWorkspaceVolume.java
@@ -13,6 +13,7 @@ import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
 import org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate;
 import org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud;
 import org.csanchez.jenkins.plugins.kubernetes.PodTemplateBuilder;
@@ -52,7 +53,7 @@ public class DefaultWorkspaceVolume implements PodDecorator {
             // @formatter:on
         }
         // default workspace volume mount. If something is already mounted in the same path ignore it
-        pod.getSpec().getContainers().stream()
+        Stream.concat(pod.getSpec().getContainers().stream(), nativeSidecars(pod))
                 .filter(c -> c.getVolumeMounts().stream()
                         .noneMatch(vm -> vm.getMountPath().equals(getWorkingDir(c))))
                 .forEach(c -> {
@@ -68,5 +69,19 @@ public class DefaultWorkspaceVolume implements PodDecorator {
 
     private String getWorkingDir(Container c) {
         return c.getWorkingDir() != null ? c.getWorkingDir() : ContainerTemplate.DEFAULT_WORKING_DIR;
+    }
+
+    /**
+     * {@code initContainers} entries declared as native sidecars ({@code restartPolicy: Always},
+     * Kubernetes 1.29+) keep running for the lifetime of the pod, just like a regular container,
+     * so they need the shared workspace volume too. Plain (run-to-completion) init containers do
+     * not, since they have already terminated by the time any pipeline step runs.
+     */
+    private static Stream<Container> nativeSidecars(Pod pod) {
+        List<Container> initContainers = pod.getSpec().getInitContainers();
+        if (initContainers == null) {
+            return Stream.empty();
+        }
+        return initContainers.stream().filter(c -> "Always".equals(c.getRestartPolicy()));
     }
 }

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodContainerSourceTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/PodContainerSourceTest.java
@@ -161,6 +161,82 @@ class PodContainerSourceTest {
         assertFalse(status.isPresent());
     }
 
+    @WithoutJenkins
+    @Test
+    void defaultPodContainerSourceGetContainerWorkingDirNativeSidecar() {
+        Pod pod = new PodBuilder()
+                .withNewSpec()
+                .addNewContainer()
+                .withName("jnlp")
+                .withWorkingDir("/home/jenkins/agent")
+                .endContainer()
+                .addNewInitContainer()
+                .withName("sidecar")
+                .withRestartPolicy("Always")
+                .withWorkingDir("/app/sidecar")
+                .endInitContainer()
+                .addNewInitContainer()
+                .withName("setup")
+                .withWorkingDir("/app/setup")
+                .endInitContainer()
+                .endSpec()
+                .build();
+
+        PodContainerSource.DefaultPodContainerSource source = new PodContainerSource.DefaultPodContainerSource();
+
+        // native sidecar (restartPolicy: Always) is a valid step-exec target
+        Optional<String> wd = source.getContainerWorkingDir(pod, "sidecar");
+        assertTrue(wd.isPresent());
+        assertEquals("/app/sidecar", wd.get());
+
+        // plain (run-to-completion) init container is not
+        wd = source.getContainerWorkingDir(pod, "setup");
+        assertFalse(wd.isPresent());
+    }
+
+    @WithoutJenkins
+    @Test
+    void defaultPodContainerSourceGetContainerStatusNativeSidecar() {
+        Pod pod = new PodBuilder()
+                .withNewSpec()
+                .addNewInitContainer()
+                .withName("sidecar")
+                .withRestartPolicy("Always")
+                .endInitContainer()
+                .addNewInitContainer()
+                .withName("setup")
+                .endInitContainer()
+                .endSpec()
+                .withNewStatus()
+                .addNewInitContainerStatus()
+                .withName("sidecar")
+                .withNewState()
+                .withNewRunning()
+                .endRunning()
+                .endState()
+                .endInitContainerStatus()
+                .addNewInitContainerStatus()
+                .withName("setup")
+                .withNewState()
+                .withNewTerminated()
+                .endTerminated()
+                .endState()
+                .endInitContainerStatus()
+                .endStatus()
+                .build();
+
+        PodContainerSource.DefaultPodContainerSource source = new PodContainerSource.DefaultPodContainerSource();
+
+        // native sidecar (restartPolicy: Always) is a valid step-exec target
+        Optional<ContainerStatus> status = source.getContainerStatus(pod, "sidecar");
+        assertTrue(status.isPresent());
+        assertEquals("sidecar", status.get().getName());
+
+        // plain (run-to-completion) init container is not, even though it has a status
+        status = source.getContainerStatus(pod, "setup");
+        assertFalse(status.isPresent());
+    }
+
     @TestExtension
     public static class TestPodContainerSource extends PodContainerSource {
 

--- a/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pod/decorator/DefaultWorkspaceVolumeTest.java
+++ b/src/test/java/org/csanchez/jenkins/plugins/kubernetes/pod/decorator/DefaultWorkspaceVolumeTest.java
@@ -1,0 +1,72 @@
+package org.csanchez.jenkins.plugins.kubernetes.pod.decorator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.VolumeMount;
+import java.util.List;
+import org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud;
+import org.csanchez.jenkins.plugins.kubernetes.PodTemplateBuilder;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.WithoutJenkins;
+
+class DefaultWorkspaceVolumeTest {
+
+    private final DefaultWorkspaceVolume decorator = new DefaultWorkspaceVolume();
+    private final KubernetesCloud cloud = new KubernetesCloud("test");
+
+    @WithoutJenkins
+    @Test
+    void mountsWorkspaceVolumeInNativeSidecar() {
+        Pod pod = new PodBuilder()
+                .withNewSpec()
+                .addNewContainer()
+                .withName("jnlp")
+                .endContainer()
+                .addNewInitContainer()
+                .withName("sidecar")
+                .withRestartPolicy("Always")
+                .endInitContainer()
+                .addNewInitContainer()
+                .withName("setup")
+                .endInitContainer()
+                .endSpec()
+                .build();
+
+        Pod decorated = decorator.decorate(cloud, pod);
+
+        Container jnlp = findContainer(decorated.getSpec().getContainers(), "jnlp");
+        assertHasWorkspaceVolumeMount(jnlp);
+
+        Container sidecar = findContainer(decorated.getSpec().getInitContainers(), "sidecar");
+        assertHasWorkspaceVolumeMount(sidecar);
+
+        // plain (run-to-completion) init container does not need the shared workspace: it has
+        // already terminated by the time any pipeline step could use it.
+        Container setup = findContainer(decorated.getSpec().getInitContainers(), "setup");
+        assertTrue(
+                setup.getVolumeMounts() == null
+                        || setup.getVolumeMounts().stream()
+                                .noneMatch(vm -> vm.getName().equals(PodTemplateBuilder.WORKSPACE_VOLUME_NAME)),
+                "plain init container should not get the workspace volume mount");
+    }
+
+    private static Container findContainer(List<Container> containers, String name) {
+        return containers.stream()
+                .filter(c -> c.getName().equals(name))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("container " + name + " not found"));
+    }
+
+    private static void assertHasWorkspaceVolumeMount(Container container) {
+        VolumeMount mount = container.getVolumeMounts().stream()
+                .filter(vm -> vm.getName().equals(PodTemplateBuilder.WORKSPACE_VOLUME_NAME))
+                .findFirst()
+                .orElseThrow(() ->
+                        new AssertionError("container " + container.getName() + " missing workspace volume mount"));
+        assertEquals(PodTemplateBuilder.WORKSPACE_VOLUME_NAME, mount.getName());
+    }
+}


### PR DESCRIPTION
## Summary

Kubernetes 1.29+ [native sidecar containers](https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/) — an `initContainers` entry with `restartPolicy: Always` — run for the whole lifetime of the pod, just like a regular container. Today the `container(name) { ... }` pipeline step can't target one, even though it's fully reachable via the Kubernetes API (`kubectl exec` works fine against it).

Root cause: `PodContainerSource.DefaultPodContainerSource` only ever searches `pod.spec.containers` / `pod.status.containerStatuses`. A native sidecar's status/working-dir lookup silently comes back empty, so `ContainerExecDecorator` can't resolve it. `DefaultWorkspaceVolume` has the identical scope limit — it only mounts the shared workspace volume into `pod.spec.containers` — so even if the exec channel opened, `durable-task`'s step-completion tracking has nowhere to write its marker files. Symptom in a real pipeline: `process apparently never started`, then the build fails once the agent's idle-retention timeout kicks in.

This PR extends both lookups to also consider `initContainers` entries specifically declared as native sidecars (`restartPolicy: Always`). Plain run-to-completion init containers are deliberately left untouched — they've already terminated by the time any pipeline step could run, so treating them as valid exec/mount targets wouldn't be meaningful.

## Why this over a custom `PodContainerSource` extension

`PodContainerSource` is already an `ExtensionPoint`, so this could be done as a separate extension without touching `DefaultPodContainerSource` at all. I went with fixing the default implementation directly because the workspace-volume side (`DefaultWorkspaceVolume`) has no equivalent extension point today, so a subset of this fix has to land in core code regardless — and once that's true, keeping the container-status half in the same default implementation seemed more consistent than splitting the fix across a core change and a bundled extension for what's really one coherent feature (native sidecars as step targets).

## Test plan

- Added unit tests to `PodContainerSourceTest` covering both a native sidecar (found) and a plain init container (correctly not found), for both `getContainerWorkingDir` and `getContainerStatus`.
- Added `DefaultWorkspaceVolumeTest` covering the same distinction for workspace-volume mounting.
- **Verified against the actual failure this fixes**, not just the unit tests: built this change, packaged the `.hpi`, swapped it into a real Jenkins instance's `kubernetes` plugin against a real Kubernetes cluster (minikube, 1.29+), and reproduced the fix end-to-end:
  - Before: a pipeline with `container('sidecar-container') { sh '...' }` targeting a native sidecar fails with `process apparently never started`, confirmed the container itself is running and reachable via manual `kubectl exec`.
  - After (this patch): the same pipeline succeeds, the step's output is captured normally, and the pod still correctly reaches phase `Succeeded` afterwards with the native sidecar auto-terminated by kubelet once the regular containers finish.

## Related

- #2369 ([JENKINS-62665](https://issues.jenkins.io/browse/JENKINS-62665)) — open request for more general `initContainers` support in the plugin. Different specific ask (pre-scheduling gating vs. step-exec), but related: confirms `initContainers` have no first-class support surface here today.