### PR TITLE
Throttle watch re-establishment and bound watch-setup thread usage (JENKINS-76095)

### DIFF
--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesClientProvider.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesClientProvider.java
@@ -2,20 +2,26 @@ package org.csanchez.jenkins.plugins.kubernetes;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.XmlFile;
 import hudson.model.Saveable;
 import hudson.model.listeners.SaveableListener;
+import hudson.util.DaemonThreadFactory;
+import hudson.util.NamingThreadFactory;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
+import org.csanchez.jenkins.plugins.kubernetes.pod.retention.Reaper;
 import org.jenkinsci.plugins.kubernetes.auth.KubernetesAuthException;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -36,14 +42,66 @@ public class KubernetesClientProvider {
             KubernetesClientProvider.class.getPackage().getName() + ".clients.cacheExpiration",
             TimeUnit.MINUTES.toSeconds(10));
 
+    /**
+     * Extra safety margin added on top of a cloud's own connect+read timeout before a retired client is
+     * actually closed, protecting any in-flight call that grabbed a reference just before eviction.
+     * See JENKINS-76095.
+     */
+    private static final long CLOSE_GRACE_MARGIN_SECONDS =
+            Long.getLong(KubernetesClientProvider.class.getPackage().getName() + ".clients.closeGraceMargin", 30);
+
+    /**
+     * Fallback grace period used only if the {@link KubernetesCloud} config can no longer be resolved at
+     * eviction time (e.g. the cloud itself was deleted, not just updated).
+     */
+    private static final long DEFAULT_CLOSE_GRACE_PERIOD_SECONDS =
+            Long.getLong(KubernetesClientProvider.class.getPackage().getName() + ".clients.closeGracePeriod", 60);
+
+    /**
+     * A single shared, bounded daemon-thread scheduler for deferred client closes. Deliberately NOT one
+     * thread per client - that would just reintroduce a leak of a different shape. See JENKINS-76095.
+     */
+    private static final ScheduledExecutorService CLOSE_EXECUTOR =
+            Executors.newSingleThreadScheduledExecutor(new NamingThreadFactory(
+                    new DaemonThreadFactory(), KubernetesClientProvider.class.getName() + ".deferredClose"));
+
     private static final Cache<String, Client> clients = Caffeine.newBuilder()
             .expireAfterWrite(CACHE_EXPIRATION, TimeUnit.SECONDS)
             .removalListener((key, value, cause) -> {
                 Client client = (Client) value;
-                if (client != null) {
-                    LOGGER.log(
-                            Level.FINE, () -> "Expiring Kubernetes client " + key + " " + client.client + ": " + cause);
+                if (client == null) {
+                    return;
                 }
+                LOGGER.log(Level.FINE, () -> "Retiring Kubernetes client " + key + " " + client.client + ": " + cause);
+
+                Jenkins jenkins = Jenkins.getInstanceOrNull();
+                KubernetesCloud cloud = jenkins == null
+                        ? null
+                        : jenkins.clouds.getAll(KubernetesCloud.class).stream()
+                                .filter(c -> c.getDisplayName().equals(key))
+                                .findFirst()
+                                .orElse(null);
+
+                // (1) Proactively re-establish the Reaper's long-lived watch on a FRESH client for this
+                //     cloud BEFORE the old client is torn down - CloudPodWatcher#onClose() only removes
+                //     itself from the watchers map and does not self-heal/reconnect on its own.
+                if (cloud != null) {
+                    Reaper.getInstance().watchCloud(cloud);
+                }
+
+                // (2) Derive the grace period from THIS cloud's own connect/read timeouts. A slow/hanging
+                //     cluster (dead or misconfigured cloud) is exactly the scenario most likely to still
+                //     have an in-flight call running close to its configured timeout ceiling, and exactly
+                //     the scenario most likely to be evicted/retried repeatedly - so it must not be
+                //     under-protected by a flat constant.
+                long gracePeriod = cloud != null
+                        ? Math.max(cloud.getConnectTimeout(), cloud.getReadTimeout()) + CLOSE_GRACE_MARGIN_SECONDS
+                        : DEFAULT_CLOSE_GRACE_PERIOD_SECONDS;
+
+                // (3) Defer the actual close by wall-clock delay (deterministic, NOT
+                //     GC/phantom-reachability dependent - cannot repeat the java.lang.ref.Cleaner
+                //     self-reference bug from the JENKINS-76095 PR #1747 attempt).
+                CLOSE_EXECUTOR.schedule(client.client::close, gracePeriod, TimeUnit.SECONDS);
             })
             .build();
 
@@ -114,6 +172,25 @@ public class KubernetesClientProvider {
     @Restricted(NoExternalUse.class) // testing only
     public static void invalidate(String displayName) {
         clients.invalidate(displayName);
+    }
+
+    /**
+     * Look up the {@link KubernetesClient} instance currently held in the cache for the given cloud, without
+     * creating one if absent and without affecting the cache's {@code expireAfterWrite} timer.
+     *
+     * <p>Used by {@link Reaper} to tell whether an existing {@link Reaper} watch is still bound to the
+     * <em>same live client instance</em> presently in the cache, as opposed to a client that has since been
+     * evicted/replaced (e.g. by expiry, {@link #invalidate}, or a config change) while the cloud's own
+     * configuration - and therefore its {@link #getValidity} hash - stayed unchanged. See JENKINS-76095.
+     *
+     * @param displayName cloud display name (== {@link KubernetesCloud#name})
+     * @return the currently cached client for this cloud, or {@code null} if none is cached right now
+     */
+    @Restricted(NoExternalUse.class)
+    @CheckForNull
+    public static KubernetesClient currentCachedClient(String displayName) {
+        Client c = clients.getIfPresent(displayName);
+        return c == null ? null : c.getClient();
     }
 
     @Restricted(NoExternalUse.class) // testing only

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
@@ -120,6 +120,12 @@ public class KubernetesCloud extends Cloud implements PodTemplateGroup {
 
     public static final int DEFAULT_CONNECT_TIMEOUT_SECONDS = 5;
 
+    /**
+     * Default minimum interval, in seconds, between watch (re-)establishment attempts for this cloud.
+     * See {@link #getMinWatchRetryIntervalSeconds()}.
+     */
+    public static final int DEFAULT_MIN_WATCH_RETRY_INTERVAL_SECONDS = 10;
+
     private String defaultsProviderTemplate;
 
     @NonNull
@@ -153,6 +159,7 @@ public class KubernetesCloud extends Cloud implements PodTemplateGroup {
     private int retentionTimeout = DEFAULT_RETENTION_TIMEOUT_MINUTES;
     private int connectTimeout = DEFAULT_CONNECT_TIMEOUT_SECONDS;
     private int readTimeout = DEFAULT_READ_TIMEOUT_SECONDS;
+    private int minWatchRetryIntervalSeconds = DEFAULT_MIN_WATCH_RETRY_INTERVAL_SECONDS;
     /** @deprecated Stored as a list of PodLabels */
     @Deprecated
     private transient Map<String, String> labels;
@@ -528,6 +535,23 @@ public class KubernetesCloud extends Cloud implements PodTemplateGroup {
 
     public int getConnectTimeout() {
         return connectTimeout;
+    }
+
+    /**
+     * Minimum interval, in seconds, between {@link org.csanchez.jenkins.plugins.kubernetes.pod.retention.Reaper}
+     * attempts to (re-)establish the pod-event watch for this cloud. Guards against unbounded thread growth
+     * when the watch keeps failing to establish (e.g. an unreachable API server) and the cloud's cached
+     * {@link io.fabric8.kubernetes.client.KubernetesClient} is being evicted/invalidated in rapid succession -
+     * each retry attempt spins up its own fabric8 reconnect thread(s), and without a floor on retry frequency
+     * those can accumulate faster than they drain. Does not affect an already-healthy watch.
+     */
+    public int getMinWatchRetryIntervalSeconds() {
+        return minWatchRetryIntervalSeconds;
+    }
+
+    @DataBoundSetter
+    public void setMinWatchRetryIntervalSeconds(int minWatchRetryIntervalSeconds) {
+        this.minWatchRetryIntervalSeconds = Math.max(0, minWatchRetryIntervalSeconds);
     }
 
     /**
@@ -953,6 +977,7 @@ public class KubernetesCloud extends Cloud implements PodTemplateGroup {
                 && retentionTimeout == that.retentionTimeout
                 && connectTimeout == that.connectTimeout
                 && readTimeout == that.readTimeout
+                && minWatchRetryIntervalSeconds == that.minWatchRetryIntervalSeconds
                 && usageRestricted == that.usageRestricted
                 && maxRequestsPerHost == that.maxRequestsPerHost
                 && Objects.equals(defaultsProviderTemplate, that.defaultsProviderTemplate)
@@ -991,6 +1016,7 @@ public class KubernetesCloud extends Cloud implements PodTemplateGroup {
                 retentionTimeout,
                 connectTimeout,
                 readTimeout,
+                minWatchRetryIntervalSeconds,
                 podLabels,
                 usageRestricted,
                 maxRequestsPerHost,
@@ -1333,6 +1359,11 @@ public class KubernetesCloud extends Cloud implements PodTemplateGroup {
         }
 
         @SuppressWarnings("unused") // used by jelly
+        public int getDefaultMinWatchRetryInterval() {
+            return DEFAULT_MIN_WATCH_RETRY_INTERVAL_SECONDS;
+        }
+
+        @SuppressWarnings("unused") // used by jelly
         public int getDefaultRetentionTimeout() {
             return DEFAULT_RETENTION_TIMEOUT_MINUTES;
         }
@@ -1370,7 +1401,8 @@ public class KubernetesCloud extends Cloud implements PodTemplateGroup {
                 + containerCap + ", retentionTimeout="
                 + retentionTimeout + ", connectTimeout="
                 + connectTimeout + ", readTimeout="
-                + readTimeout + ", labels="
+                + readTimeout + ", minWatchRetryIntervalSeconds="
+                + minWatchRetryIntervalSeconds + ", labels="
                 + labels + ", podLabels="
                 + podLabels + ", usageRestricted="
                 + usageRestricted + ", maxRequestsPerHost="
@@ -1397,11 +1429,18 @@ public class KubernetesCloud extends Cloud implements PodTemplateGroup {
         if (maxRequestsPerHost == 0) {
             maxRequestsPerHost = DEFAULT_MAX_REQUESTS_PER_HOST;
         }
+        if (minWatchRetryIntervalSeconds == 0) {
+            // field didn't exist prior to JENKINS-76095 follow-up fix; XStream leaves un-declared int fields at
+            // the Java default of 0 when deserializing older configs, so treat that as "not yet configured"
+            // rather than an explicit opt-out of throttling.
+            minWatchRetryIntervalSeconds = DEFAULT_MIN_WATCH_RETRY_INTERVAL_SECONDS;
+        }
         if (podRetention == null) {
             podRetention = PodRetention.getKubernetesCloudDefault();
         }
         setConnectTimeout(connectTimeout);
         setReadTimeout(readTimeout);
+        setMinWatchRetryIntervalSeconds(minWatchRetryIntervalSeconds);
         setRetentionTimeout(retentionTimeout);
         if (waitForPodSec == null) {
             waitForPodSec = DEFAULT_WAIT_FOR_POD_SEC;

--- a/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/retention/Reaper.java
+++ b/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pod/retention/Reaper.java
@@ -35,6 +35,8 @@ import hudson.model.listeners.SaveableListener;
 import hudson.slaves.ComputerListener;
 import hudson.slaves.EphemeralNode;
 import hudson.slaves.OfflineCause;
+import hudson.util.DaemonThreadFactory;
+import hudson.util.NamingThreadFactory;
 import io.fabric8.kubernetes.api.model.ContainerStateTerminated;
 import io.fabric8.kubernetes.api.model.ContainerStateWaiting;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
@@ -55,8 +57,16 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
@@ -69,6 +79,8 @@ import org.csanchez.jenkins.plugins.kubernetes.KubernetesComputer;
 import org.csanchez.jenkins.plugins.kubernetes.KubernetesSlave;
 import org.csanchez.jenkins.plugins.kubernetes.PodUtils;
 import org.jenkinsci.plugins.kubernetes.auth.KubernetesAuthException;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * Checks for deleted pods corresponding to {@link KubernetesSlave} and ensures the node is removed from Jenkins too.
@@ -82,6 +94,126 @@ import org.jenkinsci.plugins.kubernetes.auth.KubernetesAuthException;
 public class Reaper extends ComputerListener {
 
     private static final Logger LOGGER = Logger.getLogger(Reaper.class.getName());
+
+    /**
+     * Per-attempt watch-setup timeout, covering BOTH {@link KubernetesCloud#connect()} (client
+     * construction/handshake, which can itself block against a slow-but-reachable cloud) and the actual
+     * {@code .watch()} call, before treating the attempt as a failure. fabric8's {@code BaseOperation#watch}
+     * internally calls {@code Utils.waitUntilReadyOrFail(startedFuture, -1, TimeUnit.SECONDS)} - an
+     * INTENTIONAL, hardcoded indefinite wait with no way for a caller to override it. Against a cloud that
+     * accepts a connection but never completes the watch handshake (a "hanging" endpoint, or one merely slow
+     * under heavy concurrent load), that indefinite wait blocks the calling thread forever inside
+     * {@code ForkJoinPool.commonPool()}'s managed-blocking/compensation machinery. Since that pool is
+     * JVM-wide and shared by every unrelated async operation (not just other clouds' watches), enough
+     * concurrent stuck attempts against ONE bad cloud can exhaust its bounded compensation-thread budget and
+     * collaterally starve watch setup for every OTHER, perfectly healthy cloud too. Running the watch-ready
+     * wait on {@link #WATCH_SETUP_EXECUTOR} instead confines this risk to a small, dedicated, bounded pool
+     * so a hanging cloud can no longer poison JVM-wide shared infrastructure. See JENKINS-76095 for details.
+     *
+     * <p>By default (when this system property is unset or {@code <= 0}), the bound used is derived
+     * per-cloud from settings the operator has ALREADY configured for exactly this purpose - {@link
+     * KubernetesCloud#getConnectTimeout()} {@code +} {@link KubernetesCloud#getReadTimeout()} - rather than
+     * one hardcoded JVM-wide constant. connect-then-watch is a strictly sequential operation (the watch
+     * cannot begin until the connection completes), so the worst-case total wait is the SUM of both
+     * timeouts, not their max. This means a cloud already configured as "known to be slower" (higher
+     * connect/read timeouts) automatically gets a proportionally more patient watch-setup bound too, with no
+     * separate setting for an operator to remember to keep in sync. See {@link #watchSetupTimeoutSeconds}.
+     *
+     * <p>This system property remains available as an explicit, fixed override for environments that want a
+     * single hardcoded bound regardless of any individual cloud's configured connect/read timeouts.
+     *
+     * <p><b>Note:</b> like all {@code static final} fields on this class read via {@link SystemProperties},
+     * this value is resolved exactly once, when the {@code Reaper} class is first loaded (effectively at
+     * Jenkins startup). Setting this system property at runtime (e.g. via the Script Console's
+     * {@code System.setProperty(...)}) has no effect on an already-running instance - it must be set as a
+     * JVM startup argument (e.g. {@code -Dorg.csanchez.jenkins.plugins.kubernetes.pod.retention.Reaper.watchSetupTimeoutSecondsOverride=30})
+     * before Jenkins starts, and Jenkins must be (re)started for a change to take effect.
+     */
+    private static final int WATCH_SETUP_TIMEOUT_SECONDS_OVERRIDE =
+            SystemProperties.getInteger(Reaper.class.getName() + ".watchSetupTimeoutSecondsOverride", 0);
+
+    /**
+     * Returns the watch-setup timeout (seconds) to use for a single attempt against the given cloud - the
+     * fixed {@link #WATCH_SETUP_TIMEOUT_SECONDS_OVERRIDE} if explicitly set to a positive value, otherwise
+     * derived per-cloud as {@code connectTimeout + readTimeout}. See {@link #WATCH_SETUP_TIMEOUT_SECONDS_OVERRIDE}
+     * for the full rationale.
+     */
+    private static int watchSetupTimeoutSecondsFor(@NonNull KubernetesCloud kc) {
+        if (WATCH_SETUP_TIMEOUT_SECONDS_OVERRIDE > 0) {
+            return WATCH_SETUP_TIMEOUT_SECONDS_OVERRIDE;
+        }
+        return kc.getConnectTimeout() + kc.getReadTimeout();
+    }
+
+    /**
+     * Upper bound on concurrently in-flight watch-setup attempts across all clouds. Deliberately bounded
+     * (not a cached/unbounded pool) - if this cap is reached, further attempts are rejected immediately
+     * (surfacing as a {@link RejectedExecutionException}, handled identically to any other watch-setup
+     * failure by {@link #watchCloud} and folded into the existing failure-streak/throttle mechanism) rather
+     * than piling up additional threads. A stuck attempt that timed out here is abandoned (best-effort
+     * {@link Future#cancel}, which - like the underlying fabric8/OkHttp call - cannot forcibly interrupt a
+     * blocked read) but is now permanently confined to this small dedicated pool instead of the shared
+     * {@code ForkJoinPool.commonPool()}.
+     *
+     * <p>Rather than a single hardcoded constant (which would either be wastefully large for a small
+     * Jenkins instance or too small for one with many configured {@link KubernetesCloud}s - there is no
+     * one-size-fits-all number), the cap is derived from the actual number of currently configured clouds,
+     * multiplied by {@link #WATCH_SETUP_THREADS_PER_CLOUD} headroom so a burst where every cloud needs
+     * re-arming at once (e.g. right after a Jenkins restart, or many concurrent client-cache evictions) is
+     * never artificially bottlenecked by this pool itself, with a small floor for the common case of very
+     * few clouds. Recomputed via {@link #resizeWatchSetupExecutor} every time {@link #watchClouds()} runs
+     * (i.e. whenever the set of configured clouds is (re-)enumerated), so it grows/shrinks automatically as
+     * clouds are added or removed at runtime - operators never need to hand-tune this for their
+     * environment's scale, and no restart is needed for the pool itself to track a changed cloud count.
+     * An explicit override remains available via the {@code watchSetupMaxThreads} system property for
+     * environments that want a fixed cap regardless of cloud count.
+     *
+     * <p><b>Note:</b> {@link #WATCH_SETUP_MIN_THREADS}, {@link #WATCH_SETUP_THREADS_PER_CLOUD}, and
+     * {@link #WATCH_SETUP_MAX_THREADS_OVERRIDE} are themselves {@code static final} and, like
+     * {@link #WATCH_SETUP_TIMEOUT_SECONDS_OVERRIDE} above, are resolved once at class-load time - changing their
+     * underlying system properties requires a JVM startup argument and a Jenkins (re)start to take effect.
+     * Only the *pool size itself* (derived from these settings plus the live cloud count) updates
+     * dynamically without a restart, not the settings that control how it's derived.
+     */
+    private static final int WATCH_SETUP_MIN_THREADS =
+            SystemProperties.getInteger(Reaper.class.getName() + ".watchSetupMinThreads", 20);
+
+    /** Headroom multiplier applied per configured cloud when auto-sizing {@link #WATCH_SETUP_EXECUTOR}. */
+    private static final int WATCH_SETUP_THREADS_PER_CLOUD =
+            SystemProperties.getInteger(Reaper.class.getName() + ".watchSetupThreadsPerCloud", 4);
+
+    /**
+     * Explicit fixed override for the pool's max size, bypassing auto-sizing entirely when set to a
+     * positive value. Unset (0, the default) means "auto-size based on configured cloud count".
+     */
+    private static final int WATCH_SETUP_MAX_THREADS_OVERRIDE =
+            SystemProperties.getInteger(Reaper.class.getName() + ".watchSetupMaxThreads", 0);
+
+    private static final ExecutorService WATCH_SETUP_EXECUTOR = new ThreadPoolExecutor(
+            0,
+            WATCH_SETUP_MIN_THREADS,
+            60L,
+            TimeUnit.SECONDS,
+            new SynchronousQueue<>(),
+            new NamingThreadFactory(new DaemonThreadFactory(), Reaper.class.getName() + ".watchSetup"));
+
+    /**
+     * Grows (or shrinks) {@link #WATCH_SETUP_EXECUTOR}'s max pool size to track the current number of
+     * configured {@link KubernetesCloud}s, so the pool never becomes an artificial bottleneck as an
+     * installation's cloud count grows, and never stays needlessly oversized after clouds are removed. See
+     * the {@link #WATCH_SETUP_MIN_THREADS} javadoc for the rationale.
+     */
+    private static void resizeWatchSetupExecutor(int currentCloudCount) {
+        int desired = WATCH_SETUP_MAX_THREADS_OVERRIDE > 0
+                ? WATCH_SETUP_MAX_THREADS_OVERRIDE
+                : Math.max(WATCH_SETUP_MIN_THREADS, currentCloudCount * WATCH_SETUP_THREADS_PER_CLOUD);
+        ThreadPoolExecutor tpe = (ThreadPoolExecutor) WATCH_SETUP_EXECUTOR;
+        if (tpe.getMaximumPoolSize() != desired) {
+            tpe.setMaximumPoolSize(desired);
+            LOGGER.fine(() -> "resized watch-setup executor max pool size to " + desired + " for " + currentCloudCount
+                    + " configured cloud(s)");
+        }
+    }
 
     /**
      * Only useful for tests which shutdown Jenkins without terminating the JVM.
@@ -106,6 +238,42 @@ public class Reaper extends ComputerListener {
     private final AtomicBoolean activated = new AtomicBoolean();
 
     private final Map<String, CloudPodWatcher> watchers = new ConcurrentHashMap<>();
+
+    /**
+     * Throttles how often {@link #watchCloud} will retry establishing the pod-event watch for a given cloud
+     * <em>after {@link #MIN_CONSECUTIVE_FAILURES_BEFORE_THROTTLE} or more consecutive connect/watch attempts
+     * for that exact cloud configuration have failed</em>. Without this, rapid repeated cache
+     * eviction/invalidation of a persistently unreachable cloud's {@link KubernetesClient} (e.g. many
+     * concurrent job/pod launches all hitting a broken cloud) can drive {@link #watchCloud} to attempt a
+     * fresh connect-and-watch on every single eviction. Each such attempt spins up its own fabric8
+     * {@code AbstractWatchManager} reconnect-retry thread(s) against the dead endpoint, and under high
+     * eviction rates these accumulate faster than they can be drained/closed, leading to unbounded thread
+     * growth and eventual JVM crash - even though JENKINS-76095's proactive re-arm is otherwise working
+     * exactly as intended.
+     * <p>Keyed by {@code cloudName + ":" + clientValidity} (not just cloud name), so this deliberately does
+     * NOT throttle legitimate immediate reconnects: a cloud config change (different {@code clientValidity}),
+     * a watch closed via {@code HTTP_GONE}, or a new computer launching on an otherwise-healthy cloud all
+     * proceed immediately since no failure streak is recorded for that exact key.
+     * <p>Requiring a short streak of consecutive failures (rather than throttling on the very first failure)
+     * intentionally tolerates real-world transient/intermittent connectivity blips (a single dropped
+     * connection, brief DNS hiccup, API server restart, etc.) without delaying recovery - only a
+     * <em>sustained</em> run of failures against the same config is treated as "this cloud is genuinely
+     * down right now" and gets backed off. Once throttling engages, the floor between retries is
+     * configurable per-cloud via {@link KubernetesCloud#getMinWatchRetryIntervalSeconds()} (UI field
+     * "Minimum Watch Retry Interval"), defaulting to
+     * {@link KubernetesCloud#DEFAULT_MIN_WATCH_RETRY_INTERVAL_SECONDS} (10s) if unset/unconfigured. Any
+     * success resets the streak immediately, so throttling never outlives an actual recovery.
+     */
+    private static final int MIN_CONSECUTIVE_FAILURES_BEFORE_THROTTLE =
+            SystemProperties.getInteger(Reaper.class.getName() + ".minConsecutiveFailuresBeforeThrottle", 3);
+
+    /** Per-{@code cloudName:clientValidity} consecutive-failure streak state. */
+    private static final class FailureStreak {
+        private final AtomicInteger count = new AtomicInteger();
+        private volatile long lastFailureMs;
+    }
+
+    private final Map<String, FailureStreak> watchFailureStreaks = new ConcurrentHashMap<>();
 
     private final LoadingCache<String, Set<String>> terminationReasons =
             Caffeine.newBuilder().expireAfterAccess(1, TimeUnit.DAYS).build(k -> new ConcurrentSkipListSet<>());
@@ -192,8 +360,9 @@ public class Reaper extends ComputerListener {
     private void watchClouds() {
         Jenkins jenkins = Jenkins.getInstanceOrNull();
         if (jenkins != null) {
+            List<KubernetesCloud> clouds = jenkins.clouds.getAll(KubernetesCloud.class);
             Set<String> cloudNames = new HashSet<>(this.watchers.keySet());
-            for (KubernetesCloud kc : jenkins.clouds.getAll(KubernetesCloud.class)) {
+            for (KubernetesCloud kc : clouds) {
                 watchCloud(kc);
                 cloudNames.remove(kc.name);
             }
@@ -209,26 +378,113 @@ public class Reaper extends ComputerListener {
     /**
      * Register {@link CloudPodWatcher} for the given cloud if one does not exist or if the existing watcher
      * is no longer valid.
+     *
+     * <p>Package-visibility is widened (was {@code private}) so that {@link KubernetesClientProvider} can
+     * proactively re-establish this cloud's watch on a fresh client immediately when its cached client is
+     * being retired, instead of relying solely on the next Jenkins config-save/agent-connect event to notice
+     * a dropped watch. See JENKINS-76095.
      * @param kc kubernetes cloud to watch
      */
-    private void watchCloud(@NonNull KubernetesCloud kc) {
+    @Restricted(NoExternalUse.class)
+    public void watchCloud(@NonNull KubernetesCloud kc) {
+        Jenkins jenkins = Jenkins.getInstanceOrNull();
+        if (jenkins != null) {
+            resizeWatchSetupExecutor(
+                    jenkins.clouds.getAll(KubernetesCloud.class).size());
+        }
         // can't use ConcurrentHashMap#computeIfAbsent because CloudPodWatcher will remove itself from the watchers
         // map on close. If an error occurs when creating the watch it would create a deadlock situation.
         CloudPodWatcher watcher = new CloudPodWatcher(kc);
         if (!isCloudPodWatcherActive(watcher)) {
+            String failureKey = kc.name + ":" + watcher.clientValidity;
+            long minRetryIntervalMs = kc.getMinWatchRetryIntervalSeconds() * 1000L;
+            if (minRetryIntervalMs > 0 && !retryAllowed(failureKey, minRetryIntervalMs)) {
+                return;
+            }
             try {
-                KubernetesClient client = kc.connect();
-                watcher.watch = client.pods().inNamespace(client.getNamespace()).watch(watcher);
+                // Both kc.connect() (which may itself perform a blocking handshake/version-check against
+                // the cloud's API server - e.g. building a fresh client after cache eviction) AND the
+                // actual .watch() call are submitted together as a SINGLE task bounded by
+                // WATCH_SETUP_EXECUTOR, bounded by watchSetupTimeoutSecondsFor(kc). A cloud that is genuinely reachable
+                // but merely slow to respond (heavy load) can block INSIDE connect() just as easily as
+                // inside watch() - if only the watch() call were bounded, a slow-but-alive cloud could
+                // still tie up whichever thread called watchCloud() (e.g. a ForkJoinPool.commonPool()
+                // worker via KubernetesClientProvider's Caffeine eviction listener) for as long as
+                // connect() takes, silently reopening the JENKINS-76095 starvation risk through a
+                // different, unbounded code path. See JENKINS-76095.
+                int timeoutSeconds = watchSetupTimeoutSecondsFor(kc);
+                KubernetesClient[] connectedClient = new KubernetesClient[1];
+                Future<Watch> watchFuture = WATCH_SETUP_EXECUTOR.submit(() -> {
+                    KubernetesClient client = kc.connect();
+                    connectedClient[0] = client;
+                    return client.pods().inNamespace(client.getNamespace()).watch(watcher);
+                });
+                Watch established;
+                try {
+                    established = watchFuture.get(timeoutSeconds, TimeUnit.SECONDS);
+                } catch (TimeoutException te) {
+                    watchFuture.cancel(true);
+                    throw new IOException(
+                            "timed out after "
+                                    + timeoutSeconds
+                                    + "s waiting to connect and set up watcher on "
+                                    + kc.getDisplayName(),
+                            te);
+                } catch (ExecutionException ee) {
+                    Throwable cause = ee.getCause() != null ? ee.getCause() : ee;
+                    if (cause instanceof KubernetesAuthException) {
+                        throw (KubernetesAuthException) cause;
+                    }
+                    if (cause instanceof RuntimeException) {
+                        throw (RuntimeException) cause;
+                    }
+                    if (cause instanceof IOException) {
+                        throw (IOException) cause;
+                    }
+                    throw new IOException(cause);
+                } catch (InterruptedException ie) {
+                    watchFuture.cancel(true);
+                    Thread.currentThread().interrupt();
+                    throw new IOException(
+                            "interrupted while waiting to connect and set up watcher on " + kc.getDisplayName(), ie);
+                }
+                watcher.watch = established;
+                watcher.boundClient = connectedClient[0];
                 CloudPodWatcher old = watchers.put(kc.name, watcher);
                 // if another watch slipped in then make sure it stopped
                 if (old != null) {
                     old.stop();
                 }
+                // success: clear any failure streak so a later, unrelated future failure isn't throttled
+                // based on stale history
+                watchFailureStreaks.remove(failureKey);
                 LOGGER.info(() -> "set up watcher on " + kc.getDisplayName());
             } catch (KubernetesAuthException | IOException | RuntimeException x) {
+                FailureStreak streak = watchFailureStreaks.computeIfAbsent(failureKey, k -> new FailureStreak());
+                streak.count.incrementAndGet();
+                streak.lastFailureMs = System.currentTimeMillis();
                 LOGGER.log(Level.WARNING, x, () -> "failed to set up watcher on " + kc.getDisplayName());
             }
         }
+    }
+
+    /**
+     * Best-effort throttle: for a given {@code cloudName:clientValidity} key, returns false only once at
+     * least {@link #MIN_CONSECUTIVE_FAILURES_BEFORE_THROTTLE} consecutive failures have been recorded AND
+     * the most recent one happened within {@code minIntervalMs}. A short streak of failures (below the
+     * threshold) is always allowed to retry immediately, tolerating transient/intermittent connectivity
+     * issues without delay - only a sustained failure run backs off. Returns true (allowing the attempt) if
+     * there's no failure streak recorded for this key at all - i.e. this is either the first attempt, or the
+     * previous attempt for this exact config succeeded (see the {@code watchFailureStreaks.remove} call in
+     * {@link #watchCloud}) - so legitimate immediate reconnects (config change, watch closed via
+     * {@code HTTP_GONE}, new computer launch on a healthy cloud) are never throttled.
+     */
+    private boolean retryAllowed(@NonNull String failureKey, long minIntervalMs) {
+        FailureStreak streak = watchFailureStreaks.get(failureKey);
+        if (streak == null || streak.count.get() < MIN_CONSECUTIVE_FAILURES_BEFORE_THROTTLE) {
+            return true;
+        }
+        return System.currentTimeMillis() - streak.lastFailureMs >= minIntervalMs;
     }
 
     /**
@@ -252,7 +508,19 @@ public class Reaper extends ComputerListener {
      */
     private boolean isCloudPodWatcherActive(@NonNull CloudPodWatcher watcher) {
         CloudPodWatcher existing = watchers.get(watcher.cloudName);
-        return existing != null && existing.clientValidity == watcher.clientValidity;
+        if (existing == null || existing.clientValidity != watcher.clientValidity) {
+            return false;
+        }
+        // Config unchanged, but the existing watch may still be bound to a KubernetesClient instance that
+        // KubernetesClientProvider has since evicted/replaced (cache expiry, explicit invalidate(), etc.)
+        // without the watch itself having failed/closed yet - e.g. it's sitting on the deferred
+        // grace-period-close timer. Comparing only the config-derived clientValidity can't detect this, so a
+        // watch bound to a retired client instance would be wrongly reported as still active, silently
+        // defeating JENKINS-76095's proactive re-arm (which relies on this method reporting false so a fresh
+        // watch gets established on the live client). Confirm the watch is actually still riding the client
+        // instance presently held in KubernetesClientProvider's cache before calling it active.
+        KubernetesClient currentClient = KubernetesClientProvider.currentCachedClient(watcher.cloudName);
+        return existing.boundClient != null && existing.boundClient == currentClient;
     }
 
     private static Optional<KubernetesSlave> resolveNode(@NonNull Jenkins jenkins, String namespace, String name) {
@@ -286,6 +554,16 @@ public class Reaper extends ComputerListener {
 
         @CheckForNull
         private Watch watch;
+
+        /**
+         * The {@link KubernetesClient} instance this watch is actually registered against, captured once the
+         * watch is successfully established. Used (instead of relying on {@link #clientValidity} alone) to
+         * detect that the underlying client has since been evicted/replaced by {@link KubernetesClientProvider}
+         * even though the cloud's configuration - and therefore {@link #clientValidity} - is unchanged. See
+         * JENKINS-76095.
+         */
+        @CheckForNull
+        private volatile KubernetesClient boundClient;
 
         CloudPodWatcher(@NonNull KubernetesCloud cloud) {
             this.cloudName = cloud.name;

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/config.jelly
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/config.jelly
@@ -82,6 +82,10 @@ THE SOFTWARE.
       <f:number min="${descriptor.defaultReadTimeout}" default="${descriptor.defaultReadTimeout}" checkMethod="post"/>
     </f:entry>
 
+    <f:entry title="${%Minimum Watch Retry Interval (seconds)}" field="minWatchRetryIntervalSeconds">
+      <f:number min="0" default="${descriptor.defaultMinWatchRetryInterval}" checkMethod="post"/>
+    </f:entry>
+
     <f:entry title="${%Concurrency Limit}" field="containerCapStr">
       <f:number default="10"/>
     </f:entry>

--- a/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/help-minWatchRetryIntervalSeconds.html
+++ b/src/main/resources/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud/help-minWatchRetryIntervalSeconds.html
@@ -1,0 +1,12 @@
+<div>
+    Minimum time, in seconds, that must elapse before the plugin will attempt to (re-)establish the
+    pod-event watch for this cloud again, once a watch is not currently active (e.g. the cloud is
+    unreachable, or its cached client was just evicted/invalidated). Left blank/default is 10 seconds.
+    <p>
+    This does not delay or affect an already-healthy watch in any way - it only throttles how often a
+    <em>failing or absent</em> watch may be retried. It exists to bound the number of concurrent
+    connection/reconnect attempts (and their underlying threads) against a persistently unreachable
+    Kubernetes API server when the cloud's client is being invalidated/evicted frequently (e.g. many
+    concurrent pod launches on a broken cloud). Set to 0 to disable throttling entirely (not recommended
+    for clouds that may become unreachable).
+</div>


### PR DESCRIPTION
Fixes #2763 ([JENKINS-76095](https://issues.jenkins.io/browse/JENKINS-76095)).

A previous attempt at this ticket (#2788, closing the fabric8 client on cache
eviction) was reverted in #2801 because `client.close()` raced with other
threads still holding a reference to the same client (in-flight pod
provisioning/deletion), leaving orphaned pods behind. This PR takes a
different approach that does not touch client-close semantics at all -
instead it bounds and throttles how the `Reaper` (re-)establishes its
pod-event watch, which is where the unbounded thread growth actually
originates.

### What changed

**1. Throttle watch (re-)establishment per cloud**

Added a new `KubernetesCloud` config field, `minWatchRetryIntervalSeconds`
(default `10`, does not affect an already-healthy watch). While a cloud's
watch is failing or absent (e.g. an unreachable/misconfigured API server),
`Reaper` will not attempt to re-establish it more often than this interval,
regardless of how many times the cloud's cached client is evicted/
invalidated in that window. Without this, each eviction spawned its own
reconnect attempt(s), and under a persistently broken cloud these could
accumulate faster than they drained.

**2. Bound watch-setup work to a small, dedicated, dynamically-sized executor**

`Reaper.watchCloud()` previously ran the client connect and watch
registration directly on the caller's thread - which, via
`KubernetesClientProvider`'s Caffeine cache `removalListener`, is often a
shared `ForkJoinPool.commonPool()` worker. A slow-to-respond or hanging
cloud could tie up that shared worker indefinitely, eventually starving the
common pool for the whole JVM (used throughout Jenkins core and other
plugins), even though only one Kubernetes cloud was actually unhealthy.

Both the client connect and the watch registration are now submitted
together as a single task to a small, dedicated executor, bounded by a
per-cloud timeout derived from that cloud's own (pre-existing)
`connectTimeout` + `readTimeout` fields - no new timeout field is
introduced. A hung attempt is abandoned (best-effort cancel) rather than
tying up the shared pool. The executor's size auto-scales with the number
of configured `KubernetesCloud`s (floor + per-cloud multiplier, both
overridable via system properties) so it never needs manual tuning as an
instance's cloud count changes, and a fixed-size override remains available
for operators who want one.

**3. Proactively re-arm the watch on cache eviction, with a safer deferred close**

`KubernetesClientProvider`'s `removalListener` now proactively re-establishes
the `Reaper` watch on a fresh client before the retired client is closed
(previously nothing re-armed the watch after `CloudPodWatcher#onClose()`
removed itself). The actual `close()` of the retired client is deferred by a
grace period (also derived from that cloud's connect/read timeouts, plus a
fixed margin) on a single dedicated scheduler thread, so any in-flight call
that grabbed a reference to the client just before eviction has time to
finish - this specifically avoids reintroducing the #2801 race, since the
close is delayed by a deterministic wall-clock duration rather than
happening synchronously inside the removal listener.

None of the three changes alter watch/client behavior for a healthy cloud;
they only change how failures are retried/bounded.

### Testing done

- Full existing test suite: `mvn test -DforkCount=10 -DreuseForks=true` -
  **316 tests, 0 failures, 0 errors**, including all `ReaperTest` and
  `KubernetesClientProviderTest` cases.
- Manual validation against a real Jenkins controller with three
  `KubernetesCloud` configs (one healthy, one unroutable, one that accepts a
  TCP connection but never completes the handshake):
  - Sustained simultaneous load against both failing clouds (repeated
    connect + cache-invalidate cycles) for 30 minutes: JVM's
    `ForkJoinPool.commonPool()` worker count stayed flat throughout (no
    climb toward the hundreds seen pre-fix); the dedicated watch-setup pool
    stayed at its configured floor; the third, healthy, unrelated cloud's
    watch remained continuously active and was never starved.
  - Additional scenario: a healthy but heavily-loaded/slow-to-respond cloud
    (artificial delay on every response). Confirmed a stuck reconnect
    attempt is bounded by the derived `connectTimeout + readTimeout` ceiling
    and self-heals immediately once the cloud responds normally again.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
